### PR TITLE
给思维链 UI 加 data 标记，支持自定义 CSS 无缝隐藏

### DIFF
--- a/components/chat/chat-room.tsx
+++ b/components/chat/chat-room.tsx
@@ -5147,7 +5147,7 @@ export function ChatRoom({ session, onBack }: ChatRoomProps) {
                     } : {};
 
                     return (
-                        <div key={msg.id} className="flex flex-col gap-4" {...(hiddenEmpty ? { style: { display: "none" } } : {})}>
+                        <div key={msg.id} className="flex flex-col gap-4" {...(hiddenEmpty ? { style: { display: "none" } } : {})} {...(isEmptyBubble && renderMsg.reasoningText && !showTime ? { "data-reasoning-only": "" } : {})}>
                             {showTime && (
                                 <div className="flex justify-center w-full">
                                     <span className="chat-sys-msg py-[2px] px-2 rounded select-none">
@@ -5157,7 +5157,7 @@ export function ChatRoom({ session, onBack }: ChatRoomProps) {
                             )}
                             {/* 思维链触发条（Claude app 风格）：点击打开底部弹窗 */}
                             {renderMsg.reasoningText && msg.role !== "user" && uiRole(msg) !== "system" && (
-                                <div className="chat-msg-wrapper" data-role={uiRole(msg)} style={{ marginBottom: -8 }}>
+                                <div className="chat-msg-wrapper" data-role={uiRole(msg)} data-reasoning-row="" style={{ marginBottom: -8 }}>
                                     <div className="w-[40px] shrink-0" />
                                     <button
                                         type="button"


### PR DESCRIPTION
## 背景

用户想通过聊天的「自定义 CSS 样式」隐藏思维链触发条（`.chat-reasoning-trigger`）。直接 `display: none` 后，工具调用轮次之间会残留空隙，原因有两层：

1. 触发条外面包着一行独立的 `.chat-msg-wrapper`（带 `marginBottom: -8`），隐藏内部按钮后该行仍参与消息内部 `gap-4` 布局；
2. 工具调用的中间轮消息往往只有思维链、没有可见正文，隐藏触发条后整条消息变成 0 高的空容器，但仍在消息列表（外层 `gap-4`）中占一个 16px 间距。该容器没有任何可选择的类名，纯 CSS 无法安全地选中它。

## 改动

`components/chat/chat-room.tsx`（仅 2 行）：

- 思维链触发条所在行加 `data-reasoning-row` 属性；
- 仅含思维链、无可见正文的消息容器（`isEmptyBubble && reasoningText`）加 `data-reasoning-only` 属性；带时间戳（`showTime`）时不标记，避免隐藏时误伤时间显示。

默认展示完全不受影响——两个属性不携带任何样式，仅为自定义 CSS 提供稳定锚点。部署后用户可用以下 CSS 完全隐藏思维链且无残留空隙（无需 `:has()`，旧 WebView 也兼容）：

```css
.chat-reasoning-trigger { display: none; }
[data-reasoning-row] { display: none; }
[data-reasoning-only] { display: none; }
```

## 验证

- `npx tsc --noEmit` 通过
- diff 已确认仅 2 处内容改动，保留原文件行尾

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WQkLvzbQQyuWcLAFfqnrX

---
_Generated by [Claude Code](https://claude.ai/code/session_016WQkLvzbQQyuWcLAFfqnrX)_