### PR TITLE
资源集市：新增独立桌面 App（GitHub 仓库当后端）

### DIFF
--- a/components/desktop-shell.tsx
+++ b/components/desktop-shell.tsx
@@ -18,6 +18,7 @@ import MusicFloat from "@/components/music/music-float";
 import MiniAppWindow from "@/components/music/mini-app-window";
 import { PhoneCalendarApp } from "@/components/calendar-app";
 import { PhoneQaApp } from "@/components/phone-qa-app";
+import { ResourceHubApp } from "@/components/resource-hub/resource-hub-app";
 import "@/lib/qa-error-log";
 import { DiaryApp } from "@/components/diary/diary-app";
 import { XiaohongshuApp } from "@/components/xiaohongshu/xiaohongshu-app";
@@ -3384,6 +3385,9 @@ html,body{margin:0;padding:0;width:100%;height:100%;background:#121110;color:rgb
     }
     if (activeApp === "qa") {
       return <PhoneQaApp onClose={() => setActiveApp(null)} onNotice={setNotice} />;
+    }
+    if (activeApp === "resource_hub") {
+      return <ResourceHubApp onClose={() => setActiveApp(null)} onNotice={setNotice} />;
     }
 
     if (activeApp === "diary") {

--- a/components/icon-glyph.tsx
+++ b/components/icon-glyph.tsx
@@ -37,6 +37,7 @@ import {
   mdiAccount,
   mdiHome,
   mdiHammerWrench,
+  mdiStorefrontOutline,
 } from "@mdi/js";
 
 type IconGlyphProps = {
@@ -69,6 +70,7 @@ const MDI_PATHS: Record<IconId, string> = {
   group_chat: mdiAccountGroup,
   theme: mdiPalette,
   resources: mdiDatabase,
+  resource_hub: mdiStorefrontOutline,
   characters: mdiAccount,
   dwelling: mdiHome,
 };

--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+// 资源集市：社区资源市场（GitHub 仓库当后端，浏览走 CDN，安装进本机存储）。
+// 普通用户零配置：打开即从默认资源仓库拉目录；仓库地址可在设置里改。
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Download, RefreshCw, Search, Settings2, Store } from "lucide-react";
+import { PageShell } from "@/components/ui/page-shell";
+import { ContentDialog } from "@/components/ui/modal";
+import { Input } from "@/components/ui/form";
+import {
+    fetchResourceHubIndex,
+    installResourceHubItem,
+    loadInstalledResourceMap,
+    loadResourceHubSource,
+    resolveResourceHubAssetUrl,
+    saveResourceHubSource,
+} from "@/lib/resource-hub-client";
+import {
+    RESOURCE_HUB_KIND_LABELS,
+    type ResourceHubIndex,
+    type ResourceHubItem,
+    type ResourceHubKind,
+    type ResourceHubSource,
+} from "@/lib/resource-hub-types";
+
+type LoadState = "loading" | "ready" | "error";
+type InstallState = "installing" | "done" | "error";
+
+const KIND_FILTERS: Array<{ key: ResourceHubKind | "all"; label: string }> = [
+    { key: "all", label: "全部" },
+    { key: "character", label: RESOURCE_HUB_KIND_LABELS.character },
+    { key: "preset", label: RESOURCE_HUB_KIND_LABELS.preset },
+    { key: "worldbook", label: RESOURCE_HUB_KIND_LABELS.worldbook },
+    { key: "regex", label: RESOURCE_HUB_KIND_LABELS.regex },
+    { key: "css", label: RESOURCE_HUB_KIND_LABELS.css },
+];
+
+export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onNotice?: (msg: string) => void }) {
+    const [source, setSource] = useState<ResourceHubSource>(() => loadResourceHubSource());
+    const [index, setIndex] = useState<ResourceHubIndex | null>(null);
+    const [loadState, setLoadState] = useState<LoadState>("loading");
+    const [loadError, setLoadError] = useState("");
+    const [filter, setFilter] = useState<ResourceHubKind | "all">("all");
+    const [query, setQuery] = useState("");
+    const [installStates, setInstallStates] = useState<Record<string, InstallState>>({});
+    const [installedMap, setInstalledMap] = useState(() => loadInstalledResourceMap());
+    const [showSourceEditor, setShowSourceEditor] = useState(false);
+    const [sourceDraft, setSourceDraft] = useState<ResourceHubSource>(source);
+
+    const reload = useCallback((activeSource: ResourceHubSource) => {
+        setLoadState("loading");
+        setLoadError("");
+        fetchResourceHubIndex(activeSource)
+            .then(data => {
+                setIndex(data);
+                setLoadState("ready");
+            })
+            .catch(err => {
+                setLoadError(err instanceof Error ? err.message : String(err));
+                setLoadState("error");
+            });
+    }, []);
+
+    useEffect(() => { reload(source); }, [reload, source]);
+
+    const visibleItems = useMemo(() => {
+        const items = index?.items ?? [];
+        const trimmed = query.trim().toLowerCase();
+        return items.filter(item => {
+            if (filter !== "all" && item.kind !== filter) return false;
+            if (!trimmed) return true;
+            const haystack = [item.name, item.author, item.description, ...(item.tags ?? [])]
+                .filter(Boolean).join(" ").toLowerCase();
+            return haystack.includes(trimmed);
+        });
+    }, [index, filter, query]);
+
+    const handleInstall = useCallback(async (item: ResourceHubItem) => {
+        setInstallStates(prev => ({ ...prev, [item.id]: "installing" }));
+        try {
+            const message = await installResourceHubItem(source, item);
+            setInstallStates(prev => ({ ...prev, [item.id]: "done" }));
+            setInstalledMap(loadInstalledResourceMap());
+            onNotice?.(message);
+        } catch (err) {
+            setInstallStates(prev => ({ ...prev, [item.id]: "error" }));
+            onNotice?.(`安装失败：${err instanceof Error ? err.message : String(err)}`);
+        }
+    }, [onNotice, source]);
+
+    const handleSourceSave = useCallback(() => {
+        const next: ResourceHubSource = {
+            owner: sourceDraft.owner.trim(),
+            repo: sourceDraft.repo.trim(),
+            branch: sourceDraft.branch.trim() || "main",
+        };
+        if (!next.owner || !next.repo) {
+            onNotice?.("仓库 owner 和名称不能为空");
+            return;
+        }
+        saveResourceHubSource(next);
+        setSource(next);
+        setShowSourceEditor(false);
+    }, [onNotice, sourceDraft]);
+
+    const renderItemCard = (item: ResourceHubItem) => {
+        const state = installStates[item.id];
+        const installedRecord = installedMap[item.id];
+        const isInstalled = state === "done" || (!!installedRecord && installedRecord.version === item.version);
+        const busy = state === "installing";
+        return (
+            <div key={item.id} className="ui-group-card">
+                <div className="flex items-start gap-3">
+                    {item.cover && (
+                        <div className="w-12 h-12 shrink-0 rounded-xl overflow-hidden bg-black/5 dark:bg-white/10">
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img src={resolveResourceHubAssetUrl(source, item.cover)} alt="" className="w-full h-full object-cover" loading="lazy" />
+                        </div>
+                    )}
+                    <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+                        <div className="flex items-center gap-2 min-w-0">
+                            <span className="menu-label truncate">{item.name}</span>
+                            <span className="ts-11 shrink-0 px-1.5 py-0.5 rounded-md bg-black/5 dark:bg-white/10 text-[var(--c-icon)]">
+                                {RESOURCE_HUB_KIND_LABELS[item.kind]}
+                            </span>
+                        </div>
+                        <span className="menu-desc !mt-0">
+                            {[item.author && `by ${item.author}`, item.version && `v${item.version}`].filter(Boolean).join(" · ")}
+                        </span>
+                        {item.description && <span className="menu-desc !mt-0 line-clamp-2">{item.description}</span>}
+                    </div>
+                    <button
+                        className={`ui-btn ${isInstalled ? "ui-btn-ghost" : "ui-btn-primary"} shrink-0 !px-3`}
+                        disabled={busy || isInstalled}
+                        onClick={() => handleInstall(item)}
+                    >
+                        {busy ? "安装中..." : isInstalled ? "已安装" : (
+                            <span className="flex items-center gap-1"><Download size={13} />安装</span>
+                        )}
+                    </button>
+                </div>
+            </div>
+        );
+    };
+
+    return (
+        <PageShell
+            title="资源集市"
+            onBack={onClose}
+            rightAction={
+                <div className="flex items-center gap-1">
+                    <button className="ui-bare-btn" aria-label="刷新" onClick={() => reload(source)}>
+                        <RefreshCw size={18} strokeWidth={1.75} className={loadState === "loading" ? "is-spinning" : undefined} />
+                    </button>
+                    <button className="ui-bare-btn" aria-label="资源仓库设置" onClick={() => { setSourceDraft(source); setShowSourceEditor(true); }}>
+                        <Settings2 size={18} strokeWidth={1.75} />
+                    </button>
+                </div>
+            }
+        >
+            <div className="flex flex-col gap-3 p-4">
+                <div className="relative">
+                    <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--c-icon)] pointer-events-none" />
+                    <input
+                        className="ui-input w-full !pl-9"
+                        value={query}
+                        onChange={e => setQuery(e.target.value)}
+                        placeholder="搜索资源、作者、标签..."
+                    />
+                </div>
+
+                <div className="flex items-center gap-2 overflow-x-auto pb-0.5 -mx-1 px-1">
+                    {KIND_FILTERS.map(({ key, label }) => (
+                        <button
+                            key={key}
+                            className="ui-chip shrink-0"
+                            data-active={filter === key ? "1" : undefined}
+                            style={filter === key ? { background: "var(--c-icon-active, var(--c-text))", color: "var(--c-card, #fff)" } : undefined}
+                            onClick={() => setFilter(key)}
+                        >
+                            {label}
+                        </button>
+                    ))}
+                </div>
+
+                {index?.notice && loadState === "ready" && (
+                    <div className="ui-group-card py-2">
+                        <span className="menu-desc !mt-0 whitespace-pre-wrap">{index.notice}</span>
+                    </div>
+                )}
+
+                {loadState === "loading" && (
+                    <div className="ui-empty-compact mt-6"><span className="menu-desc">目录加载中...</span></div>
+                )}
+
+                {loadState === "error" && (
+                    <div className="ui-empty-compact mt-6 flex flex-col items-center gap-2">
+                        <Store size={28} className="text-[var(--c-icon)] opacity-60" />
+                        <span className="menu-desc text-center">
+                            资源仓库暂时无法访问（{loadError}）。
+                            <br />可能是仓库尚未就绪或网络问题，可点右上角刷新重试。
+                        </span>
+                    </div>
+                )}
+
+                {loadState === "ready" && visibleItems.length === 0 && (
+                    <div className="ui-empty-compact mt-6">
+                        <span className="menu-desc">{query.trim() ? "没有匹配的资源" : "该分类暂时没有资源"}</span>
+                    </div>
+                )}
+
+                {loadState === "ready" && visibleItems.map(renderItemCard)}
+            </div>
+
+            {showSourceEditor && (
+                <ContentDialog
+                    title="资源仓库"
+                    confirmLabel="保存"
+                    onConfirm={handleSourceSave}
+                    onCancel={() => setShowSourceEditor(false)}
+                >
+                    <div className="flex flex-col gap-3 text-left w-full">
+                        <div className="flex flex-col gap-1">
+                            <label className="menu-desc ml-1">GitHub 用户/组织</label>
+                            <Input value={sourceDraft.owner} onChange={e => setSourceDraft(prev => ({ ...prev, owner: e.target.value }))} />
+                        </div>
+                        <div className="flex flex-col gap-1">
+                            <label className="menu-desc ml-1">仓库名</label>
+                            <Input value={sourceDraft.repo} onChange={e => setSourceDraft(prev => ({ ...prev, repo: e.target.value }))} />
+                        </div>
+                        <div className="flex flex-col gap-1">
+                            <label className="menu-desc ml-1">分支</label>
+                            <Input value={sourceDraft.branch} placeholder="main" onChange={e => setSourceDraft(prev => ({ ...prev, branch: e.target.value }))} />
+                        </div>
+                        <span className="menu-desc ml-1">资源经 jsDelivr CDN 拉取，公开仓库无需登录。除非要换资源源，一般不用改。</span>
+                    </div>
+                </ContentDialog>
+            )}
+        </PageShell>
+    );
+}

--- a/docs/resource-hub.md
+++ b/docs/resource-hub.md
@@ -1,0 +1,139 @@
+# 资源集市（Resource Hub）
+
+小手机内置的社区资源市场。**后端是一个公开 GitHub 仓库**，浏览走 jsDelivr CDN（国内可达、无限流、免费），安装直接写进本机存储 —— 全程不经过自建服务器。
+
+- 前端：桌面「资源集市」App（`components/resource-hub/resource-hub-app.tsx`）
+- 客户端：`lib/resource-hub-client.ts`（CDN 多镜像回退 + 各类型安装）
+- 默认资源仓库：`xiaolongbao0709/ai-phone-resource-hub@main`（App 设置里可改）
+
+## 资源仓库结构
+
+```
+ai-phone-resource-hub/           （公开仓库）
+├── index.json                   ← 总目录（市场页启动时拉这一个文件）
+├── characters/  唐簪雪.json      ← 角色卡（ai_phone_character 导出格式）
+├── presets/     日常向.json      ← 预设（预设管理页导出的 JSON）
+├── worldbooks/  古风世界.json    ← 世界书（世界书管理页导出的 JSON）
+├── regexes/     去括号.json      ← 正则组（正则管理页导出的 JSON）
+├── css/         奶油白.css       ← CSS 方案（纯 CSS 文本）
+├── covers/      xxx.webp        ← 封面图（可选，建议 ≤100KB）
+└── .github/workflows/build-index.yml
+```
+
+## index.json 格式
+
+```json
+{
+  "schema": "ai_phone_resource_hub",
+  "schemaVersion": 1,
+  "updatedAt": "2026-08-10T00:00:00Z",
+  "notice": "可选的公告，显示在市场列表顶部",
+  "items": [
+    {
+      "id": "characters/唐簪雪",
+      "kind": "character",
+      "name": "唐簪雪",
+      "path": "characters/唐簪雪.json",
+      "author": "小笼包",
+      "description": "一句话简介",
+      "version": "1.0",
+      "tags": ["古风"],
+      "cover": "covers/tzx.webp"
+    },
+    {
+      "id": "css/奶油白",
+      "kind": "css",
+      "name": "奶油白",
+      "path": "css/奶油白.css",
+      "cssTarget": "global"
+    }
+  ]
+}
+```
+
+字段说明：
+- `kind`：`character` / `preset` / `worldbook` / `regex` / `css`
+- `path`：资源文件在仓库内的相对路径
+- `cover`：仓库相对路径或完整 URL，可省略
+- `cssTarget`（仅 css）：`global` / `chat_app` / `chat_session` / `story` / `music` / `calendar`，缺省 `global`
+- `version`：变更后市场端"已安装"标记会失效，用户可重新安装升级
+
+## 自动生成 index.json（GitHub Actions）
+
+merge 后自动扫描目录重建索引，投稿 PR 里不需要手改 index.json。
+`.github/workflows/build-index.yml`：
+
+```yaml
+name: Build index
+on:
+  push:
+    branches: [main]
+    paths: ["characters/**", "presets/**", "worldbooks/**", "regexes/**", "css/**"]
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions: { contents: write }
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build index.json
+        run: node scripts/build-index.mjs
+      - name: Commit
+        run: |
+          git config user.name "resource-hub-bot"
+          git config user.email "bot@users.noreply.github.com"
+          git add index.json
+          git diff --cached --quiet || git commit -m "chore: rebuild index.json"
+          git push
+```
+
+`scripts/build-index.mjs`（放在资源仓库里）：
+
+```js
+import { readdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+
+const KINDS = [
+  ["characters", "character", ".json"],
+  ["presets", "preset", ".json"],
+  ["worldbooks", "worldbook", ".json"],
+  ["regexes", "regex", ".json"],
+  ["css", "css", ".css"],
+];
+
+const items = [];
+for (const [dir, kind, ext] of KINDS) {
+  if (!existsSync(dir)) continue;
+  for (const file of readdirSync(dir).filter(f => f.endsWith(ext)).sort()) {
+    const path = `${dir}/${file}`;
+    const name = file.slice(0, -ext.length);
+    // 同名 .meta.json 里可补充 author/description/version/tags/cover/cssTarget
+    const metaPath = `${dir}/${name}.meta.json`;
+    let meta = {};
+    if (existsSync(metaPath)) {
+      try { meta = JSON.parse(readFileSync(metaPath, "utf8")); } catch { /* 忽略坏 meta */ }
+    }
+    items.push({ id: `${dir}/${name}`, kind, name, path, ...meta });
+  }
+}
+
+writeFileSync("index.json", JSON.stringify({
+  schema: "ai_phone_resource_hub",
+  schemaVersion: 1,
+  updatedAt: new Date().toISOString(),
+  items,
+}, null, 2));
+console.log(`index.json: ${items.length} items`);
+```
+
+## 运营流程
+
+- **投稿**：PR 往对应目录加文件（资源文件 + 可选的同名 `.meta.json`）
+- **上架**：merge PR（Actions 自动重建索引）
+- **下架**：删文件 merge；**回滚**：revert commit
+- **CDN 缓存**：jsDelivr 对 `@main` 的缓存最长约 12 小时；急刷可访问
+  `https://purge.jsdelivr.net/gh/<owner>/<repo>@main/index.json`
+
+## 体积约束
+
+- jsDelivr 单文件上限 20MB；封面图建议压到 100KB 内
+- 表情包 / 主题包等图片重的资源类型属于二期，方案是包内只存图床 URL

--- a/lib/desktop-config.ts
+++ b/lib/desktop-config.ts
@@ -24,6 +24,7 @@ export type IconId =
   | "settings"
   | "theme"
   | "resources"
+  | "resource_hub"
   | "characters"
   | "worldbuilder"
   | "qa";
@@ -54,7 +55,7 @@ export const PAGE_2_DEFAULT: IconId[] = [
 ];
 
 // 第三页默认图标（居中放置，位置见 createDefaultDesktopIconLayout）
-export const PAGE_3_DEFAULT: IconId[] = ["worldbuilder", "qa"];
+export const PAGE_3_DEFAULT: IconId[] = ["worldbuilder", "qa", "resource_hub"];
 
 export const DOCK_DEFAULT: IconId[] = ["settings", "theme", "resources", "characters"];
 
@@ -92,6 +93,7 @@ export const ICONS: Record<IconId, IconMeta> = {
   settings: { id: "settings", label: "设置", tone: "var(--c-icon-slate)", placeholder: false },
   theme: { id: "theme", label: "\u4E3B\u9898", tone: "var(--c-icon-violet)", placeholder: true },
   resources: { id: "resources", label: "\u8D44\u6E90\u5E93", tone: "var(--c-icon-teal)", placeholder: false },
+  resource_hub: { id: "resource_hub", label: "资源集市", tone: "var(--c-icon-amber)", placeholder: false },
   characters: {
     id: "characters",
     label: "\u89D2\u8272",

--- a/lib/resource-hub-client.ts
+++ b/lib/resource-hub-client.ts
@@ -1,0 +1,195 @@
+// lib/resource-hub-client.ts
+// 资源集市客户端：CDN 多镜像拉取 + 各资源类型的本地安装。
+// 浏览走 jsDelivr（国内可达、免限流），失败逐级回退，全程不经过自家服务端。
+
+import { kvGet, kvSet, registerKvMigration } from "./kv-db";
+import {
+    isResourceHubKind,
+    RESOURCE_HUB_DEFAULT_SOURCE,
+    type ResourceHubIndex,
+    type ResourceHubItem,
+    type ResourceHubSource,
+} from "./resource-hub-types";
+import { createCharacter, loadCharacters, parseCharacterFromJson, saveCharacters } from "./character-storage";
+import {
+    loadPresets, savePresets, parsePresetFromJson,
+    loadWorldBooks, saveWorldBooks, parseWorldBookFromJson,
+    loadRegexes, saveRegexes, parseRegexFromJson,
+} from "./settings-storage";
+import { saveScheme } from "./css-scheme-storage";
+
+const SOURCE_KEY = "ai_phone_resource_hub_source_v1";
+const INSTALLED_KEY = "ai_phone_resource_hub_installed_v1";
+registerKvMigration(SOURCE_KEY);
+registerKvMigration(INSTALLED_KEY);
+
+const FETCH_TIMEOUT_MS = 15000;
+
+// ── 源配置 ──
+
+export function loadResourceHubSource(): ResourceHubSource {
+    try {
+        const raw = kvGet(SOURCE_KEY);
+        if (raw) {
+            const parsed = JSON.parse(raw) as Partial<ResourceHubSource>;
+            if (parsed.owner && parsed.repo) {
+                return { owner: parsed.owner, repo: parsed.repo, branch: parsed.branch || "main" };
+            }
+        }
+    } catch { /* fall through */ }
+    return { ...RESOURCE_HUB_DEFAULT_SOURCE };
+}
+
+export function saveResourceHubSource(source: ResourceHubSource): void {
+    kvSet(SOURCE_KEY, JSON.stringify(source));
+}
+
+// ── CDN 拉取（多镜像回退）──
+
+function buildMirrorUrls(source: ResourceHubSource, path: string): string[] {
+    const { owner, repo, branch } = source;
+    const clean = path.replace(/^\/+/, "");
+    return [
+        `https://cdn.jsdelivr.net/gh/${owner}/${repo}@${branch}/${clean}`,
+        `https://fastly.jsdelivr.net/gh/${owner}/${repo}@${branch}/${clean}`,
+        `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${clean}`,
+    ];
+}
+
+async function fetchWithTimeout(url: string): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+        return await fetch(url, { signal: controller.signal, cache: "no-cache" });
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+/** 逐镜像尝试拉取文本；全部失败抛最后一个错误。 */
+export async function fetchResourceHubText(source: ResourceHubSource, path: string): Promise<string> {
+    let lastError: Error = new Error("无可用镜像");
+    for (const url of buildMirrorUrls(source, path)) {
+        try {
+            const res = await fetchWithTimeout(url);
+            if (res.ok) return await res.text();
+            lastError = new Error(`HTTP ${res.status}`);
+        } catch (err) {
+            lastError = err instanceof Error ? err : new Error(String(err));
+        }
+    }
+    throw lastError;
+}
+
+/** 封面等资源的展示 URL（相对路径转 CDN 主镜像，完整 URL 原样返回）。 */
+export function resolveResourceHubAssetUrl(source: ResourceHubSource, pathOrUrl: string): string {
+    if (/^https?:\/\//i.test(pathOrUrl)) return pathOrUrl;
+    return buildMirrorUrls(source, pathOrUrl)[0];
+}
+
+function normalizeIndex(raw: unknown): ResourceHubIndex {
+    const record = (raw ?? {}) as Record<string, unknown>;
+    if (record.schema !== "ai_phone_resource_hub" || !Array.isArray(record.items)) {
+        throw new Error("目录格式不正确（缺少 schema 或 items）");
+    }
+    const items: ResourceHubItem[] = [];
+    for (const entry of record.items) {
+        const item = (entry ?? {}) as Record<string, unknown>;
+        if (typeof item.id !== "string" || typeof item.name !== "string" || typeof item.path !== "string") continue;
+        if (!isResourceHubKind(item.kind)) continue;
+        items.push({
+            id: item.id,
+            kind: item.kind,
+            name: item.name,
+            path: item.path,
+            author: typeof item.author === "string" ? item.author : undefined,
+            description: typeof item.description === "string" ? item.description : undefined,
+            version: typeof item.version === "string" ? item.version : undefined,
+            tags: Array.isArray(item.tags) ? item.tags.filter((t): t is string => typeof t === "string") : undefined,
+            cover: typeof item.cover === "string" ? item.cover : undefined,
+            updatedAt: typeof item.updatedAt === "string" ? item.updatedAt : undefined,
+            cssTarget: typeof item.cssTarget === "string" ? item.cssTarget : undefined,
+        });
+    }
+    return {
+        schema: "ai_phone_resource_hub",
+        schemaVersion: typeof record.schemaVersion === "number" ? record.schemaVersion : 1,
+        updatedAt: typeof record.updatedAt === "string" ? record.updatedAt : undefined,
+        notice: typeof record.notice === "string" ? record.notice : undefined,
+        items,
+    };
+}
+
+export async function fetchResourceHubIndex(source: ResourceHubSource): Promise<ResourceHubIndex> {
+    const text = await fetchResourceHubText(source, "index.json");
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(text);
+    } catch {
+        throw new Error("目录不是合法的 JSON");
+    }
+    return normalizeIndex(parsed);
+}
+
+// ── 已安装记录 ──
+
+type InstalledMap = Record<string, { version?: string; installedAt: string }>;
+
+export function loadInstalledResourceMap(): InstalledMap {
+    try {
+        const raw = kvGet(INSTALLED_KEY);
+        return raw ? (JSON.parse(raw) as InstalledMap) : {};
+    } catch { return {}; }
+}
+
+function markInstalled(item: ResourceHubItem): void {
+    const map = loadInstalledResourceMap();
+    map[item.id] = { version: item.version, installedAt: new Date().toISOString() };
+    kvSet(INSTALLED_KEY, JSON.stringify(map));
+}
+
+// ── 安装 ──
+
+const CSS_TARGETS = new Set(["global", "chat_app", "chat_session", "story", "music", "calendar"]);
+
+/** 拉取资源文件并装进本机对应存储；返回展示用的结果说明。 */
+export async function installResourceHubItem(source: ResourceHubSource, item: ResourceHubItem): Promise<string> {
+    const text = await fetchResourceHubText(source, item.path);
+    switch (item.kind) {
+        case "character": {
+            const data = parseCharacterFromJson(text);
+            if (!data) throw new Error("角色卡解析失败");
+            const character = createCharacter(data);
+            saveCharacters([...loadCharacters(), character]);
+            markInstalled(item);
+            return `角色「${character.name}」已加入角色库`;
+        }
+        case "preset": {
+            const preset = parsePresetFromJson(text, item.name);
+            if (!preset) throw new Error("预设解析失败");
+            savePresets([...loadPresets(), preset]);
+            markInstalled(item);
+            return `预设「${preset.name}」已导入`;
+        }
+        case "worldbook": {
+            const book = parseWorldBookFromJson(text);
+            if (!book) throw new Error("世界书解析失败");
+            saveWorldBooks([...loadWorldBooks(), book]);
+            markInstalled(item);
+            return `世界书「${book.name}」已导入`;
+        }
+        case "regex": {
+            const regex = parseRegexFromJson(text, item.name);
+            if (!regex) throw new Error("正则解析失败");
+            saveRegexes([...loadRegexes(), regex]);
+            markInstalled(item);
+            return `正则组「${regex.name}」已导入`;
+        }
+        case "css": {
+            const target = item.cssTarget && CSS_TARGETS.has(item.cssTarget) ? item.cssTarget : "global";
+            saveScheme(target, item.name, text);
+            markInstalled(item);
+            return `CSS 方案「${item.name}」已保存，可在对应界面的 CSS 设置里应用`;
+        }
+    }
+}

--- a/lib/resource-hub-types.ts
+++ b/lib/resource-hub-types.ts
@@ -1,0 +1,56 @@
+// lib/resource-hub-types.ts
+// 资源集市：GitHub 仓库当后端的社区资源市场。
+// 仓库根目录维护一份 index.json 总目录，市场页经 CDN 拉取后按需安装单个资源文件。
+
+export type ResourceHubKind = "character" | "preset" | "worldbook" | "regex" | "css";
+
+export const RESOURCE_HUB_KIND_LABELS: Record<ResourceHubKind, string> = {
+    character: "角色卡",
+    preset: "预设",
+    worldbook: "世界书",
+    regex: "正则",
+    css: "CSS 方案",
+};
+
+export function isResourceHubKind(value: unknown): value is ResourceHubKind {
+    return typeof value === "string" && value in RESOURCE_HUB_KIND_LABELS;
+}
+
+export type ResourceHubItem = {
+    /** 目录内唯一 ID（建议 kind/文件名） */
+    id: string;
+    kind: ResourceHubKind;
+    name: string;
+    /** 资源文件在仓库内的相对路径 */
+    path: string;
+    author?: string;
+    description?: string;
+    version?: string;
+    tags?: string[];
+    /** 封面：仓库相对路径或完整 http(s) URL */
+    cover?: string;
+    updatedAt?: string;
+    /** css 类型专用：方案目标（global / chat_app / chat_session / story / music / calendar） */
+    cssTarget?: string;
+};
+
+export type ResourceHubIndex = {
+    schema: "ai_phone_resource_hub";
+    schemaVersion: number;
+    updatedAt?: string;
+    /** 市场公告（可选，显示在列表顶部） */
+    notice?: string;
+    items: ResourceHubItem[];
+};
+
+export type ResourceHubSource = {
+    owner: string;
+    repo: string;
+    branch: string;
+};
+
+export const RESOURCE_HUB_DEFAULT_SOURCE: ResourceHubSource = {
+    owner: "xiaolongbao0709",
+    repo: "ai-phone-resource-hub",
+    branch: "main",
+};


### PR DESCRIPTION
从 clean- 仓库移植（两仓库桌面配置文件已分叉，注册处按本仓库内容手动适配，新增文件逐字一致）。

## 内容

新增「资源集市」独立桌面 App：后端是一个公开 GitHub 仓库，浏览走 jsDelivr CDN（国内可达、免限流），安装直接调各资源类型现有导入函数写进本机存储，全程不经过自建服务器，零配置打开即用。

- `lib/resource-hub-types.ts` / `lib/resource-hub-client.ts`：index.json 目录格式、CDN 三镜像回退、五类资源（角色卡/预设/世界书/正则/CSS）安装落库
- `components/resource-hub/resource-hub-app.tsx`：搜索、分类筛选、公告、安装状态、换源弹窗
- 桌面注册：`resource_hub` 图标默认放第 3 页，存量用户由默认图标兜底逻辑自动补上
- `docs/resource-hub.md`：资源仓库规范、自动建索引 Actions、运营流程

## 验证

clean- 侧浏览器实测：mock CDN 目录后列表/筛选/搜索正常，角色卡/预设/CSS 安装真实落库；真实桌面第 3 页出现图标并可进入 App。本仓库 `tsc --noEmit` 0 错误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_