### PR TITLE
资源集市：进入时弹出「施工中」提示

### DIFF
--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -6,7 +6,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Download, RefreshCw, Search, Settings2, Store } from "lucide-react";
 import { PageShell } from "@/components/ui/page-shell";
-import { ContentDialog } from "@/components/ui/modal";
+import { ConfirmDialog, ContentDialog } from "@/components/ui/modal";
 import { Input } from "@/components/ui/form";
 import {
     fetchResourceHubIndex,
@@ -47,6 +47,8 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     const [installedMap, setInstalledMap] = useState(() => loadInstalledResourceMap());
     const [showSourceEditor, setShowSourceEditor] = useState(false);
     const [sourceDraft, setSourceDraft] = useState<ResourceHubSource>(source);
+    // 施工提示：每次进入弹一次，正式开张后移除
+    const [showConstructionNotice, setShowConstructionNotice] = useState(true);
 
     const reload = useCallback((activeSource: ResourceHubSource) => {
         setLoadState("loading");
@@ -212,6 +214,19 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
 
                 {loadState === "ready" && visibleItems.map(renderItemCard)}
             </div>
+
+            {showConstructionNotice && (
+                <ConfirmDialog
+                    title="施工中"
+                    message="此app正在施工，请先去别的地方逛逛吧～"
+                    icon={Store}
+                    variant="action"
+                    cancelLabel="仍要看看"
+                    confirmLabel="返回桌面"
+                    onCancel={() => setShowConstructionNotice(false)}
+                    onConfirm={onClose}
+                />
+            )}
 
             {showSourceEditor && (
                 <ContentDialog


### PR DESCRIPTION
资源仓库尚未正式开张，进入资源集市 App 先弹一次施工提示：「仍要看看」关闭弹窗留在 App，「返回桌面」回桌面。正式开张后移除该弹窗即可。

浏览器实测：弹窗按预期出现，文案与两个按钮正确，「仍要看看」关闭弹窗并停留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_