### PR TITLE
MCP：401 按来源分流提示，修复「OAuth 授权」死循环引导

### DIFF
--- a/components/settings/toolbox-settings.tsx
+++ b/components/settings/toolbox-settings.tsx
@@ -1559,7 +1559,7 @@ export function ToolboxSettings() {
                                     value={editMcp.accessToken || ""}
                                     placeholder="需要鉴权的 MCP 填这里，会作为 Bearer Token 发送"
                                     onChange={e => setM({
-                                        accessToken: e.target.value.trim(),
+                                        accessToken: e.target.value.trim().replace(/^bearer\s+/i, ""),
                                         refreshToken: undefined,
                                         tokenExpiresAt: undefined,
                                         oauthClientId: undefined,
@@ -1608,6 +1608,9 @@ export function ToolboxSettings() {
                                         </button>
                                     </div>
                                     {editMcp.accessToken && <span className="menu-desc text-[var(--c-icon-green)]">✓ 已配置 Token</span>}
+                                    {editMcp.accessToken && Object.keys(editMcp.headers || {}).some(k => k.trim().toLowerCase() === "authorization") && (
+                                        <span className="menu-desc text-[var(--c-danger)]">已配置访问 Token，请求头中的 Authorization 将被忽略（以 Token 栏为准）</span>
+                                    )}
                                     {authResult && <span className={`menu-desc ${authResult.includes("✓") ? "text-[var(--c-icon-green)]" : "text-[var(--c-danger)]"}`}>{authResult}</span>}
                                     {discoverError && <span className="menu-desc text-[var(--c-danger)]">{discoverError}</span>}
                                     {editMcp.discoveredTools && editMcp.discoveredTools.length > 0 && (

--- a/lib/tool-executor.ts
+++ b/lib/tool-executor.ts
@@ -3334,7 +3334,9 @@ async function mcpRequest(
     });
 
     if (res.status === 401) {
-        return { error: { code: 401, message: res.headers["www-authenticate"] || "Unauthorized" }, headers: res.headers };
+        // 把响应体带回去：401 可能来自应用登录网关、隧道/反代或 MCP 服务器本身，
+        // 上层靠 body + WWW-Authenticate 头才能区分并给出正确指引。
+        return { error: { code: 401, message: res.text.slice(0, 300) || "Unauthorized" }, headers: res.headers };
     }
 
     if (res.status < 200 || res.status >= 300) {
@@ -3357,6 +3359,23 @@ async function mcpRequest(
 }
 
 // ── MCP Initialize Handshake ──────────────────
+
+/**
+ * 401 分流：同一个状态码可能来自三个完全不同的地方，指错路会让用户在
+ * 「OAuth 授权」按钮上打转（服务器不支持 OAuth 时那条路是死胡同）。
+ */
+function describeMcpUnauthorized(wwwAuthenticate: string | undefined, bodyText: string): string {
+    // 托管部署下 middleware 对 /api/tool-proxy 的登录拦截——和 MCP 服务器无关
+    if (bodyText.includes("请先登录")) {
+        return "鉴权失败（401）：应用登录已过期，请刷新页面重新登录后再试（与 MCP 服务器配置无关）。";
+    }
+    // 标准 MCP OAuth 服务器会带 WWW-Authenticate 头，此时点授权按钮才是正解
+    if (wwwAuthenticate) {
+        return "需要 OAuth 授权。请在设置中点击「授权」按钮。";
+    }
+    return "鉴权失败（401）：Token 可能无效或已过期。本地工具类 MCP 通常不支持 OAuth，"
+        + "请在设置中检查「访问 Token」是否为最新值（这类工具重启后 token 会变化），不必点击授权按钮。";
+}
 
 async function mcpInitialize(server: McpServerConfig, signal?: AbortSignal): Promise<{ success: boolean; error?: string }> {
     throwIfAborted(signal);
@@ -3385,9 +3404,9 @@ async function mcpInitialize(server: McpServerConfig, signal?: AbortSignal): Pro
         clientInfo: MCP_CLIENT_INFO,
     }, authHeaders, false, useSse, signal);
 
-    // Handle 401 — needs OAuth
+    // Handle 401 — 按来源分流：应用登录网关 / 真 OAuth 服务器 / Token 失效
     if (initRes.error?.code === 401) {
-        return { success: false, error: "需要 OAuth 授权。请在设置中点击「授权」按钮。" };
+        return { success: false, error: describeMcpUnauthorized(initRes.headers["www-authenticate"], initRes.error.message) };
     }
 
     if (initRes.error) {
@@ -3462,10 +3481,15 @@ async function ensureTokenFresh(server: McpServerConfig, signal?: AbortSignal): 
     }
 }
 
+/** 用户常把 "Bearer xxx" 整段粘进 Token 栏，发出去会变成 "Bearer Bearer xxx"——这里兜底剥掉前缀。 */
+function bearerAuthValue(accessToken: string): string {
+    return `Bearer ${accessToken.replace(/^bearer\s+/i, "")}`;
+}
+
 function buildMcpAuthHeaders(server: McpServerConfig): Record<string, string> {
     const headers: Record<string, string> = cleanHeaders(server.headers);
     if (server.accessToken) {
-        headers["Authorization"] = `Bearer ${server.accessToken}`;
+        headers["Authorization"] = bearerAuthValue(server.accessToken);
     }
     return headers;
 }
@@ -3473,7 +3497,7 @@ function buildMcpAuthHeaders(server: McpServerConfig): Record<string, string> {
 function getMcpSessionHeaders(server: McpServerConfig): Record<string, string> {
     const headers: Record<string, string> = cleanHeaders(server.headers);
     if (server.sessionId) headers["Mcp-Session-Id"] = server.sessionId;
-    if (server.accessToken) headers["Authorization"] = `Bearer ${server.accessToken}`;
+    if (server.accessToken) headers["Authorization"] = bearerAuthValue(server.accessToken);
     return headers;
 }
 
@@ -3612,7 +3636,7 @@ async function resolveMcpOAuthMetadata(
         }
     }
 
-    throw new Error("无法发现 OAuth 授权端点");
+    throw new Error("无法发现 OAuth 授权端点——该服务器可能不支持 OAuth。若已有 Token，直接填入「访问 Token」即可，无需授权。");
 }
 
 function persistMcpOAuthState(server: McpServerConfig): void {


### PR DESCRIPTION
同步自 ai-virtual-phone-clean- 的修复。

## 问题

所有 MCP 401 一律提示"需要 OAuth 授权，请点击授权按钮"，但 401 可能来自三个不同来源，其中两个点授权按钮是死胡同（不支持 OAuth 的服务器只会再报"无法发现 OAuth 授权端点"，用户在两个报错之间打转）。

## 改动

- `mcpRequest` 401 时把响应体带回，`mcpInitialize` 按 body + `WWW-Authenticate` 头分流成三条文案：登录网关 401 → 提示重新登录；带 `WWW-Authenticate` → 提示点授权；裸 401 → 提示检查访问 Token（本地工具类 MCP 重启后 token 会轮换）
- 「访问 Token」输入剥掉误粘的 `Bearer ` 前缀，发送侧同样兜底，避免 `Bearer Bearer xxx`
- Token 与请求头 Authorization 同时配置时，设置页显式提示请求头将被忽略（此前静默覆盖）
- "无法发现 OAuth 授权端点"追加指引：可能不支持 OAuth，直接填访问 Token 即可

## 验证

浏览器实测（mock `/api/tool-proxy` 走真实 `discoverMcpTools` 链路）：三类 401 分别得到正确指引；Token 栏填 `Bearer abc123` 或 `abc123` 发出的 Authorization 头均为单个 `Bearer abc123`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_