### PR TITLE
表情包：修复上传 GIF 被拍平成静态图

### DIFF
--- a/components/chat/sticker-manager.tsx
+++ b/components/chat/sticker-manager.tsx
@@ -12,6 +12,7 @@ import {
     addStickerToPack,
     addStickersToPack,
     addStickerByUrlToPack,
+    checkStickerBlob,
     renameStickerInPack,
     removeStickerFromPack,
     getPackAssignments,
@@ -501,14 +502,23 @@ function AddStickerDialog({
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [previewSrc, setPreviewSrc] = useState<string | null>(null);
     const [adding, setAdding] = useState(false);
+    const [fileError, setFileError] = useState<string | null>(null);
     const selectedFile = useRef<File | null>(null);
 
     const hasImage = !!previewSrc;
-    const canSubmit = !!name.trim() && hasImage;
+    const canSubmit = !!name.trim() && hasImage && !fileError;
 
     const handleFileChange = () => {
         const f = fileInputRef.current?.files?.[0];
         if (!f) return;
+        const err = checkStickerBlob(f);
+        setFileError(err);
+        if (err) {
+            selectedFile.current = null;
+            setPreviewSrc(null);
+            if (fileInputRef.current) fileInputRef.current.value = "";
+            return;
+        }
         selectedFile.current = f;
         setUrl("");
         const reader = new FileReader();
@@ -520,6 +530,7 @@ function AddStickerDialog({
         const trimmed = url.trim();
         if (trimmed) {
             selectedFile.current = null;
+            setFileError(null);
             if (fileInputRef.current) fileInputRef.current.value = "";
             setPreviewSrc(trimmed);
         }
@@ -529,7 +540,13 @@ function AddStickerDialog({
         if (!canSubmit || adding) return;
         setAdding(true);
         if (selectedFile.current) {
-            await addStickerToPack(packId, name.trim(), selectedFile.current);
+            try {
+                await addStickerToPack(packId, name.trim(), selectedFile.current);
+            } catch {
+                setFileError("添加失败，请换一张图片重试");
+                setAdding(false);
+                return;
+            }
         } else if (url.trim()) {
             addStickerByUrlToPack(packId, name.trim(), url.trim());
         }
@@ -592,6 +609,7 @@ function AddStickerDialog({
                                     <span className="ts-13">选择图片</span>
                                 </button>
                             )}
+                            {fileError && <span className="ts-11 ml-1" style={{ color: "var(--c-danger)" }}>{fileError}</span>}
                         </div>
                     </div>
                 </div>
@@ -750,6 +768,7 @@ function BatchAddStickerDialog({
         const k = t.toLowerCase();
         if (existingNames.current.has(k)) return "与已有表情重名";
         if ((nameCounts.get(k) ?? 0) > 1) return "本批重名";
+        if (r.file) return checkStickerBlob(r.file);
         return null;
     };
 

--- a/components/phone-theme-app.tsx
+++ b/components/phone-theme-app.tsx
@@ -45,6 +45,7 @@ import {
   saveThemeAssetFromBlob,
   deleteThemeAsset,
   getThemeAssetMap,
+  describeAssetSaveError,
 } from "@/lib/theme-storage";
 import { BINDING_ACCENTS } from "@/lib/ui-accent-colors";
 import { ConfirmDialog, ContentDialog } from "@/components/ui/modal";
@@ -1055,8 +1056,8 @@ function IconSkinPage({
         (Object.values(resolveActiveIconSkins(next)).filter(Boolean) as string[])
       );
       setThumbs(map);
-    } catch {
-      onNotice("上传失败，请重试");
+    } catch (error) {
+      onNotice(describeAssetSaveError(error));
     }
     setUploadTarget(null);
   }, [draft, uploadTarget, onDraftChange, onApply, onNotice]);
@@ -1092,8 +1093,8 @@ function IconSkinPage({
       await onApply(next);
       const map = await getThemeAssetMap([assetId]);
       setDockThumbUrl(map[assetId] ?? null);
-    } catch {
-      onNotice("上传失败，请重试");
+    } catch (error) {
+      onNotice(describeAssetSaveError(error));
     }
   }, [draft, onDraftChange, onApply, onNotice]);
 
@@ -1317,8 +1318,8 @@ function WallpaperPage({
       // Reload thumbnails for the new asset
       const map = await getThemeAssetMap(next.wallpaperLibrary);
       setThumbs(map);
-    } catch {
-      onNotice("\u4E0A\u4F20\u5931\u8D25\uFF0C\u8BF7\u91CD\u8BD5");
+    } catch (error) {
+      onNotice(describeAssetSaveError(error));
     }
   }, [draft, onDraftChange, onApply, onNotice]);
 

--- a/lib/custom-sticker-storage.ts
+++ b/lib/custom-sticker-storage.ts
@@ -3,7 +3,14 @@
 // Data model: StickerPack[] + assignments (packId → characterId[]).
 // Metadata in localStorage, images in IndexedDB (ThemeAssetType "sticker").
 
-import { saveThemeAssetFromBlob, deleteThemeAsset, getThemeAssetDataUrl, getThemeAssetMap } from "./theme-storage";
+import {
+    saveThemeAssetFromBlob,
+    deleteThemeAsset,
+    getThemeAssetDataUrl,
+    getThemeAssetMap,
+    isAnimatedImageBlob,
+    checkAnimatedAssetSize,
+} from "./theme-storage";
 import { kvGet, kvSet, registerKvMigration } from "./kv-db";
 
 const PACKS_KEY = "ai_phone_sticker_packs_v1";
@@ -104,12 +111,13 @@ export function renameStickerPack(packId: string, newName: string): void {
 
 // ── Sticker items within a pack ──
 
+/** GIF 原样保留(不经 canvas 重编码,避免动图变静帧);其余图片走压缩。 */
 export async function addStickerToPack(packId: string, name: string, imageBlob: Blob): Promise<StickerItem | null> {
     const packs = readPacks();
     const pack = packs.find(p => p.id === packId);
     if (!pack) return null;
-    const compressed = await compressStickerImage(imageBlob);
-    const assetId = await saveThemeAssetFromBlob(compressed, "sticker");
+    const prepared = isAnimatedImageBlob(imageBlob) ? imageBlob : await compressStickerImage(imageBlob);
+    const assetId = await saveThemeAssetFromBlob(prepared, "sticker");
     const item: StickerItem = {
         id: `stk_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         name,
@@ -138,7 +146,7 @@ export async function addStickersToPack(
     for (let i = 0; i < items.length; i++) {
         try {
             const src = items[i].blob;
-            const prepared = src.type === "image/gif" ? src : await compressStickerImage(src);
+            const prepared = isAnimatedImageBlob(src) ? src : await compressStickerImage(src);
             const assetId = await saveThemeAssetFromBlob(prepared, "sticker");
             pack.stickers.push({
                 id: `stk_${Date.now()}_${i}_${Math.random().toString(36).slice(2, 6)}`,
@@ -153,6 +161,11 @@ export async function addStickersToPack(
     }
     writePacks(packs);
     return { added, failed };
+}
+
+/** 上传前预检：通过返回 null，否则返回给用户看的错误文案（目前只有动图体积限制）。 */
+export function checkStickerBlob(blob: Blob): string | null {
+    return checkAnimatedAssetSize(blob);
 }
 
 export function addStickerByUrlToPack(packId: string, name: string, url: string): StickerItem | null {

--- a/lib/theme-storage.ts
+++ b/lib/theme-storage.ts
@@ -10,6 +10,41 @@ const THEME_DB_VERSION = 2;
 const THEME_ASSET_STORE = "assets";
 const IMAGE_MAX_DIMENSION = 2200;
 const IMAGE_TARGET_SIZE_BYTES = 2 * 1024 * 1024;
+/**
+ * 动图（GIF）不经 canvas 重编码，会原样落库，因此单独限制体积。
+ * dataUrl 存储比原文件再大约 1/3，超过这个阈值应让用户换图而不是静默拍平成静帧。
+ */
+export const ANIMATED_ASSET_MAX_BYTES = 3 * 1024 * 1024;
+
+/** 动图体积超限：调用方应提示用户换一张更小的图。 */
+export class AnimatedAssetTooLargeError extends Error {
+  constructor() {
+    super("动图体积超出限制");
+    this.name = "AnimatedAssetTooLargeError";
+  }
+}
+
+/** 该 blob 是否是必须保留原始编码的动图格式。 */
+export function isAnimatedImageBlob(blob: Blob): boolean {
+  return (blob.type || "").toLowerCase() === "image/gif";
+}
+
+/** 上传前预检：返回给用户看的错误文案，通过则返回 null。 */
+export function checkAnimatedAssetSize(blob: Blob): string | null {
+  if (!isAnimatedImageBlob(blob)) return null;
+  if (blob.size <= ANIMATED_ASSET_MAX_BYTES) return null;
+  const limitMb = Math.round(ANIMATED_ASSET_MAX_BYTES / (1024 * 1024));
+  return `GIF 需小于 ${limitMb}MB（当前 ${(blob.size / (1024 * 1024)).toFixed(1)}MB），请换一张`;
+}
+
+/** 把上传异常翻译成给用户看的文案。 */
+export function describeAssetSaveError(error: unknown, fallback = "上传失败，请重试"): string {
+  if (error instanceof AnimatedAssetTooLargeError) {
+    const limitMb = Math.round(ANIMATED_ASSET_MAX_BYTES / (1024 * 1024));
+    return `GIF 需小于 ${limitMb}MB，请换一张`;
+  }
+  return fallback;
+}
 
 export type ThemeAssetRecord = {
   id: string;
@@ -150,6 +185,14 @@ async function normalizeRasterBlob(blob: Blob): Promise<Blob> {
 async function normalizeIncomingBlob(blob: Blob): Promise<Blob> {
   const mime = blob.type.toLowerCase();
   if (mime === "image/svg+xml") {
+    return blob;
+  }
+  if (mime === "image/gif") {
+    // GIF 必须原样保留：canvas 只能取到第一帧，重编码等于把动图拍平成静态图。
+    // 代价是无法压缩，所以改为体积超限时报错，交给调用方提示用户。
+    if (blob.size > ANIMATED_ASSET_MAX_BYTES) {
+      throw new AnimatedAssetTooLargeError();
+    }
     return blob;
   }
   if (!mime.startsWith("image/")) {


### PR DESCRIPTION
同步自 ai-virtual-phone-clean- 的修复（两仓库文件内容一致，补丁干净应用）。

## 问题

GIF 表情上传后变成静态图，与文件大小无关：

1. `addStickerToPack`（单张添加）无条件走 `compressStickerImage`，`createImageBitmap` 对 GIF 只解第一帧。
2. `addStickersToPack`（批量添加）虽有 GIF 豁免，但下游 `saveThemeAssetFromBlob → normalizeIncomingBlob` 只放行 svg，GIF 被 `normalizeRasterBlob` 转成静态 PNG。同一入口也影响动图壁纸、图标皮肤、Dock 皮肤。

## 改动

- `normalizeIncomingBlob` 放行 `image/gif`（与 `media-maintenance`、`css-asset-tools` 已有的 GIF 跳过保持一致）
- `addStickerToPack` 补上与批量路径相同的 GIF 判断，统一用 `isAnimatedImageBlob`
- GIF 不再压缩会原样落库，新增 3MB 上限：超限抛 `AnimatedAssetTooLargeError`，添加表情弹窗与主题上传处提示用户换图

## 验证

浏览器实测：2 帧 GIF 经主题资源、单张添加、批量添加三条路径均保持 `image/gif` 且帧数不变；PNG 仍照常压缩成 webp；超限 GIF 被拒绝并提示。发给 LLM 的 vision 链路不受影响（`resolveVisionImageRefForApi` 仍将 GIF 转静态 JPEG）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_