### PR TITLE
资源集市改版：自动抓取仓库文件夹 + 复古 Windows UI + 导入目的地选择

### DIFF
--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -1,63 +1,59 @@
 "use client";
 
-// 资源集市：社区资源市场（GitHub 仓库当后端，浏览走 CDN，安装进本机存储）。
-// 普通用户零配置：打开即从默认资源仓库拉目录；仓库地址可在设置里改。
+// 资源集市：社区资源市场（GitHub 仓库当后端，浏览走 CDN）。
+// 首页自动显示仓库根目录的文件夹（仿文件管理器），文件夹页为古早论坛式列表，
+// 资源可下载或导入（导入时选择目的地）。整体为复古 Windows 风格。
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Download, RefreshCw, Search, Settings2, Store } from "lucide-react";
-import { PageShell } from "@/components/ui/page-shell";
-import { ConfirmDialog, ContentDialog } from "@/components/ui/modal";
-import { Input } from "@/components/ui/form";
+import { loadCharacters } from "@/lib/character-storage";
+import { loadChatContacts } from "@/lib/chat-storage";
 import {
-    fetchResourceHubIndex,
-    installResourceHubItem,
-    loadInstalledResourceMap,
+    checkImportFileForDestination,
+    downloadResourceHubFile,
+    fetchShareIndex,
+    importResourceHubFile,
     loadResourceHubSource,
     resolveResourceHubAssetUrl,
     saveResourceHubSource,
 } from "@/lib/resource-hub-client";
 import {
-    RESOURCE_HUB_KIND_LABELS,
-    type ResourceHubIndex,
-    type ResourceHubItem,
-    type ResourceHubKind,
+    IMPORT_DESTINATIONS,
+    type ImportDestination,
     type ResourceHubSource,
+    type ShareIndex,
+    type ShareIndexEntry,
 } from "@/lib/resource-hub-types";
 
 type LoadState = "loading" | "ready" | "error";
-type InstallState = "installing" | "done" | "error";
 
-const KIND_FILTERS: Array<{ key: ResourceHubKind | "all"; label: string }> = [
-    { key: "all", label: "全部" },
-    { key: "character", label: RESOURCE_HUB_KIND_LABELS.character },
-    { key: "preset", label: RESOURCE_HUB_KIND_LABELS.preset },
-    { key: "worldbook", label: RESOURCE_HUB_KIND_LABELS.worldbook },
-    { key: "regex", label: RESOURCE_HUB_KIND_LABELS.regex },
-    { key: "css", label: RESOURCE_HUB_KIND_LABELS.css },
-];
+function formatEntryDate(iso: string | null): string {
+    if (!iso) return "";
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return "";
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
 
 export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onNotice?: (msg: string) => void }) {
     const [source, setSource] = useState<ResourceHubSource>(() => loadResourceHubSource());
-    const [index, setIndex] = useState<ResourceHubIndex | null>(null);
+    const [index, setIndex] = useState<ShareIndex | null>(null);
     const [loadState, setLoadState] = useState<LoadState>("loading");
     const [loadError, setLoadError] = useState("");
-    const [filter, setFilter] = useState<ResourceHubKind | "all">("all");
-    const [query, setQuery] = useState("");
-    const [installStates, setInstallStates] = useState<Record<string, InstallState>>({});
-    const [installedMap, setInstalledMap] = useState(() => loadInstalledResourceMap());
+    const [activeFolder, setActiveFolder] = useState<string | null>(null);
+    const [activeEntry, setActiveEntry] = useState<ShareIndexEntry | null>(null);
+    const [busyFile, setBusyFile] = useState<string | null>(null);
+    // 导入流程：选文件 → 选目的地 →（聊天室CSS再选角色）
+    const [importFile, setImportFile] = useState<string | null>(null);
+    const [pickCharacterFor, setPickCharacterFor] = useState<string | null>(null);
+    const [showConstructionNotice, setShowConstructionNotice] = useState(true);
     const [showSourceEditor, setShowSourceEditor] = useState(false);
     const [sourceDraft, setSourceDraft] = useState<ResourceHubSource>(source);
-    // 施工提示：每次进入弹一次，正式开张后移除
-    const [showConstructionNotice, setShowConstructionNotice] = useState(true);
 
     const reload = useCallback((activeSource: ResourceHubSource) => {
         setLoadState("loading");
         setLoadError("");
-        fetchResourceHubIndex(activeSource)
-            .then(data => {
-                setIndex(data);
-                setLoadState("ready");
-            })
+        fetchShareIndex(activeSource)
+            .then(data => { setIndex(data); setLoadState("ready"); })
             .catch(err => {
                 setLoadError(err instanceof Error ? err.message : String(err));
                 setLoadState("error");
@@ -66,192 +62,594 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
 
     useEffect(() => { reload(source); }, [reload, source]);
 
-    const visibleItems = useMemo(() => {
-        const items = index?.items ?? [];
-        const trimmed = query.trim().toLowerCase();
-        return items.filter(item => {
-            if (filter !== "all" && item.kind !== filter) return false;
-            if (!trimmed) return true;
-            const haystack = [item.name, item.author, item.description, ...(item.tags ?? [])]
-                .filter(Boolean).join(" ").toLowerCase();
-            return haystack.includes(trimmed);
-        });
-    }, [index, filter, query]);
+    const folderEntries = useMemo(() => {
+        if (!index || !activeFolder) return [];
+        return index.entries
+            .filter(e => e.folder === activeFolder)
+            .sort((a, b) => (b.updatedAt || "").localeCompare(a.updatedAt || "") || a.name.localeCompare(b.name, "zh"));
+    }, [index, activeFolder]);
 
-    const handleInstall = useCallback(async (item: ResourceHubItem) => {
-        setInstallStates(prev => ({ ...prev, [item.id]: "installing" }));
+    const chatContacts = useMemo(() => {
+        if (pickCharacterFor === null) return [];
+        const characters = loadCharacters();
+        return loadChatContacts().map(contact => ({
+            contactId: contact.id,
+            name: contact.nickname || characters.find(c => c.id === contact.characterId)?.name || "未知角色",
+        }));
+    }, [pickCharacterFor]);
+
+    const handleDownload = useCallback(async (path: string) => {
+        setBusyFile(path);
         try {
-            const message = await installResourceHubItem(source, item);
-            setInstallStates(prev => ({ ...prev, [item.id]: "done" }));
-            setInstalledMap(loadInstalledResourceMap());
-            onNotice?.(message);
+            await downloadResourceHubFile(source, path);
         } catch (err) {
-            setInstallStates(prev => ({ ...prev, [item.id]: "error" }));
-            onNotice?.(`安装失败：${err instanceof Error ? err.message : String(err)}`);
+            onNotice?.(`下载失败：${err instanceof Error ? err.message : String(err)}`);
+        } finally {
+            setBusyFile(null);
         }
     }, [onNotice, source]);
 
-    const handleSourceSave = useCallback(() => {
-        const next: ResourceHubSource = {
-            owner: sourceDraft.owner.trim(),
-            repo: sourceDraft.repo.trim(),
-            branch: sourceDraft.branch.trim() || "main",
-        };
-        if (!next.owner || !next.repo) {
-            onNotice?.("仓库 owner 和名称不能为空");
+    const runImport = useCallback(async (path: string, destination: ImportDestination, contactId?: string) => {
+        setImportFile(null);
+        setPickCharacterFor(null);
+        setBusyFile(path);
+        try {
+            const message = await importResourceHubFile(source, path, destination, { contactId });
+            onNotice?.(message);
+        } catch (err) {
+            onNotice?.(`导入失败：${err instanceof Error ? err.message : String(err)}`);
+        } finally {
+            setBusyFile(null);
+        }
+    }, [onNotice, source]);
+
+    const handlePickDestination = useCallback((destination: ImportDestination) => {
+        if (!importFile) return;
+        const typeError = checkImportFileForDestination(destination, importFile);
+        if (typeError) {
+            onNotice?.(typeError);
             return;
         }
-        saveResourceHubSource(next);
-        setSource(next);
-        setShowSourceEditor(false);
-    }, [onNotice, sourceDraft]);
+        if (destination === "chat_session_css") {
+            setPickCharacterFor(importFile);
+            setImportFile(null);
+            return;
+        }
+        void runImport(importFile, destination);
+    }, [importFile, onNotice, runImport]);
 
-    const renderItemCard = (item: ResourceHubItem) => {
-        const state = installStates[item.id];
-        const installedRecord = installedMap[item.id];
-        const isInstalled = state === "done" || (!!installedRecord && installedRecord.version === item.version);
-        const busy = state === "installing";
-        return (
-            <div key={item.id} className="ui-group-card">
-                <div className="flex items-start gap-3">
-                    {item.cover && (
-                        <div className="w-12 h-12 shrink-0 rounded-xl overflow-hidden bg-black/5 dark:bg-white/10">
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img src={resolveResourceHubAssetUrl(source, item.cover)} alt="" className="w-full h-full object-cover" loading="lazy" />
-                        </div>
-                    )}
-                    <div className="flex-1 min-w-0 flex flex-col gap-0.5">
-                        <div className="flex items-center gap-2 min-w-0">
-                            <span className="menu-label truncate">{item.name}</span>
-                            <span className="ts-11 shrink-0 px-1.5 py-0.5 rounded-md bg-black/5 dark:bg-white/10 text-[var(--c-icon)]">
-                                {RESOURCE_HUB_KIND_LABELS[item.kind]}
-                            </span>
-                        </div>
-                        <span className="menu-desc !mt-0">
-                            {[item.author && `by ${item.author}`, item.version && `v${item.version}`].filter(Boolean).join(" · ")}
-                        </span>
-                        {item.description && <span className="menu-desc !mt-0 line-clamp-2">{item.description}</span>}
-                    </div>
-                    <button
-                        className={`ui-btn ${isInstalled ? "ui-btn-ghost" : "ui-btn-primary"} shrink-0 !px-3`}
-                        disabled={busy || isInstalled}
-                        onClick={() => handleInstall(item)}
-                    >
-                        {busy ? "安装中..." : isInstalled ? "已安装" : (
-                            <span className="flex items-center gap-1"><Download size={13} />安装</span>
-                        )}
-                    </button>
-                </div>
-            </div>
-        );
-    };
+    const title = activeEntry ? activeEntry.name : activeFolder ? activeFolder : "资源集市";
+    const handleBack = activeEntry
+        ? () => setActiveEntry(null)
+        : activeFolder
+            ? () => setActiveFolder(null)
+            : onClose;
 
     return (
-        <PageShell
-            title="资源集市"
-            onBack={onClose}
-            rightAction={
-                <div className="flex items-center gap-1">
-                    <button className="ui-bare-btn" aria-label="刷新" onClick={() => reload(source)}>
-                        <RefreshCw size={18} strokeWidth={1.75} className={loadState === "loading" ? "is-spinning" : undefined} />
-                    </button>
-                    <button className="ui-bare-btn" aria-label="资源仓库设置" onClick={() => { setSourceDraft(source); setShowSourceEditor(true); }}>
-                        <Settings2 size={18} strokeWidth={1.75} />
-                    </button>
-                </div>
-            }
-        >
-            <div className="flex flex-col gap-3 p-4">
-                <div className="relative">
-                    <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--c-icon)] pointer-events-none" />
-                    <input
-                        className="ui-input w-full !pl-9"
-                        value={query}
-                        onChange={e => setQuery(e.target.value)}
-                        placeholder="搜索资源、作者、标签..."
-                    />
+        <div className="rh-root page-shell">
+            {/* 窗口标题栏 */}
+            <div className="rh-window">
+                <div className="rh-titlebar">
+                    <span className="rh-titlebar-icon">🗂️</span>
+                    <span className="rh-titlebar-text">{title} - 资源集市</span>
+                    <span className="rh-titlebar-controls">
+                        <button className="rh-tb-btn" aria-label="资源仓库设置" onClick={() => { setSourceDraft(source); setShowSourceEditor(true); }}>⚙</button>
+                        <button className="rh-tb-btn" aria-label="刷新" onClick={() => reload(source)}>⟳</button>
+                        <button className="rh-tb-btn" aria-label="关闭" onClick={onClose}>✕</button>
+                    </span>
                 </div>
 
-                <div className="flex items-center gap-2 overflow-x-auto pb-0.5 -mx-1 px-1">
-                    {KIND_FILTERS.map(({ key, label }) => (
-                        <button
-                            key={key}
-                            className="ui-chip shrink-0"
-                            data-active={filter === key ? "1" : undefined}
-                            style={filter === key ? { background: "var(--c-icon-active, var(--c-text))", color: "var(--c-card, #fff)" } : undefined}
-                            onClick={() => setFilter(key)}
-                        >
-                            {label}
-                        </button>
-                    ))}
+                {/* 工具条（返回/地址） */}
+                <div className="rh-toolbar">
+                    <button className="rh-btn" onClick={handleBack}>← 返回</button>
+                    <span className="rh-address">
+                        地址：C:\资源集市{activeFolder ? `\\${activeFolder}` : ""}{activeEntry ? `\\${activeEntry.name}` : ""}
+                    </span>
                 </div>
 
-                {index?.notice && loadState === "ready" && (
-                    <div className="ui-group-card py-2">
-                        <span className="menu-desc !mt-0 whitespace-pre-wrap">{index.notice}</span>
-                    </div>
-                )}
+                {/* 内容区 */}
+                <div className="rh-body">
+                    {loadState === "loading" && <div className="rh-center-hint">正在读取目录，请稍候...</div>}
 
-                {loadState === "loading" && (
-                    <div className="ui-empty-compact mt-6"><span className="menu-desc">目录加载中...</span></div>
-                )}
-
-                {loadState === "error" && (
-                    <div className="ui-empty-compact mt-6 flex flex-col items-center gap-2">
-                        <Store size={28} className="text-[var(--c-icon)] opacity-60" />
-                        <span className="menu-desc text-center">
+                    {loadState === "error" && (
+                        <div className="rh-center-hint">
+                            <div className="ts-24 mb-2">🚧</div>
                             资源仓库暂时无法访问（{loadError}）。
-                            <br />可能是仓库尚未就绪或网络问题，可点右上角刷新重试。
-                        </span>
-                    </div>
-                )}
+                            <br />可能是网络问题或仓库尚未就绪，可点右上角 ⟳ 重试。
+                        </div>
+                    )}
 
-                {loadState === "ready" && visibleItems.length === 0 && (
-                    <div className="ui-empty-compact mt-6">
-                        <span className="menu-desc">{query.trim() ? "没有匹配的资源" : "该分类暂时没有资源"}</span>
-                    </div>
-                )}
+                    {/* 首页：文件夹（一行两个） */}
+                    {loadState === "ready" && !activeFolder && (
+                        index && index.folders.length > 0 ? (
+                            <div className="rh-folder-grid">
+                                {index.folders.map(folder => (
+                                    <button key={folder.name} className="rh-folder" onDoubleClick={() => setActiveFolder(folder.name)} onClick={() => setActiveFolder(folder.name)}>
+                                        <span className="rh-folder-icon">📁</span>
+                                        <span className="rh-folder-name">{folder.name}</span>
+                                        <span className="rh-folder-count">{folder.count} 个对象</span>
+                                    </button>
+                                ))}
+                            </div>
+                        ) : (
+                            <div className="rh-center-hint">仓库里还没有资源文件夹</div>
+                        )
+                    )}
 
-                {loadState === "ready" && visibleItems.map(renderItemCard)}
+                    {/* 文件夹页：论坛式列表 */}
+                    {loadState === "ready" && activeFolder && !activeEntry && (
+                        folderEntries.length > 0 ? (
+                            <div className="rh-entry-list">
+                                {folderEntries.map(entry => (
+                                    <button key={entry.path} className="rh-entry" onClick={() => setActiveEntry(entry)}>
+                                        {entry.images.length > 0 ? (
+                                            // eslint-disable-next-line @next/next/no-img-element
+                                            <img className="rh-entry-thumb" src={resolveResourceHubAssetUrl(source, entry.images[0])} alt="" loading="lazy" />
+                                        ) : (
+                                            <span className="rh-entry-thumb rh-entry-thumb-blank">📄</span>
+                                        )}
+                                        <span className="rh-entry-main">
+                                            <span className="rh-entry-title">{entry.name}</span>
+                                            {entry.description && <span className="rh-entry-desc">{entry.description}</span>}
+                                            <span className="rh-entry-meta">
+                                                {[formatEntryDate(entry.updatedAt), `${entry.files.length} 个文件`].filter(Boolean).join(" · ")}
+                                            </span>
+                                        </span>
+                                    </button>
+                                ))}
+                            </div>
+                        ) : (
+                            <div className="rh-center-hint">这个文件夹还是空的</div>
+                        )
+                    )}
+
+                    {/* 资源详情页 */}
+                    {loadState === "ready" && activeEntry && (
+                        <div className="rh-detail">
+                            {activeEntry.images.length > 0 && (
+                                <div className="rh-detail-images">
+                                    {activeEntry.images.map(img => (
+                                        // eslint-disable-next-line @next/next/no-img-element
+                                        <img key={img} src={resolveResourceHubAssetUrl(source, img)} alt="" loading="lazy" />
+                                    ))}
+                                </div>
+                            )}
+                            {activeEntry.description && <div className="rh-detail-desc">{activeEntry.description}</div>}
+                            <div className="rh-detail-files-title">文件列表</div>
+                            {activeEntry.files.length > 0 ? activeEntry.files.map(file => (
+                                <div key={file} className="rh-file-row">
+                                    <span className="rh-file-name">📎 {file.split("/").pop()}</span>
+                                    <span className="rh-file-actions">
+                                        <button className="rh-btn" disabled={busyFile === file} onClick={() => handleDownload(file)}>下载</button>
+                                        <button className="rh-btn rh-btn-primary" disabled={busyFile === file} onClick={() => setImportFile(file)}>
+                                            {busyFile === file ? "处理中..." : "导入"}
+                                        </button>
+                                    </span>
+                                </div>
+                            )) : (
+                                <div className="rh-center-hint">该资源没有可下载的文件</div>
+                            )}
+                        </div>
+                    )}
+                </div>
+
+                {/* 状态栏 */}
+                <div className="rh-statusbar">
+                    <span>
+                        {loadState === "ready"
+                            ? activeFolder
+                                ? `${folderEntries.length} 个对象`
+                                : `${index?.folders.length ?? 0} 个文件夹`
+                            : "..."}
+                    </span>
+                    <span>资源仓库：{source.owner}/{source.repo}</span>
+                </div>
             </div>
 
+            {/* 施工提示（正式开张后移除） */}
             {showConstructionNotice && (
-                <ConfirmDialog
-                    title="施工中"
-                    message="此app正在施工，请先去别的地方逛逛吧～"
-                    icon={Store}
-                    variant="action"
-                    cancelLabel="仍要看看"
-                    confirmLabel="返回桌面"
-                    onCancel={() => setShowConstructionNotice(false)}
-                    onConfirm={onClose}
-                />
+                <div className="rh-dialog-overlay">
+                    <div className="rh-dialog">
+                        <div className="rh-titlebar"><span className="rh-titlebar-text">系统提示</span></div>
+                        <div className="rh-dialog-body">
+                            <span className="rh-dialog-icon">🚧</span>
+                            此app正在施工，请先去别的地方逛逛吧～
+                        </div>
+                        <div className="rh-dialog-footer">
+                            <button className="rh-btn" onClick={() => setShowConstructionNotice(false)}>仍要看看</button>
+                            <button className="rh-btn rh-btn-primary" onClick={onClose}>返回桌面</button>
+                        </div>
+                    </div>
+                </div>
             )}
 
-            {showSourceEditor && (
-                <ContentDialog
-                    title="资源仓库"
-                    confirmLabel="保存"
-                    onConfirm={handleSourceSave}
-                    onCancel={() => setShowSourceEditor(false)}
-                >
-                    <div className="flex flex-col gap-3 text-left w-full">
-                        <div className="flex flex-col gap-1">
-                            <label className="menu-desc ml-1">GitHub 用户/组织</label>
-                            <Input value={sourceDraft.owner} onChange={e => setSourceDraft(prev => ({ ...prev, owner: e.target.value }))} />
+            {/* 导入目的地选择 */}
+            {importFile && (
+                <div className="rh-dialog-overlay" onClick={() => setImportFile(null)}>
+                    <div className="rh-dialog" onClick={e => e.stopPropagation()}>
+                        <div className="rh-titlebar">
+                            <span className="rh-titlebar-text">导入到...</span>
+                            <span className="rh-titlebar-controls">
+                                <button className="rh-tb-btn" onClick={() => setImportFile(null)}>✕</button>
+                            </span>
                         </div>
-                        <div className="flex flex-col gap-1">
-                            <label className="menu-desc ml-1">仓库名</label>
-                            <Input value={sourceDraft.repo} onChange={e => setSourceDraft(prev => ({ ...prev, repo: e.target.value }))} />
+                        <div className="rh-dialog-body rh-dest-list">
+                            {IMPORT_DESTINATIONS.map(dest => (
+                                <button key={dest.key} className="rh-dest" onClick={() => handlePickDestination(dest.key)}>
+                                    <span className="rh-dest-label">{dest.label}</span>
+                                    <span className="rh-dest-hint">{dest.hint}</span>
+                                </button>
+                            ))}
                         </div>
-                        <div className="flex flex-col gap-1">
-                            <label className="menu-desc ml-1">分支</label>
-                            <Input value={sourceDraft.branch} placeholder="main" onChange={e => setSourceDraft(prev => ({ ...prev, branch: e.target.value }))} />
-                        </div>
-                        <span className="menu-desc ml-1">资源经 jsDelivr CDN 拉取，公开仓库无需登录。除非要换资源源，一般不用改。</span>
                     </div>
-                </ContentDialog>
+                </div>
             )}
-        </PageShell>
+
+            {/* 聊天室 CSS：选择角色 */}
+            {pickCharacterFor && (
+                <div className="rh-dialog-overlay" onClick={() => setPickCharacterFor(null)}>
+                    <div className="rh-dialog" onClick={e => e.stopPropagation()}>
+                        <div className="rh-titlebar">
+                            <span className="rh-titlebar-text">应用到哪个角色的聊天室？</span>
+                            <span className="rh-titlebar-controls">
+                                <button className="rh-tb-btn" onClick={() => setPickCharacterFor(null)}>✕</button>
+                            </span>
+                        </div>
+                        <div className="rh-dialog-body rh-dest-list">
+                            {chatContacts.length > 0 ? chatContacts.map(contact => (
+                                <button key={contact.contactId} className="rh-dest" onClick={() => void runImport(pickCharacterFor, "chat_session_css", contact.contactId)}>
+                                    <span className="rh-dest-label">{contact.name}</span>
+                                </button>
+                            )) : (
+                                <div className="rh-center-hint">还没有聊天联系人，先去聊天里添加角色吧</div>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* 资源仓库设置 */}
+            {showSourceEditor && (
+                <div className="rh-dialog-overlay" onClick={() => setShowSourceEditor(false)}>
+                    <div className="rh-dialog" onClick={e => e.stopPropagation()}>
+                        <div className="rh-titlebar"><span className="rh-titlebar-text">资源仓库</span></div>
+                        <div className="rh-dialog-body rh-form">
+                            <label>GitHub 用户/组织
+                                <input className="rh-input" value={sourceDraft.owner} onChange={e => setSourceDraft(prev => ({ ...prev, owner: e.target.value }))} />
+                            </label>
+                            <label>仓库名
+                                <input className="rh-input" value={sourceDraft.repo} onChange={e => setSourceDraft(prev => ({ ...prev, repo: e.target.value }))} />
+                            </label>
+                            <label>分支
+                                <input className="rh-input" value={sourceDraft.branch} placeholder="main" onChange={e => setSourceDraft(prev => ({ ...prev, branch: e.target.value }))} />
+                            </label>
+                            <div className="rh-form-hint">资源经 jsDelivr CDN 读取，公开仓库无需登录。除非换资源源，一般不用改。</div>
+                        </div>
+                        <div className="rh-dialog-footer">
+                            <button className="rh-btn" onClick={() => setShowSourceEditor(false)}>取消</button>
+                            <button className="rh-btn rh-btn-primary" onClick={() => {
+                                const next: ResourceHubSource = {
+                                    owner: sourceDraft.owner.trim(),
+                                    repo: sourceDraft.repo.trim(),
+                                    branch: sourceDraft.branch.trim() || "main",
+                                };
+                                if (!next.owner || !next.repo) { onNotice?.("仓库 owner 和名称不能为空"); return; }
+                                saveResourceHubSource(next);
+                                setSource(next);
+                                setActiveFolder(null);
+                                setActiveEntry(null);
+                                setShowSourceEditor(false);
+                            }}>保存</button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            <style>{`
+                .rh-root {
+                    position: absolute;
+                    inset: 0;
+                    background: #008080;
+                    padding: calc(var(--status-bar-top, 12px) + 34px) 10px 16px;
+                    display: flex;
+                    flex-direction: column;
+                    overflow: hidden;
+                }
+                .rh-root, .rh-root button, .rh-root input {
+                    font-family: "Microsoft YaHei", "PingFang SC", Tahoma, "MS Sans Serif", sans-serif;
+                }
+                .rh-window {
+                    flex: 1;
+                    min-height: 0;
+                    display: flex;
+                    flex-direction: column;
+                    background: #c0c0c0;
+                    border: 2px solid;
+                    border-color: #ffffff #404040 #404040 #ffffff;
+                    box-shadow: 1px 1px 0 #000;
+                }
+                .rh-titlebar {
+                    display: flex;
+                    align-items: center;
+                    gap: 6px;
+                    padding: 3px 4px 3px 6px;
+                    background: linear-gradient(90deg, #000080, #1084d0);
+                    color: #fff;
+                    font-size: calc(13px * var(--app-text-scale, 1));
+                    font-weight: 700;
+                    user-select: none;
+                    flex-shrink: 0;
+                }
+                .rh-titlebar-text {
+                    flex: 1;
+                    min-width: 0;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
+                .rh-titlebar-controls { display: flex; gap: 3px; }
+                .rh-tb-btn {
+                    width: 22px;
+                    height: 20px;
+                    display: inline-flex;
+                    align-items: center;
+                    justify-content: center;
+                    background: #c0c0c0;
+                    color: #000;
+                    font-size: 12px;
+                    border: 2px solid;
+                    border-color: #ffffff #404040 #404040 #ffffff;
+                    cursor: pointer;
+                    padding: 0;
+                }
+                .rh-tb-btn:active { border-color: #404040 #ffffff #ffffff #404040; }
+                .rh-toolbar {
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+                    padding: 5px 6px;
+                    border-bottom: 1px solid #808080;
+                    box-shadow: 0 1px 0 #fff;
+                    flex-shrink: 0;
+                }
+                .rh-address {
+                    flex: 1;
+                    min-width: 0;
+                    background: #fff;
+                    border: 2px solid;
+                    border-color: #404040 #ffffff #ffffff #404040;
+                    padding: 3px 6px;
+                    font-size: calc(11px * var(--app-text-scale, 1));
+                    color: #000;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
+                .rh-btn {
+                    background: #c0c0c0;
+                    color: #000;
+                    font-size: calc(12px * var(--app-text-scale, 1));
+                    padding: 4px 12px;
+                    border: 2px solid;
+                    border-color: #ffffff #404040 #404040 #ffffff;
+                    cursor: pointer;
+                    white-space: nowrap;
+                }
+                .rh-btn:active { border-color: #404040 #ffffff #ffffff #404040; }
+                .rh-btn:disabled { color: #808080; text-shadow: 1px 1px 0 #fff; cursor: default; }
+                .rh-btn-primary { font-weight: 700; outline: 1px solid #000; }
+                .rh-body {
+                    flex: 1;
+                    min-height: 0;
+                    overflow-y: auto;
+                    background: #fff;
+                    border: 2px solid;
+                    border-color: #404040 #ffffff #ffffff #404040;
+                    margin: 6px;
+                    color: #000;
+                }
+                .rh-center-hint {
+                    padding: 42px 20px;
+                    text-align: center;
+                    color: #404040;
+                    font-size: calc(12px * var(--app-text-scale, 1));
+                    line-height: 1.8;
+                }
+                /* 首页文件夹网格：一行两个 */
+                .rh-folder-grid {
+                    display: grid;
+                    grid-template-columns: 1fr 1fr;
+                    gap: 4px;
+                    padding: 10px;
+                }
+                .rh-folder {
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                    gap: 2px;
+                    padding: 14px 6px 10px;
+                    background: none;
+                    border: 1px dotted transparent;
+                    cursor: pointer;
+                }
+                .rh-folder:active { border-color: #000080; background: #e4ecf7; }
+                .rh-folder-icon { font-size: 40px; line-height: 1; }
+                .rh-folder-name {
+                    font-size: calc(13px * var(--app-text-scale, 1));
+                    color: #000;
+                    word-break: break-all;
+                }
+                .rh-folder-count { font-size: calc(10px * var(--app-text-scale, 1)); color: #808080; }
+                /* 论坛式条目列表 */
+                .rh-entry-list { display: flex; flex-direction: column; }
+                .rh-entry {
+                    display: flex;
+                    align-items: flex-start;
+                    gap: 10px;
+                    padding: 10px;
+                    background: none;
+                    border: none;
+                    border-bottom: 1px solid #d4d0c8;
+                    cursor: pointer;
+                    text-align: left;
+                }
+                .rh-entry:active { background: #e4ecf7; }
+                .rh-entry-thumb {
+                    width: 52px;
+                    height: 52px;
+                    flex-shrink: 0;
+                    object-fit: cover;
+                    border: 1px solid #808080;
+                    background: #f4f4f4;
+                }
+                .rh-entry-thumb-blank {
+                    display: inline-flex;
+                    align-items: center;
+                    justify-content: center;
+                    font-size: 24px;
+                }
+                .rh-entry-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+                .rh-entry-title {
+                    font-size: calc(13px * var(--app-text-scale, 1));
+                    color: #000080;
+                    font-weight: 700;
+                    text-decoration: underline;
+                    word-break: break-all;
+                }
+                .rh-entry-desc {
+                    font-size: calc(11px * var(--app-text-scale, 1));
+                    color: #404040;
+                    line-height: 1.5;
+                    display: -webkit-box;
+                    -webkit-line-clamp: 2;
+                    -webkit-box-orient: vertical;
+                    overflow: hidden;
+                    white-space: pre-line;
+                }
+                .rh-entry-meta { font-size: calc(10px * var(--app-text-scale, 1)); color: #808080; }
+                /* 详情 */
+                .rh-detail { padding: 10px; display: flex; flex-direction: column; gap: 10px; }
+                .rh-detail-images { display: flex; flex-direction: column; gap: 8px; }
+                .rh-detail-images img { max-width: 100%; border: 1px solid #808080; }
+                .rh-detail-desc {
+                    font-size: calc(12px * var(--app-text-scale, 1));
+                    line-height: 1.8;
+                    white-space: pre-wrap;
+                    color: #000;
+                    background: #ffffe1;
+                    border: 1px solid #808080;
+                    padding: 8px 10px;
+                }
+                .rh-detail-files-title {
+                    font-size: calc(12px * var(--app-text-scale, 1));
+                    font-weight: 700;
+                    border-bottom: 1px solid #808080;
+                    padding-bottom: 3px;
+                }
+                .rh-file-row {
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+                    justify-content: space-between;
+                    padding: 4px 0;
+                }
+                .rh-file-name {
+                    flex: 1;
+                    min-width: 0;
+                    font-size: calc(12px * var(--app-text-scale, 1));
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
+                .rh-file-actions { display: flex; gap: 6px; flex-shrink: 0; }
+                .rh-statusbar {
+                    display: flex;
+                    justify-content: space-between;
+                    gap: 8px;
+                    padding: 3px 8px;
+                    font-size: calc(10px * var(--app-text-scale, 1));
+                    color: #000;
+                    border-top: 1px solid #fff;
+                    box-shadow: 0 -1px 0 #808080;
+                    flex-shrink: 0;
+                }
+                .rh-statusbar span {
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
+                /* 对话框 */
+                .rh-dialog-overlay {
+                    position: absolute;
+                    inset: 0;
+                    background: rgba(0, 0, 0, 0.3);
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    z-index: 60;
+                    padding: 20px;
+                }
+                .rh-dialog {
+                    width: min(340px, 92%);
+                    max-height: 76vh;
+                    display: flex;
+                    flex-direction: column;
+                    background: #c0c0c0;
+                    border: 2px solid;
+                    border-color: #ffffff #404040 #404040 #ffffff;
+                    box-shadow: 2px 2px 0 #000;
+                }
+                .rh-dialog-body {
+                    padding: 14px 12px;
+                    font-size: calc(13px * var(--app-text-scale, 1));
+                    color: #000;
+                    overflow-y: auto;
+                    display: flex;
+                    align-items: center;
+                    gap: 10px;
+                }
+                .rh-dialog-icon { font-size: 30px; }
+                .rh-dialog-footer {
+                    display: flex;
+                    justify-content: center;
+                    gap: 10px;
+                    padding: 0 12px 12px;
+                }
+                .rh-dest-list { flex-direction: column; align-items: stretch; gap: 3px; }
+                .rh-dest {
+                    display: flex;
+                    flex-direction: column;
+                    align-items: flex-start;
+                    gap: 1px;
+                    padding: 7px 10px;
+                    background: #fff;
+                    border: 1px solid #808080;
+                    cursor: pointer;
+                    text-align: left;
+                }
+                .rh-dest:active { background: #000080; }
+                .rh-dest:active .rh-dest-label, .rh-dest:active .rh-dest-hint { color: #fff; }
+                .rh-dest-label { font-size: calc(13px * var(--app-text-scale, 1)); color: #000; font-weight: 700; }
+                .rh-dest-hint { font-size: calc(10px * var(--app-text-scale, 1)); color: #808080; }
+                .rh-form { flex-direction: column; align-items: stretch; gap: 8px; }
+                .rh-form label {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 3px;
+                    font-size: calc(11px * var(--app-text-scale, 1));
+                    color: #000;
+                }
+                .rh-input {
+                    background: #fff;
+                    border: 2px solid;
+                    border-color: #404040 #ffffff #ffffff #404040;
+                    padding: 4px 6px;
+                    font-size: calc(13px * var(--app-text-scale, 1));
+                    color: #000;
+                    outline: none;
+                }
+                .rh-form-hint { font-size: calc(10px * var(--app-text-scale, 1)); color: #606060; line-height: 1.6; }
+            `}</style>
+        </div>
     );
 }

--- a/docs/resource-hub.md
+++ b/docs/resource-hub.md
@@ -1,139 +1,60 @@
 # 资源集市（Resource Hub）
 
-小手机内置的社区资源市场。**后端是一个公开 GitHub 仓库**，浏览走 jsDelivr CDN（国内可达、无限流、免费），安装直接写进本机存储 —— 全程不经过自建服务器。
+小手机内置的社区资源市场。**后端是公开 GitHub 仓库 `xiaolongbao0709/ai-virtual-phone-share`**，浏览走 jsDelivr CDN（国内可达、免限流、免费），导入直接写进本机存储 —— 全程不经过自建服务器。
 
-- 前端：桌面「资源集市」App（`components/resource-hub/resource-hub-app.tsx`）
-- 客户端：`lib/resource-hub-client.ts`（CDN 多镜像回退 + 各类型安装）
-- 默认资源仓库：`xiaolongbao0709/share@main`（App 设置里可改）
+- 前端：桌面「资源集市」App（`components/resource-hub/resource-hub-app.tsx`），复古 Windows 风格
+- 客户端：`lib/resource-hub-client.ts`（CDN 三镜像回退 + 索引 + 各目的地导入）
+- 资源仓库地址可在 App 标题栏 ⚙ 里更换
 
-## 资源仓库结构
+## 仓库结构：完全自由
+
+**前端不预设任何文件夹** —— 仓库根目录建什么文件夹，市场首页（仿文件管理器，一行两个）就显示什么。分类下每个**子文件夹**或**孤立文件**是一条资源：
 
 ```
-share/                           （公开仓库）
-├── index.json                   ← 总目录（市场页启动时拉这一个文件）
-├── characters/  唐簪雪.json      ← 角色卡（ai_phone_character 导出格式）
-├── presets/     日常向.json      ← 预设（预设管理页导出的 JSON）
-├── worldbooks/  古风世界.json    ← 世界书（世界书管理页导出的 JSON）
-├── regexes/     去括号.json      ← 正则组（正则管理页导出的 JSON）
-├── css/         奶油白.css       ← CSS 方案（纯 CSS 文本）
-├── covers/      xxx.webp        ← 封面图（可选，建议 ≤100KB）
-└── .github/workflows/build-index.yml
+ai-virtual-phone-share/
+├── _index.json            ← 时间索引，Actions 自动生成，勿手改
+├── 预设/
+│   ├── 日常向预设/         ← 子文件夹式资源
+│   │   ├── 日常向.json      ← 本体（可多个）
+│   │   ├── 说明.txt         ← 可选：说明（论坛列表显示摘要）
+│   │   └── 封面.jpg         ← 可选：图片（列表显示第一张）
+│   └── 极简预设.json       ← 孤立文件式资源（纯文字条目）
+└── 随便新建的分类/          ← 前端自动出现
 ```
 
-## index.json 格式
+文件夹页为古早论坛式列表，按 `_index.json` 里的更新时间倒序（索引由 Actions 用 `git log` 生成；索引不可用时前端退化为 jsDelivr data API 现场扫树，无时间与说明）。
 
-```json
-{
-  "schema": "ai_phone_resource_hub",
-  "schemaVersion": 1,
-  "updatedAt": "2026-08-10T00:00:00Z",
-  "notice": "可选的公告，显示在市场列表顶部",
-  "items": [
-    {
-      "id": "characters/唐簪雪",
-      "kind": "character",
-      "name": "唐簪雪",
-      "path": "characters/唐簪雪.json",
-      "author": "小笼包",
-      "description": "一句话简介",
-      "version": "1.0",
-      "tags": ["古风"],
-      "cover": "covers/tzx.webp"
-    },
-    {
-      "id": "css/奶油白",
-      "kind": "css",
-      "name": "奶油白",
-      "path": "css/奶油白.css",
-      "cssTarget": "global"
-    }
-  ]
-}
-```
+## 下载与导入
 
-字段说明：
-- `kind`：`character` / `preset` / `worldbook` / `regex` / `css`
-- `path`：资源文件在仓库内的相对路径
-- `cover`：仓库相对路径或完整 URL，可省略
-- `cssTarget`（仅 css）：`global` / `chat_app` / `chat_session` / `story` / `music` / `calendar`，缺省 `global`
-- `version`：变更后市场端"已安装"标记会失效，用户可重新安装升级
+资源详情页每个文件有两个动作：
 
-## 自动生成 index.json（GitHub Actions）
+- **下载**：原文件下载到本机
+- **导入**：弹出目的地选择，直接落库：
 
-merge 后自动扫描目录重建索引，投稿 PR 里不需要手改 index.json。
-`.github/workflows/build-index.yml`：
+| 目的地 | 接受文件 | 落点 |
+|---|---|---|
+| 预设 / 正则 / 世界书 | JSON | 对应管理页列表 |
+| 角色卡 | JSON / PNG | 角色库 |
+| 聊天室自定义CSS | CSS/TXT | **需选角色** → 直接应用到该角色聊天室，并存入方案库 |
+| 聊天主页自定义CSS | CSS/TXT | 直接应用 + 存方案库 |
+| 全局自定义CSS | CSS/TXT | 应用到外观页全局样式 + 存方案库 |
+| 应用 | zip / 单 HTML | 应用市场同款安装（桌面自动出图标） |
+| 游戏 | 草稿 JSON（`ai-phone-game-draft`） | 游戏草稿箱 |
+| 黑市剧场 | 草稿 JSON（`ai-phone-theater-draft`） | 黑市工作室草稿箱 |
+| 插件 | JS 源码 | 聊天插件（同 id 覆盖升级） |
 
-```yaml
-name: Build index
-on:
-  push:
-    branches: [main]
-    paths: ["characters/**", "presets/**", "worldbooks/**", "regexes/**", "css/**"]
-  workflow_dispatch:
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions: { contents: write }
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build index.json
-        run: node scripts/build-index.mjs
-      - name: Commit
-        run: |
-          git config user.name "resource-hub-bot"
-          git config user.email "bot@users.noreply.github.com"
-          git add index.json
-          git diff --cached --quiet || git commit -m "chore: rebuild index.json"
-          git push
-```
+## 资源仓库侧（ai-virtual-phone-share 内自带）
 
-`scripts/build-index.mjs`（放在资源仓库里）：
-
-```js
-import { readdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
-
-const KINDS = [
-  ["characters", "character", ".json"],
-  ["presets", "preset", ".json"],
-  ["worldbooks", "worldbook", ".json"],
-  ["regexes", "regex", ".json"],
-  ["css", "css", ".css"],
-];
-
-const items = [];
-for (const [dir, kind, ext] of KINDS) {
-  if (!existsSync(dir)) continue;
-  for (const file of readdirSync(dir).filter(f => f.endsWith(ext)).sort()) {
-    const path = `${dir}/${file}`;
-    const name = file.slice(0, -ext.length);
-    // 同名 .meta.json 里可补充 author/description/version/tags/cover/cssTarget
-    const metaPath = `${dir}/${name}.meta.json`;
-    let meta = {};
-    if (existsSync(metaPath)) {
-      try { meta = JSON.parse(readFileSync(metaPath, "utf8")); } catch { /* 忽略坏 meta */ }
-    }
-    items.push({ id: `${dir}/${name}`, kind, name, path, ...meta });
-  }
-}
-
-writeFileSync("index.json", JSON.stringify({
-  schema: "ai_phone_resource_hub",
-  schemaVersion: 1,
-  updatedAt: new Date().toISOString(),
-  items,
-}, null, 2));
-console.log(`index.json: ${items.length} items`);
-```
+- `README.md`：投稿约定
+- `scripts/build-index.mjs` + `.github/workflows/build-index.yml`：push 后自动重建 `_index.json`（fetch-depth 0 取真实更新时间；bot 提交自动跳过防死循环）
 
 ## 运营流程
 
-- **投稿**：PR 往对应目录加文件（资源文件 + 可选的同名 `.meta.json`）
-- **上架**：merge PR（Actions 自动重建索引）
-- **下架**：删文件 merge；**回滚**：revert commit
-- **CDN 缓存**：jsDelivr 对 `@main` 的缓存最长约 12 小时；急刷可访问
-  `https://purge.jsdelivr.net/gh/<owner>/<repo>@main/index.json`
+- **投稿**：PR 往分类文件夹加子文件夹（本体 + 可选 说明.txt + 可选图片）
+- **上架**：merge PR（Actions 自动重建索引）；**下架**：删文件 merge；**回滚**：revert
+- **CDN 缓存**：jsDelivr 对 `@main` 最长缓存约 12 小时；急刷访问
+  `https://purge.jsdelivr.net/gh/xiaolongbao0709/ai-virtual-phone-share@main/_index.json`
 
 ## 体积约束
 
-- jsDelivr 单文件上限 20MB；封面图建议压到 100KB 内
-- 表情包 / 主题包等图片重的资源类型属于二期，方案是包内只存图床 URL
+jsDelivr 单文件上限 20MB；图片建议单张 ≤ 300KB。

--- a/lib/resource-hub-client.ts
+++ b/lib/resource-hub-client.ts
@@ -1,27 +1,30 @@
 // lib/resource-hub-client.ts
-// 资源集市客户端：CDN 多镜像拉取 + 各资源类型的本地安装。
+// 资源集市客户端：CDN 多镜像拉取 + 目录索引 + 各目的地的导入落库。
 // 浏览走 jsDelivr（国内可达、免限流），失败逐级回退，全程不经过自家服务端。
 
 import { kvGet, kvSet, registerKvMigration } from "./kv-db";
 import {
-    isResourceHubKind,
     RESOURCE_HUB_DEFAULT_SOURCE,
-    type ResourceHubIndex,
-    type ResourceHubItem,
+    type ImportDestination,
     type ResourceHubSource,
+    type ShareIndex,
+    type ShareIndexEntry,
+    type ShareIndexFolder,
 } from "./resource-hub-types";
-import { createCharacter, loadCharacters, parseCharacterFromJson, saveCharacters } from "./character-storage";
+import { createCharacter, loadCharacters, parseCharacterFromJson, parseCharacterFromPng, saveCharacters } from "./character-storage";
 import {
     loadPresets, savePresets, parsePresetFromJson,
     loadWorldBooks, saveWorldBooks, parseWorldBookFromJson,
     loadRegexes, saveRegexes, parseRegexFromJson,
 } from "./settings-storage";
 import { saveScheme } from "./css-scheme-storage";
+import { createOrGetSession, loadChatSessions, saveChatSessions } from "./chat-storage";
+import { readThemeProfile, writeThemeProfile } from "./theme-storage";
+import { loadGameDrafts, saveGameDrafts } from "./game-storage";
+import type { GameTemplateDraft } from "./game-types";
 
 const SOURCE_KEY = "ai_phone_resource_hub_source_v1";
-const INSTALLED_KEY = "ai_phone_resource_hub_installed_v1";
 registerKvMigration(SOURCE_KEY);
-registerKvMigration(INSTALLED_KEY);
 
 const FETCH_TIMEOUT_MS = 15000;
 
@@ -46,9 +49,13 @@ export function saveResourceHubSource(source: ResourceHubSource): void {
 
 // ── CDN 拉取（多镜像回退）──
 
+function encodePath(path: string): string {
+    return path.replace(/^\/+/, "").split("/").map(encodeURIComponent).join("/");
+}
+
 function buildMirrorUrls(source: ResourceHubSource, path: string): string[] {
     const { owner, repo, branch } = source;
-    const clean = path.replace(/^\/+/, "");
+    const clean = encodePath(path);
     return [
         `https://cdn.jsdelivr.net/gh/${owner}/${repo}@${branch}/${clean}`,
         `https://fastly.jsdelivr.net/gh/${owner}/${repo}@${branch}/${clean}`,
@@ -66,13 +73,12 @@ async function fetchWithTimeout(url: string): Promise<Response> {
     }
 }
 
-/** 逐镜像尝试拉取文本；全部失败抛最后一个错误。 */
-export async function fetchResourceHubText(source: ResourceHubSource, path: string): Promise<string> {
+async function fetchMirrored(source: ResourceHubSource, path: string): Promise<Response> {
     let lastError: Error = new Error("无可用镜像");
     for (const url of buildMirrorUrls(source, path)) {
         try {
             const res = await fetchWithTimeout(url);
-            if (res.ok) return await res.text();
+            if (res.ok) return res;
             lastError = new Error(`HTTP ${res.status}`);
         } catch (err) {
             lastError = err instanceof Error ? err : new Error(String(err));
@@ -81,115 +87,301 @@ export async function fetchResourceHubText(source: ResourceHubSource, path: stri
     throw lastError;
 }
 
-/** 封面等资源的展示 URL（相对路径转 CDN 主镜像，完整 URL 原样返回）。 */
+/** 逐镜像尝试拉取文本；全部失败抛最后一个错误。 */
+export async function fetchResourceHubText(source: ResourceHubSource, path: string): Promise<string> {
+    return (await fetchMirrored(source, path)).text();
+}
+
+/** 二进制拉取（角色卡 PNG、应用 zip）。 */
+export async function fetchResourceHubBinary(source: ResourceHubSource, path: string): Promise<ArrayBuffer> {
+    return (await fetchMirrored(source, path)).arrayBuffer();
+}
+
+/** 图片等资源的展示 URL（仓库相对路径转 CDN 主镜像）。 */
 export function resolveResourceHubAssetUrl(source: ResourceHubSource, pathOrUrl: string): string {
     if (/^https?:\/\//i.test(pathOrUrl)) return pathOrUrl;
     return buildMirrorUrls(source, pathOrUrl)[0];
 }
 
-function normalizeIndex(raw: unknown): ResourceHubIndex {
+// ── 目录索引 ──
+
+function normalizeIndex(raw: unknown): ShareIndex {
     const record = (raw ?? {}) as Record<string, unknown>;
-    if (record.schema !== "ai_phone_resource_hub" || !Array.isArray(record.items)) {
-        throw new Error("目录格式不正确（缺少 schema 或 items）");
+    if (record.schema !== "ai_phone_share_index" || !Array.isArray(record.entries) || !Array.isArray(record.folders)) {
+        throw new Error("索引格式不正确");
     }
-    const items: ResourceHubItem[] = [];
-    for (const entry of record.items) {
-        const item = (entry ?? {}) as Record<string, unknown>;
-        if (typeof item.id !== "string" || typeof item.name !== "string" || typeof item.path !== "string") continue;
-        if (!isResourceHubKind(item.kind)) continue;
-        items.push({
-            id: item.id,
-            kind: item.kind,
+    const folders: ShareIndexFolder[] = [];
+    for (const f of record.folders) {
+        const item = (f ?? {}) as Record<string, unknown>;
+        if (typeof item.name !== "string") continue;
+        folders.push({ name: item.name, count: typeof item.count === "number" ? item.count : 0 });
+    }
+    const entries: ShareIndexEntry[] = [];
+    for (const e of record.entries) {
+        const item = (e ?? {}) as Record<string, unknown>;
+        if (typeof item.folder !== "string" || typeof item.name !== "string" || typeof item.path !== "string") continue;
+        entries.push({
+            folder: item.folder,
             name: item.name,
+            type: item.type === "dir" ? "dir" : "file",
             path: item.path,
-            author: typeof item.author === "string" ? item.author : undefined,
-            description: typeof item.description === "string" ? item.description : undefined,
-            version: typeof item.version === "string" ? item.version : undefined,
-            tags: Array.isArray(item.tags) ? item.tags.filter((t): t is string => typeof t === "string") : undefined,
-            cover: typeof item.cover === "string" ? item.cover : undefined,
-            updatedAt: typeof item.updatedAt === "string" ? item.updatedAt : undefined,
-            cssTarget: typeof item.cssTarget === "string" ? item.cssTarget : undefined,
+            files: Array.isArray(item.files) ? item.files.filter((v): v is string => typeof v === "string") : [],
+            images: Array.isArray(item.images) ? item.images.filter((v): v is string => typeof v === "string") : [],
+            description: typeof item.description === "string" ? item.description : "",
+            updatedAt: typeof item.updatedAt === "string" ? item.updatedAt : null,
         });
     }
     return {
-        schema: "ai_phone_resource_hub",
+        schema: "ai_phone_share_index",
         schemaVersion: typeof record.schemaVersion === "number" ? record.schemaVersion : 1,
-        updatedAt: typeof record.updatedAt === "string" ? record.updatedAt : undefined,
-        notice: typeof record.notice === "string" ? record.notice : undefined,
-        items,
+        generatedAt: typeof record.generatedAt === "string" ? record.generatedAt : undefined,
+        folders,
+        entries,
     };
 }
 
-export async function fetchResourceHubIndex(source: ResourceHubSource): Promise<ResourceHubIndex> {
-    const text = await fetchResourceHubText(source, "index.json");
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(text);
-    } catch {
-        throw new Error("目录不是合法的 JSON");
+const IMAGE_RE = /\.(jpe?g|png|webp|gif)$/i;
+const DESC_NAME_RE = /^(说明\.txt|readme\.(md|txt))$/i;
+
+/** 兜底：_index.json 不可用时，用 jsDelivr data API 的文件树现场构建索引（无时间与说明）。 */
+async function buildIndexFromTree(source: ResourceHubSource): Promise<ShareIndex> {
+    const { owner, repo, branch } = source;
+    const res = await fetchWithTimeout(`https://data.jsdelivr.com/v1/packages/gh/${owner}/${repo}@${branch}?structure=flat`);
+    if (!res.ok) throw new Error(`文件树获取失败（HTTP ${res.status}）`);
+    const data = await res.json() as { files?: Array<{ name?: string }> };
+    const paths = (data.files ?? [])
+        .map(f => (f.name || "").replace(/^\/+/, ""))
+        .filter(p => p && !p.startsWith(".") && !p.startsWith("_") && !p.startsWith("scripts/"));
+
+    const folderMap = new Map<string, Map<string, ShareIndexEntry>>();
+    for (const p of paths) {
+        const segments = p.split("/");
+        if (segments.length < 2) continue; // 根目录孤立文件不算资源
+        const folder = segments[0];
+        if (folder.startsWith(".")) continue;
+        if (!folderMap.has(folder)) folderMap.set(folder, new Map());
+        const entryMap = folderMap.get(folder)!;
+        if (segments.length === 2) {
+            // 孤立文件式资源
+            const key = `file:${p}`;
+            entryMap.set(key, {
+                folder,
+                name: segments[1].replace(/\.[^.]+$/, ""),
+                type: "file",
+                path: p,
+                files: [p],
+                images: [],
+                description: "",
+                updatedAt: null,
+            });
+        } else {
+            // 子文件夹式资源（取第二层为资源名，深层文件归并进来）
+            const entryPath = `${segments[0]}/${segments[1]}`;
+            const key = `dir:${entryPath}`;
+            if (!entryMap.has(key)) {
+                entryMap.set(key, {
+                    folder,
+                    name: segments[1],
+                    type: "dir",
+                    path: entryPath,
+                    files: [],
+                    images: [],
+                    description: "",
+                    updatedAt: null,
+                });
+            }
+            const entry = entryMap.get(key)!;
+            const base = segments[segments.length - 1];
+            if (IMAGE_RE.test(base)) entry.images.push(p);
+            else if (!DESC_NAME_RE.test(base)) entry.files.push(p);
+        }
     }
-    return normalizeIndex(parsed);
+
+    const folders: ShareIndexFolder[] = [];
+    const entries: ShareIndexEntry[] = [];
+    for (const [name, entryMap] of folderMap) {
+        folders.push({ name, count: entryMap.size });
+        entries.push(...entryMap.values());
+    }
+    return { schema: "ai_phone_share_index", schemaVersion: 0, folders, entries };
 }
 
-// ── 已安装记录 ──
-
-type InstalledMap = Record<string, { version?: string; installedAt: string }>;
-
-export function loadInstalledResourceMap(): InstalledMap {
+export async function fetchShareIndex(source: ResourceHubSource): Promise<ShareIndex> {
     try {
-        const raw = kvGet(INSTALLED_KEY);
-        return raw ? (JSON.parse(raw) as InstalledMap) : {};
-    } catch { return {}; }
+        const text = await fetchResourceHubText(source, "_index.json");
+        return normalizeIndex(JSON.parse(text));
+    } catch {
+        // 索引缺失/坏掉时退化为现场扫树（无时间排序与说明摘要）
+        return buildIndexFromTree(source);
+    }
 }
 
-function markInstalled(item: ResourceHubItem): void {
-    const map = loadInstalledResourceMap();
-    map[item.id] = { version: item.version, installedAt: new Date().toISOString() };
-    kvSet(INSTALLED_KEY, JSON.stringify(map));
+// ── 下载 ──
+
+export async function downloadResourceHubFile(source: ResourceHubSource, path: string): Promise<void> {
+    const buffer = await fetchResourceHubBinary(source, path);
+    const filename = path.split("/").pop() || "resource";
+    const { downloadFile } = await import("./download-utils");
+    await downloadFile(new Blob([buffer]), filename);
 }
 
-// ── 安装 ──
+// ── 导入 ──
 
-const CSS_TARGETS = new Set(["global", "chat_app", "chat_session", "story", "music", "calendar"]);
+const CHAT_APP_CSS_KEY = "chat-app-custom-css";
 
-/** 拉取资源文件并装进本机对应存储；返回展示用的结果说明。 */
-export async function installResourceHubItem(source: ResourceHubSource, item: ResourceHubItem): Promise<string> {
-    const text = await fetchResourceHubText(source, item.path);
-    switch (item.kind) {
+function fileBaseName(path: string): string {
+    return (path.split("/").pop() || path).replace(/\.[^.]+$/, "");
+}
+
+/** 目的地对文件类型的基本校验；返回错误文案或 null。 */
+export function checkImportFileForDestination(destination: ImportDestination, path: string): string | null {
+    const lower = path.toLowerCase();
+    const isJson = lower.endsWith(".json");
+    switch (destination) {
+        case "preset":
+        case "regex":
+        case "worldbook":
+        case "game":
+        case "theater":
+            return isJson ? null : "该目的地需要 JSON 文件";
+        case "character":
+            return isJson || lower.endsWith(".png") ? null : "角色卡需要 JSON 或 PNG 文件";
+        case "chat_session_css":
+        case "chat_app_css":
+        case "global_css":
+            return lower.endsWith(".css") || lower.endsWith(".txt") ? null : "CSS 目的地需要 .css 或 .txt 文件";
+        case "custom_app":
+            return lower.endsWith(".zip") || lower.endsWith(".html") || lower.endsWith(".htm") ? null : "应用需要 zip 安装包或单 HTML 文件";
+        case "plugin":
+            return lower.endsWith(".js") || lower.endsWith(".mjs") || lower.endsWith(".txt") ? null : "插件需要 JS 源码文件";
+    }
+}
+
+/**
+ * 把资源文件导入到指定目的地。chat_session_css 必须传 contactId（选中的角色会话）。
+ * 返回给用户看的结果说明。
+ */
+export async function importResourceHubFile(
+    source: ResourceHubSource,
+    path: string,
+    destination: ImportDestination,
+    options?: { contactId?: string },
+): Promise<string> {
+    const lower = path.toLowerCase();
+    const displayName = fileBaseName(path);
+    switch (destination) {
+        case "preset": {
+            const preset = parsePresetFromJson(await fetchResourceHubText(source, path), displayName);
+            if (!preset) throw new Error("预设解析失败，请确认文件是预设管理页导出的 JSON");
+            savePresets([...loadPresets(), preset]);
+            return `预设「${preset.name}」已导入`;
+        }
+        case "regex": {
+            const regex = parseRegexFromJson(await fetchResourceHubText(source, path), displayName);
+            if (!regex) throw new Error("正则解析失败，请确认文件是正则管理页导出的 JSON");
+            saveRegexes([...loadRegexes(), regex]);
+            return `正则组「${regex.name}」已导入`;
+        }
+        case "worldbook": {
+            const book = parseWorldBookFromJson(await fetchResourceHubText(source, path));
+            if (!book) throw new Error("世界书解析失败，请确认文件是世界书管理页导出的 JSON");
+            saveWorldBooks([...loadWorldBooks(), book]);
+            return `世界书「${book.name}」已导入`;
+        }
         case "character": {
-            const data = parseCharacterFromJson(text);
+            const data = lower.endsWith(".png")
+                ? parseCharacterFromPng(await fetchResourceHubBinary(source, path))
+                : parseCharacterFromJson(await fetchResourceHubText(source, path));
             if (!data) throw new Error("角色卡解析失败");
             const character = createCharacter(data);
             saveCharacters([...loadCharacters(), character]);
-            markInstalled(item);
             return `角色「${character.name}」已加入角色库`;
         }
-        case "preset": {
-            const preset = parsePresetFromJson(text, item.name);
-            if (!preset) throw new Error("预设解析失败");
-            savePresets([...loadPresets(), preset]);
-            markInstalled(item);
-            return `预设「${preset.name}」已导入`;
+        case "chat_session_css": {
+            const contactId = options?.contactId;
+            if (!contactId) throw new Error("请选择要应用的角色");
+            const css = await fetchResourceHubText(source, path);
+            const session = createOrGetSession(contactId);
+            const sessions = loadChatSessions().map(s => s.id === session.id ? { ...s, customCSS: css } : s);
+            saveChatSessions(sessions);
+            window.dispatchEvent(new CustomEvent("chat-session-css-updated", { detail: { sessionId: session.id, css } }));
+            saveScheme("chat_session", displayName, css);
+            return `聊天室 CSS 已应用，并存入方案库「${displayName}」`;
         }
-        case "worldbook": {
-            const book = parseWorldBookFromJson(text);
-            if (!book) throw new Error("世界书解析失败");
-            saveWorldBooks([...loadWorldBooks(), book]);
-            markInstalled(item);
-            return `世界书「${book.name}」已导入`;
+        case "chat_app_css": {
+            const css = await fetchResourceHubText(source, path);
+            kvSet(CHAT_APP_CSS_KEY, css);
+            window.dispatchEvent(new CustomEvent("chat-app-css-updated"));
+            saveScheme("chat_app", displayName, css);
+            return `聊天主页 CSS 已应用，并存入方案库「${displayName}」`;
         }
-        case "regex": {
-            const regex = parseRegexFromJson(text, item.name);
-            if (!regex) throw new Error("正则解析失败");
-            saveRegexes([...loadRegexes(), regex]);
-            markInstalled(item);
-            return `正则组「${regex.name}」已导入`;
+        case "global_css": {
+            const css = await fetchResourceHubText(source, path);
+            writeThemeProfile({ ...readThemeProfile(), globalCustomCSS: css });
+            window.dispatchEvent(new CustomEvent("theme-css-updated"));
+            saveScheme("global", displayName, css);
+            return `全局 CSS 已应用（外观页可调整），并存入方案库「${displayName}」`;
         }
-        case "css": {
-            const target = item.cssTarget && CSS_TARGETS.has(item.cssTarget) ? item.cssTarget : "global";
-            saveScheme(target, item.name, text);
-            markInstalled(item);
-            return `CSS 方案「${item.name}」已保存，可在对应界面的 CSS 设置里应用`;
+        case "custom_app": {
+            const buffer = await fetchResourceHubBinary(source, path);
+            const filename = path.split("/").pop() || "app.zip";
+            const file = new File([buffer], filename);
+            const { loadCustomAppPackage, loadSingleHtmlCustomApp, installCustomAppAsync } = await import("./custom-app-storage");
+            const { applyCustomAppRegistrationsAsync } = await import("./custom-app-registration");
+            const app = lower.endsWith(".zip") ? await loadCustomAppPackage(file) : await loadSingleHtmlCustomApp(file);
+            const installed = await installCustomAppAsync(app);
+            await applyCustomAppRegistrationsAsync(installed);
+            return `应用「${installed.name}」已安装，桌面可找到图标`;
+        }
+        case "game": {
+            const payload = JSON.parse(await fetchResourceHubText(source, path)) as { type?: string; title?: string; draft?: unknown };
+            if (payload?.type !== "ai-phone-game-draft" || !payload.draft || typeof payload.draft !== "object") {
+                throw new Error("不是有效的游戏草稿文件（需要游戏草稿箱「导出文件」生成）");
+            }
+            const now = new Date().toISOString();
+            const title = (typeof payload.title === "string" && payload.title.trim()) || displayName;
+            saveGameDrafts([
+                {
+                    id: `draft_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+                    title,
+                    draft: payload.draft as GameTemplateDraft,
+                    createdAt: now,
+                    updatedAt: now,
+                },
+                ...loadGameDrafts(),
+            ]);
+            return `游戏草稿「${title}」已导入草稿箱，可在游戏工作室查看发布`;
+        }
+        case "theater": {
+            const payload = JSON.parse(await fetchResourceHubText(source, path)) as { type?: string; title?: string; draft?: unknown };
+            if (payload?.type !== "ai-phone-theater-draft" || !payload.draft || typeof payload.draft !== "object") {
+                throw new Error("不是有效的剧场草稿文件（需要剧场草稿箱「导出文件」生成）");
+            }
+            const now = new Date().toISOString();
+            const title = (typeof payload.title === "string" && payload.title.trim()) || displayName;
+            // 与黑市工作室共用同一 kv 键与记录形状（black-market-app / qa-content-tools 同款）
+            const key = "ai_phone_black_market_studio_drafts_v1";
+            let drafts: unknown[] = [];
+            try { drafts = JSON.parse(kvGet(key) || "[]") as unknown[]; } catch { drafts = []; }
+            if (!Array.isArray(drafts)) drafts = [];
+            drafts.unshift({
+                id: `bmdraft_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+                title,
+                draft: payload.draft,
+                createdAt: now,
+                updatedAt: now,
+            });
+            kvSet(key, JSON.stringify(drafts.slice(0, 80)));
+            return `剧场草稿「${title}」已导入草稿箱，可在黑市工作室查看上架`;
+        }
+        case "plugin": {
+            const code = await fetchResourceHubText(source, path);
+            const { installChatPluginFromCode } = await import("./chat-plugin-loader");
+            const result = await installChatPluginFromCode(code);
+            if (!result.ok) throw new Error(result.error || "插件安装失败");
+            return result.upgraded
+                ? `插件「${result.name}」已升级（${result.fromVersion} → ${result.toVersion}）`
+                : `插件「${result.name}」已安装，可在聊天设置的插件管理里启用`;
         }
     }
 }

--- a/lib/resource-hub-types.ts
+++ b/lib/resource-hub-types.ts
@@ -1,46 +1,38 @@
 // lib/resource-hub-types.ts
 // 资源集市：GitHub 仓库当后端的社区资源市场。
-// 仓库根目录维护一份 index.json 总目录，市场页经 CDN 拉取后按需安装单个资源文件。
+// 仓库文件夹结构完全自由——市场首页显示仓库根目录的文件夹，
+// 索引 _index.json 由资源仓库的 GitHub Actions 自动生成（含时间/说明/图片）。
 
-export type ResourceHubKind = "character" | "preset" | "worldbook" | "regex" | "css";
-
-export const RESOURCE_HUB_KIND_LABELS: Record<ResourceHubKind, string> = {
-    character: "角色卡",
-    preset: "预设",
-    worldbook: "世界书",
-    regex: "正则",
-    css: "CSS 方案",
-};
-
-export function isResourceHubKind(value: unknown): value is ResourceHubKind {
-    return typeof value === "string" && value in RESOURCE_HUB_KIND_LABELS;
-}
-
-export type ResourceHubItem = {
-    /** 目录内唯一 ID（建议 kind/文件名） */
-    id: string;
-    kind: ResourceHubKind;
+export type ShareIndexFolder = {
     name: string;
-    /** 资源文件在仓库内的相对路径 */
-    path: string;
-    author?: string;
-    description?: string;
-    version?: string;
-    tags?: string[];
-    /** 封面：仓库相对路径或完整 http(s) URL */
-    cover?: string;
-    updatedAt?: string;
-    /** css 类型专用：方案目标（global / chat_app / chat_session / story / music / calendar） */
-    cssTarget?: string;
+    count: number;
 };
 
-export type ResourceHubIndex = {
-    schema: "ai_phone_resource_hub";
+export type ShareIndexEntry = {
+    /** 所属一级文件夹名 */
+    folder: string;
+    /** 展示名（子文件夹名或文件名去扩展名） */
+    name: string;
+    /** dir = 子文件夹式资源；file = 孤立文件式资源 */
+    type: "dir" | "file";
+    /** 仓库相对路径 */
+    path: string;
+    /** 资源本体文件（不含说明与图片） */
+    files: string[];
+    /** 图片（仓库相对路径），列表页显示第一张 */
+    images: string[];
+    /** 说明摘要（来自 说明.txt / README.md） */
+    description: string;
+    /** 最近更新时间（ISO），索引生成时来自 git log */
+    updatedAt: string | null;
+};
+
+export type ShareIndex = {
+    schema: "ai_phone_share_index";
     schemaVersion: number;
-    updatedAt?: string;
-    /** 市场公告（可选，显示在列表顶部） */
-    notice?: string;
-    items: ResourceHubItem[];
+    generatedAt?: string;
+    folders: ShareIndexFolder[];
+    entries: ShareIndexEntry[];
 };
 
 export type ResourceHubSource = {
@@ -51,6 +43,34 @@ export type ResourceHubSource = {
 
 export const RESOURCE_HUB_DEFAULT_SOURCE: ResourceHubSource = {
     owner: "xiaolongbao0709",
-    repo: "share",
+    repo: "ai-virtual-phone-share",
     branch: "main",
 };
+
+/** 导入目的地（用户在导入时选择） */
+export type ImportDestination =
+    | "preset"
+    | "regex"
+    | "worldbook"
+    | "character"
+    | "chat_session_css"
+    | "chat_app_css"
+    | "global_css"
+    | "custom_app"
+    | "game"
+    | "theater"
+    | "plugin";
+
+export const IMPORT_DESTINATIONS: Array<{ key: ImportDestination; label: string; hint: string }> = [
+    { key: "preset", label: "预设", hint: "预设管理页导出的 JSON" },
+    { key: "regex", label: "正则", hint: "正则管理页导出的 JSON" },
+    { key: "worldbook", label: "世界书", hint: "世界书管理页导出的 JSON" },
+    { key: "character", label: "角色卡", hint: "角色卡 JSON 或 PNG" },
+    { key: "chat_session_css", label: "聊天室自定义CSS", hint: "需选择应用到哪个角色" },
+    { key: "chat_app_css", label: "聊天主页自定义CSS", hint: "应用到聊天主页" },
+    { key: "global_css", label: "全局自定义CSS", hint: "应用到外观页全局样式" },
+    { key: "custom_app", label: "应用", hint: "应用市场 zip 安装包或单 HTML" },
+    { key: "game", label: "游戏", hint: "游戏草稿箱导出的 JSON" },
+    { key: "theater", label: "黑市剧场", hint: "剧场草稿箱导出的 JSON" },
+    { key: "plugin", label: "插件", hint: "聊天插件 JS 源码文件" },
+];


### PR DESCRIPTION
同步自 ai-virtual-phone-clean-（本次四个文件在两仓库逐字一致，补丁直接应用）。

## 改动

- **文件夹结构完全自由**：首页自动映射仓库根目录文件夹（仿文件管理器，一行两个）；文件夹页为古早论坛式列表（有图显图、无图纯文字），按 `_index.json` 时间倒序（Actions 自动生成；索引不可用时退化为 jsDelivr data API 扫树）
- **下载 / 导入双动作**：导入弹 11 项目的地选择 —— 预设/正则/世界书/角色卡（JSON/PNG）/聊天室CSS（选角色直接应用）/聊天主页CSS/全局CSS/应用（zip/HTML 市场同款安装）/游戏草稿/剧场草稿/插件，含按目的地的文件类型预检
- **复古 Windows UI**：标题栏、地址栏、状态栏、立体边框、系统对话框
- 资源仓库 `xiaolongbao0709/ai-virtual-phone-share` 已初始化（约定 README、自动索引 Actions、示例资源），CDN 已可访问

## 验证

浏览器实测 12 项全过（mock CDN 走真实组件）：文件夹/列表/排序/缩略图、11 项目的地、预设导入、类型预检、聊天室 CSS 选角色链路、游戏/剧场草稿落库。真实 CDN `_index.json` 已确认 200 可达。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_