### PR TITLE
图片：操作按钮统一收进全屏预览层（test）

### DIFF
--- a/components/chat/mascot-chat-room.tsx
+++ b/components/chat/mascot-chat-room.tsx
@@ -6,6 +6,7 @@ import { createPortal } from "react-dom";
 import { AlertCircle, ChevronLeft, Code, Image as ImageIcon, MessageSquare, MoreHorizontal, RotateCcw, Trash2, UserRound } from "lucide-react";
 import { PageShell } from "@/components/ui/page-shell";
 import { ConfirmDialog } from "@/components/ui/modal";
+import { MediaPreviewOverlay } from "@/components/chat/media-preview-overlay";
 import { Input } from "@/components/ui/form";
 import CSSSchemeBar from "@/components/ui/css-scheme-picker";
 import { SessionCustomCSS } from "@/components/ui/session-custom-css";
@@ -432,6 +433,7 @@ export function MascotChatRoom({ onBack, onDeleted }: MascotChatRoomProps) {
     const [visibleMascotMessageCount, setVisibleMascotMessageCount] = useState(MASCOT_INITIAL_VISIBLE_MESSAGE_COUNT);
     const [activeMascotMessageIndex, setActiveMascotMessageIndex] = useState<number | null>(null);
     const [contextMenuAnchor, setContextMenuAnchor] = useState<ContextMenuAnchor | null>(null);
+    const [previewImageUrl, setPreviewImageUrl] = useState<string | null>(null);
     const [enterToSendEnabled, setEnterToSendEnabled] = useState(() => loadChatAppSettings().enterToSendEnabled === true);
     const wrapperRef = useRef<HTMLDivElement | null>(null);
     const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -823,7 +825,16 @@ export function MascotChatRoom({ onBack, onDeleted }: MascotChatRoomProps) {
                 {msg.images.map((ref, idx) => {
                     const url = imagePreviewCache[ref] || (ref.startsWith("data:") ? ref : "");
                     if (!url) return <span key={idx} className="mascot-inline-image-loading" />;
-                    return <img key={idx} src={url} alt="" onLoad={handleMascotImageLoad} />;
+                    return (
+                        <img
+                            key={idx}
+                            src={url}
+                            alt=""
+                            style={{ cursor: "pointer" }}
+                            onLoad={handleMascotImageLoad}
+                            onClick={e => { e.stopPropagation(); setPreviewImageUrl(url); }}
+                        />
+                    );
                 })}
             </div>
         );
@@ -1155,6 +1166,14 @@ export function MascotChatRoom({ onBack, onDeleted }: MascotChatRoomProps) {
                     />
                 </div>,
                 wrapperRef.current.parentElement
+            )}
+
+            {previewImageUrl && (
+                <MediaPreviewOverlay
+                    imageUrl={previewImageUrl}
+                    saveFilename="小卷图片.png"
+                    onClose={() => setPreviewImageUrl(null)}
+                />
             )}
         </div>
     );

--- a/components/chat/media-preview-overlay.tsx
+++ b/components/chat/media-preview-overlay.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { createPortal } from "react-dom";
+
+const ACTION_BUTTON_STYLE: CSSProperties = {
+    color: "#fff",
+    fontSize: "calc(14px*var(--app-text-scale,1))",
+    opacity: 0.85,
+    border: "none",
+    cursor: "pointer",
+    padding: "8px 20px",
+    borderRadius: 20,
+    background: "rgba(255,255,255,0.15)",
+    backdropFilter: "blur(8px)",
+};
+
+/**
+ * 全屏媒体预览层：图片（或未生成时的文字描述）+ 下方操作按钮排。
+ * 聊天、朋友圈、小卷共用——聊天流里不放常驻小按钮，保存/重新生成都收在这里。
+ */
+export function MediaPreviewOverlay({
+    imageUrl,
+    description,
+    saveFilename,
+    onRegenerate,
+    regenerating,
+    onClose,
+}: {
+    imageUrl?: string | null;
+    description?: string;
+    saveFilename?: string;
+    onRegenerate?: () => void;
+    regenerating?: boolean;
+    onClose: () => void;
+}) {
+    if (typeof document === "undefined") return null;
+    return createPortal(
+        <div
+            style={{ position: "fixed", inset: 0, zIndex: 10000, background: "rgba(0,0,0,0.85)", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 16, padding: 24 }}
+            onClick={onClose}
+        >
+            {imageUrl ? (
+                <img src={imageUrl} alt="" style={{ maxWidth: "90vw", maxHeight: "75vh", objectFit: "contain", borderRadius: 8 }} />
+            ) : description ? (
+                <div
+                    style={{ color: "#fff", opacity: 0.9, maxWidth: "min(85vw, 420px)", maxHeight: "60vh", overflowY: "auto", fontSize: "calc(14px*var(--app-text-scale,1))", lineHeight: 1.8, fontStyle: "italic", whiteSpace: "pre-wrap" }}
+                    onClick={e => e.stopPropagation()}
+                >
+                    {description}
+                </div>
+            ) : null}
+            <div style={{ display: "flex", gap: 12 }} onClick={e => e.stopPropagation()}>
+                {imageUrl && saveFilename && (
+                    <button
+                        onPointerDown={e => e.stopPropagation()}
+                        onClick={async e => {
+                            e.stopPropagation();
+                            e.preventDefault();
+                            const { downloadUrl } = await import("@/lib/download-utils");
+                            await downloadUrl(imageUrl, saveFilename);
+                        }}
+                        style={ACTION_BUTTON_STYLE}
+                    >
+                        保存图片
+                    </button>
+                )}
+                {onRegenerate && (
+                    <button
+                        onPointerDown={e => e.stopPropagation()}
+                        disabled={regenerating}
+                        onClick={e => {
+                            e.stopPropagation();
+                            onRegenerate();
+                        }}
+                        style={ACTION_BUTTON_STYLE}
+                    >
+                        {regenerating ? "生成中..." : "重新生成"}
+                    </button>
+                )}
+            </div>
+        </div>,
+        document.body,
+    );
+}

--- a/components/chat/message-bubble.tsx
+++ b/components/chat/message-bubble.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode, useState, useEffect, useCallback, useRef, useMemo, memo } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo, memo } from "react";
 import { findCustomStickerByName, resolveCustomStickerUrl } from "@/lib/custom-sticker-storage";
 import { isMediaStoreRef, loadMediaObjectUrl } from "@/lib/media-cache-storage";
 import { getChatImageFromIndexedDB } from "@/lib/chat-asset-storage";
@@ -9,6 +9,7 @@ import { resolveContactCard } from "@/lib/contact-card";
 import { loadCharacters } from "@/lib/character-storage";
 import { CHAT_OPEN_SESSION_EVENT, dispatchOpenAddContact } from "@/lib/chat-notification-events";
 import { ContactCardGenerateFlow } from "@/components/chat/contact-card-generate-flow";
+import { MediaPreviewOverlay } from "@/components/chat/media-preview-overlay";
 import { findStickerByName } from "@/lib/sticker-data";
 import { splitBilingualText } from "@/lib/bilingual-text";
 import { isInvisibleOrWhitespaceOnly } from "@/lib/rich-message-parser";
@@ -17,7 +18,7 @@ import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
 import { createPortal } from "react-dom";
-import { Blocks, Maximize2, ReceiptText, RefreshCw } from "lucide-react";
+import { Blocks, Maximize2, ReceiptText } from "lucide-react";
 import { retryChatGeneratedImage } from "@/lib/generated-image-retry";
 import { ScanPayCard } from "@/components/chat/scan-pay-card";
 import { payWithWalletBalance } from "@/lib/wallet-storage";
@@ -1242,9 +1243,8 @@ function ImageBubble({
     const [regenerating, setRegenerating] = useState(false);
     const [retryError, setRetryError] = useState("");
     const isPending = d?.imageGenerationStatus === "pending";
-    const canRetry = (!msg.mediaUrl || refExpired)
-        && !isPending
-        && Boolean(d?.label?.trim());
+    const canRegenerate = !isPending && Boolean(d?.label?.trim());
+    const [showPreview, setShowPreview] = useState(false);
 
     useEffect(() => {
         if (!isMediaStoreRef(rawUrl)) {
@@ -1287,15 +1287,49 @@ function ImageBubble({
             });
     }, [characterId, msg, onUpdate, promptDraft]);
 
+    // 预览层与提示词对话框：图片正常/失败占位两种形态共用（操作按钮统一收在点开后的预览层里）
+    const previewAndDialog = (
+        <>
+            {showPreview && (
+                <MediaPreviewOverlay
+                    imageUrl={resolvedUrl || undefined}
+                    description={!resolvedUrl ? label : undefined}
+                    saveFilename={resolvedUrl ? ensureExtension(label, "image") : undefined}
+                    onRegenerate={canRegenerate ? () => { setShowPreview(false); openPromptEditor(); } : undefined}
+                    regenerating={regenerating}
+                    onClose={() => setShowPreview(false)}
+                />
+            )}
+            {showPromptEditor && typeof document !== "undefined" && createPortal(
+                <GeneratedImagePromptDialog
+                    value={promptDraft}
+                    onChange={setPromptDraft}
+                    onConfirm={handleRetry}
+                    onCancel={() => setShowPromptEditor(false)}
+                    busy={regenerating}
+                    error={retryError}
+                />,
+                document.body,
+            )}
+        </>
+    );
+
     if (resolvedUrl) {
         return (
-            <div className="chat-photo-card chat-photo-card--image rounded-none">
-                <img
-                    src={resolvedUrl}
-                    alt={label}
-                    className="chat-photo-card-image block max-w-[240px] max-h-[320px] w-auto h-auto"
-                />
-            </div>
+            <>
+                <div
+                    className="chat-photo-card chat-photo-card--image rounded-none"
+                    style={{ cursor: "pointer" }}
+                    onClick={e => { e.stopPropagation(); setShowPreview(true); }}
+                >
+                    <img
+                        src={resolvedUrl}
+                        alt={label}
+                        className="chat-photo-card-image block max-w-[240px] max-h-[320px] w-auto h-auto"
+                    />
+                </div>
+                {previewAndDialog}
+            </>
         );
     }
     // media-store 引用解析中：占个位，避免闪一下重试卡
@@ -1317,40 +1351,17 @@ function ImageBubble({
     }
     return (
         <div className="chat-generated-image-retry-stack">
-            <div className="chat-generated-image-retry-wrap" data-action-placement={msg.role === "user" ? "left" : "right"}>
-                <div className="chat-photo-card w-[180px] aspect-square rounded-none">
-                    <div className="chat-photo-card-placeholder w-full h-full flex items-center justify-center px-5">
-                        <div className="chat-photo-card-text">{label}</div>
-                    </div>
+            <div
+                className="chat-photo-card w-[180px] aspect-square rounded-none"
+                style={{ cursor: "pointer" }}
+                onClick={e => { e.stopPropagation(); setShowPreview(true); }}
+            >
+                <div className="chat-photo-card-placeholder w-full h-full flex items-center justify-center px-5">
+                    <div className="chat-photo-card-text">{label}</div>
                 </div>
-                {canRetry && (
-                    <button
-                        type="button"
-                        className="chat-generated-image-retry-btn"
-                        disabled={regenerating}
-                        aria-label="重新生成图片"
-                        onPointerDown={e => e.stopPropagation()}
-                        onClick={e => {
-                            e.stopPropagation();
-                            openPromptEditor();
-                        }}
-                    >
-                        <RefreshCw size={14} className={regenerating ? "is-spinning" : undefined} />
-                    </button>
-                )}
             </div>
             {retryError && <div className="chat-generated-image-retry-error">生成失败：{retryError}</div>}
-            {showPromptEditor && typeof document !== "undefined" && createPortal(
-                <GeneratedImagePromptDialog
-                    value={promptDraft}
-                    onChange={setPromptDraft}
-                    onConfirm={handleRetry}
-                    onCancel={() => setShowPromptEditor(false)}
-                    busy={regenerating}
-                    error={retryError}
-                />,
-                document.body,
-            )}
+            {previewAndDialog}
         </div>
     );
 }
@@ -1783,54 +1794,34 @@ export function MediaImageWithPreview({
     title,
     filename,
     onError,
-    sideAction,
-    sideActionPlacement = "right",
+    onRegenerate,
+    regenerating,
 }: {
     url: string;
     title: string;
     filename?: string;
     onError?: () => void;
-    sideAction?: ReactNode;
-    sideActionPlacement?: "left" | "right";
+    onRegenerate?: () => void;
+    regenerating?: boolean;
 }) {
     const [preview, setPreview] = useState(false);
     const saveName = filename || title;
     return (
         <>
-            <div className="chat-media-file-wrap" data-action-placement={sideActionPlacement}>
+            <div className="chat-media-file-wrap">
                 <div className="chat-media-file-card chat-media-file-image" onClick={(e) => { e.stopPropagation(); setPreview(true); }}>
                     {title && <div className="chat-media-file-title">{title}</div>}
                     <img src={url} alt={title} style={{ cursor: "pointer" }} onError={onError} />
                 </div>
-                {sideAction ? (
-                    <div className="chat-media-file-actions">
-                        {sideAction}
-                        <MediaSaveButton url={url} filename={ensureExtension(saveName, "image")} />
-                    </div>
-                ) : (
-                    <MediaSaveButton url={url} filename={ensureExtension(saveName, "image")} />
-                )}
             </div>
-            {preview && createPortal(
-                <div
-                    style={{ position: "fixed", inset: 0, zIndex: 9999, background: "rgba(0,0,0,0.85)", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 16 }}
-                    onClick={() => setPreview(false)}
-                >
-                    <img src={url} alt={title} style={{ maxWidth: "90vw", maxHeight: "80vh", objectFit: "contain", borderRadius: 8 }} />
-                    <button
-                        onPointerDown={(e) => e.stopPropagation()}
-                        onClick={async (e) => {
-                            e.stopPropagation();
-                            e.preventDefault();
-                            const { downloadUrl } = await import("@/lib/download-utils");
-                            await downloadUrl(url, ensureExtension(saveName, "image"));
-                        }}
-                        style={{ color: "#fff", fontSize: "calc(14px*var(--app-text-scale,1))", opacity: 0.8, border: "none", cursor: "pointer", padding: "8px 20px", borderRadius: 20, background: "rgba(255,255,255,0.15)", backdropFilter: "blur(8px)" }}
-                    >
-                        保存图片
-                    </button>
-                </div>,
-                document.body,
+            {preview && (
+                <MediaPreviewOverlay
+                    imageUrl={url}
+                    saveFilename={ensureExtension(saveName, "image")}
+                    onRegenerate={onRegenerate ? () => { setPreview(false); onRegenerate(); } : undefined}
+                    regenerating={regenerating}
+                    onClose={() => setPreview(false)}
+                />
             )}
         </>
     );
@@ -2033,22 +2024,8 @@ function MediaFileBubble({
                     url={url}
                     title={displayTitle}
                     filename={title}
-                    sideActionPlacement={msg.role === "user" ? "left" : "right"}
-                    sideAction={canRegenerateImage ? (
-                        <button
-                            type="button"
-                            className="chat-generated-image-retry-btn"
-                            disabled={imageRegenerating}
-                            aria-label="重新生成图片"
-                            onPointerDown={e => e.stopPropagation()}
-                            onClick={e => {
-                                e.stopPropagation();
-                                openImagePromptEditor();
-                            }}
-                        >
-                            <RefreshCw size={14} className={imageRegenerating ? "is-spinning" : undefined} />
-                        </button>
-                    ) : undefined}
+                    onRegenerate={canRegenerateImage ? openImagePromptEditor : undefined}
+                    regenerating={imageRegenerating}
                 />
                 {imageRetryError && <div className="chat-generated-image-retry-error">生成失败：{imageRetryError}</div>}
                 {showImagePromptEditor && typeof document !== "undefined" && createPortal(

--- a/components/chat/moment-post-card.tsx
+++ b/components/chat/moment-post-card.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
 import type { MomentPost, MomentComment } from "@/lib/moments-types";
 import { BilingualTextBlock, MediaImageWithPreview } from "@/components/chat/message-bubble";
+import { MediaPreviewOverlay } from "@/components/chat/media-preview-overlay";
 import {
     loadMomentComments,
     toggleMomentLike,
@@ -18,7 +19,7 @@ import { buildTwoLevelMomentThreads } from "@/lib/moments-comment-threading";
 import { getChatImageFromIndexedDB } from "@/lib/chat-asset-storage";
 import { splitBilingualText } from "@/lib/bilingual-text";
 import { retryMomentGeneratedPhoto } from "@/lib/generated-image-retry";
-import { RefreshCw, Trash2, MoreHorizontal, MapPin, Heart, MessageCircle, Pencil } from "lucide-react";
+import { Trash2, MoreHorizontal, MapPin, Heart, MessageCircle, Pencil } from "lucide-react";
 import { ConfirmDialog } from "@/components/ui";
 
 type Props = {
@@ -40,6 +41,7 @@ export function MomentPostCard({ post, onUpdate, onRequestDelete, onOpenCommentC
     const [showPhotoPromptEditor, setShowPhotoPromptEditor] = useState(false);
     const [photoPromptDraft, setPhotoPromptDraft] = useState("");
     const [photoRegenerating, setPhotoRegenerating] = useState(false);
+    const [showFallbackPreview, setShowFallbackPreview] = useState(false);
     const [photoRetryError, setPhotoRetryError] = useState("");
     const [showPostActions, setShowPostActions] = useState(false);
     const [editingPostOpen, setEditingPostOpen] = useState(false);
@@ -327,20 +329,8 @@ export function MomentPostCard({ post, onUpdate, onRequestDelete, onOpenCommentC
                         onError={() => {
                             setResolvedPhotoUrl(null);
                         }}
-                        sideAction={canRegeneratePhoto ? (
-                            <button
-                                type="button"
-                                className="feed-post-photo-retry-btn"
-                                disabled={photoRegenerating}
-                                aria-label="重新生成朋友圈图片"
-                                onClick={e => {
-                                    e.stopPropagation();
-                                    openPhotoPromptEditor();
-                                }}
-                            >
-                                <RefreshCw size={14} className={photoRegenerating ? "is-spinning" : undefined} />
-                            </button>
-                        ) : undefined}
+                        onRegenerate={canRegeneratePhoto ? openPhotoPromptEditor : undefined}
+                        regenerating={photoRegenerating}
                     />
                 )}
                 {fallbackPhotoDescription && (
@@ -348,23 +338,10 @@ export function MomentPostCard({ post, onUpdate, onRequestDelete, onOpenCommentC
                         <div className="feed-post-photo-retry-row">
                             <div
                                 className="feed-post-photo-description ts-13 italic leading-[1.8] opacity-80 text-[var(--c-text)] px-4 py-3 inline-block max-w-full"
-                                style={{ background: "color-mix(in srgb, var(--c-text) 10%, transparent)", borderRadius: 0 }}
+                                style={{ background: "color-mix(in srgb, var(--c-text) 10%, transparent)", borderRadius: 0, cursor: canRetryPhoto ? "pointer" : undefined }}
+                                onClick={canRetryPhoto ? (e => { e.stopPropagation(); setShowFallbackPreview(true); }) : undefined}
                             >
                                 <MomentInlineBilingualText text={fallbackPhotoDescription} defaultExpanded={defaultTranslationExpanded} />
-                                {canRetryPhoto && (
-                                    <button
-                                        type="button"
-                                        className="feed-post-photo-retry-btn feed-post-photo-inline-retry-btn"
-                                        disabled={photoRegenerating}
-                                        aria-label="重新生成朋友圈图片"
-                                        onClick={e => {
-                                            e.stopPropagation();
-                                            openPhotoPromptEditor();
-                                        }}
-                                    >
-                                        <RefreshCw size={14} className={photoRegenerating ? "is-spinning" : undefined} />
-                                    </button>
-                                )}
                             </div>
                         </div>
                         {post.photoGenerationStatus === "pending" && (
@@ -377,6 +354,14 @@ export function MomentPostCard({ post, onUpdate, onRequestDelete, onOpenCommentC
                 )}
                 {photoRetryError && <div className="feed-post-photo-retry-error">生成失败：{photoRetryError}</div>}
             </div>
+            {showFallbackPreview && fallbackPhotoDescription && (
+                <MediaPreviewOverlay
+                    description={fallbackPhotoDescription}
+                    onRegenerate={canRetryPhoto ? () => { setShowFallbackPreview(false); openPhotoPromptEditor(); } : undefined}
+                    regenerating={photoRegenerating}
+                    onClose={() => setShowFallbackPreview(false)}
+                />
+            )}
             {showPhotoPromptEditor && typeof document !== "undefined" && createPortal(
                 <div className="modal-overlay" data-ui="modal" onClick={() => setShowPhotoPromptEditor(false)}>
                     <div className="modal-dialog feed-post-photo-prompt-dialog" data-ui="modal-dialog" onClick={e => e.stopPropagation()}>

--- a/components/mascot/mascot-float.tsx
+++ b/components/mascot/mascot-float.tsx
@@ -15,6 +15,7 @@ import {
 import { getMascotContext, subscribeMascotContext } from "@/lib/mascot-context";
 import { mascotNavigate, DIY_WIDGET_PREVIEW_EVENT, type DiyWidgetPreviewEventDetail, type DiyWidgetPreviewRequest } from "@/lib/mascot-events";
 import { DIY_WIDGET_GUARD_STYLE } from "@/components/widgets/diy-widget-renderer";
+import { MediaPreviewOverlay } from "@/components/chat/media-preview-overlay";
 import {
   clearMascotToolHistoryMessages,
   deleteMascotMessageWithLinkedTools,
@@ -613,6 +614,7 @@ export function MascotFloat() {
   const [pendingImages, setPendingImages] = useState<string[]>([]);
   // ref → blob object URL 缓存，渲染预览用
   const [imagePreviewCache, setImagePreviewCache] = useState<Record<string, string>>({});
+  const [previewImageUrl, setPreviewImageUrl] = useState<string | null>(null);
   const [nineSliceCalibration, setNineSliceCalibration] = useState<NineSliceCalibrationEventDetail | null>(null);
   const [diyWidgetPreview, setDiyWidgetPreview] = useState<DiyWidgetPreviewRequest | null>(null);
   const [activeMascotMessageIndex, setActiveMascotMessageIndex] = useState<number | null>(null);
@@ -1018,7 +1020,16 @@ export function MascotFloat() {
                 const url = imagePreviewCache[ref];
                 if (!url) return <div key={idx} className="mascot-msg-image mascot-msg-image-loading" />;
                 /* eslint-disable-next-line @next/next/no-img-element */
-                return <img key={idx} src={url} alt="" className="mascot-msg-image" />;
+                return (
+                  <img
+                    key={idx}
+                    src={url}
+                    alt=""
+                    className="mascot-msg-image"
+                    style={{ cursor: "pointer" }}
+                    onClick={e => { e.stopPropagation(); setPreviewImageUrl(url); }}
+                  />
+                );
               })}
             </div>
           )}
@@ -1056,7 +1067,16 @@ export function MascotFloat() {
                 const url = imagePreviewCache[ref];
                 if (!url) return <div key={idx} className="mascot-msg-image mascot-msg-image-loading" />;
                 /* eslint-disable-next-line @next/next/no-img-element */
-                return <img key={idx} src={url} alt="" className="mascot-msg-image" />;
+                return (
+                  <img
+                    key={idx}
+                    src={url}
+                    alt=""
+                    className="mascot-msg-image"
+                    style={{ cursor: "pointer" }}
+                    onClick={e => { e.stopPropagation(); setPreviewImageUrl(url); }}
+                  />
+                );
               })}
             </div>
           )}
@@ -2098,6 +2118,14 @@ export function MascotFloat() {
         <NineSliceCalibrationDialog
           detail={nineSliceCalibration}
           onClose={() => setNineSliceCalibration(null)}
+        />
+      )}
+
+      {previewImageUrl && (
+        <MediaPreviewOverlay
+          imageUrl={previewImageUrl}
+          saveFilename="小卷图片.png"
+          onClose={() => setPreviewImageUrl(null)}
         />
       )}
 


### PR DESCRIPTION
同 #28，同步到 test 分支。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_