### PR TITLE
资源集市：默认资源仓库指向 xiaolongbao0709/share

### DIFF
--- a/docs/resource-hub.md
+++ b/docs/resource-hub.md
@@ -4,12 +4,12 @@
 
 - 前端：桌面「资源集市」App（`components/resource-hub/resource-hub-app.tsx`）
 - 客户端：`lib/resource-hub-client.ts`（CDN 多镜像回退 + 各类型安装）
-- 默认资源仓库：`xiaolongbao0709/ai-phone-resource-hub@main`（App 设置里可改）
+- 默认资源仓库：`xiaolongbao0709/share@main`（App 设置里可改）
 
 ## 资源仓库结构
 
 ```
-ai-phone-resource-hub/           （公开仓库）
+share/                           （公开仓库）
 ├── index.json                   ← 总目录（市场页启动时拉这一个文件）
 ├── characters/  唐簪雪.json      ← 角色卡（ai_phone_character 导出格式）
 ├── presets/     日常向.json      ← 预设（预设管理页导出的 JSON）

--- a/lib/resource-hub-types.ts
+++ b/lib/resource-hub-types.ts
@@ -51,6 +51,6 @@ export type ResourceHubSource = {
 
 export const RESOURCE_HUB_DEFAULT_SOURCE: ResourceHubSource = {
     owner: "xiaolongbao0709",
-    repo: "ai-phone-resource-hub",
+    repo: "share",
     branch: "main",
 };


### PR DESCRIPTION
默认资源源从占位仓库改为实际的 `xiaolongbao0709/share`，文档同步更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_