### PR TITLE
资源集市：应用内上传（Token 直传 + 免账号代传双链路）

### DIFF
--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -23,6 +23,13 @@ import {
     type ShareIndex,
     type ShareIndexEntry,
 } from "@/lib/resource-hub-types";
+import {
+    fileToUploadEntry,
+    loadUploadConfig,
+    saveUploadConfig,
+    uploadResource,
+    type ResourceHubUploadConfig,
+} from "@/lib/resource-hub-upload";
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -48,6 +55,16 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     const [showConstructionNotice, setShowConstructionNotice] = useState(true);
     const [showSourceEditor, setShowSourceEditor] = useState(false);
     const [sourceDraft, setSourceDraft] = useState<ResourceHubSource>(source);
+    // 上传
+    const [showUpload, setShowUpload] = useState(false);
+    const [uploadFolder, setUploadFolder] = useState("");
+    const [uploadName, setUploadName] = useState("");
+    const [uploadAuthor, setUploadAuthor] = useState("");
+    const [uploadDesc, setUploadDesc] = useState("");
+    const [uploadFiles, setUploadFiles] = useState<File[]>([]);
+    const [uploadImages, setUploadImages] = useState<File[]>([]);
+    const [uploading, setUploading] = useState(false);
+    const [uploadCfg, setUploadCfg] = useState<ResourceHubUploadConfig>(() => loadUploadConfig());
 
     const reload = useCallback((activeSource: ResourceHubSource) => {
         setLoadState("loading");
@@ -118,6 +135,32 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
         void runImport(importFile, destination);
     }, [importFile, onNotice, runImport]);
 
+    const handleUploadSubmit = useCallback(async () => {
+        const folder = uploadFolder.trim();
+        const name = uploadName.trim();
+        if (!folder || !name) { onNotice?.("请填写分类和资源名称"); return; }
+        if (uploadFiles.length === 0) { onNotice?.("请选择至少一个资源文件"); return; }
+        setUploading(true);
+        try {
+            const files = await Promise.all([...uploadFiles, ...uploadImages].map(fileToUploadEntry));
+            const result = await uploadResource(source, {
+                folder, name,
+                author: uploadAuthor.trim(),
+                description: uploadDesc.trim(),
+                files,
+            });
+            setShowUpload(false);
+            setUploadName(""); setUploadDesc(""); setUploadFiles([]); setUploadImages([]);
+            onNotice?.(result.merged
+                ? `「${name}」已上架（CDN 缓存刷新后可见）`
+                : `「${name}」已提交，等待管理员审核上架`);
+        } catch (err) {
+            onNotice?.(`上传失败：${err instanceof Error ? err.message : String(err)}`);
+        } finally {
+            setUploading(false);
+        }
+    }, [onNotice, source, uploadAuthor, uploadDesc, uploadFiles, uploadFolder, uploadImages, uploadName]);
+
     const title = activeEntry ? activeEntry.name : activeFolder ? activeFolder : "资源集市";
     const handleBack = activeEntry
         ? () => setActiveEntry(null)
@@ -145,6 +188,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     <span className="rh-address">
                         地址：C:\资源集市{activeFolder ? `\\${activeFolder}` : ""}{activeEntry ? `\\${activeEntry.name}` : ""}
                     </span>
+                    <button className="rh-btn" onClick={() => { setUploadFolder(activeFolder || ""); setShowUpload(true); }}>上传</button>
                 </div>
 
                 {/* 内容区 */}
@@ -308,6 +352,56 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                 </div>
             )}
 
+            {/* 上传对话框 */}
+            {showUpload && (
+                <div className="rh-dialog-overlay" onClick={uploading ? undefined : () => setShowUpload(false)}>
+                    <div className="rh-dialog" onClick={e => e.stopPropagation()}>
+                        <div className="rh-titlebar">
+                            <span className="rh-titlebar-text">上传资源</span>
+                            <span className="rh-titlebar-controls">
+                                <button className="rh-tb-btn" disabled={uploading} onClick={() => setShowUpload(false)}>✕</button>
+                            </span>
+                        </div>
+                        <div className="rh-dialog-body rh-form">
+                            <label>分类（已有分类名或新分类名）
+                                <input className="rh-input" list="rh-folder-options" value={uploadFolder} placeholder="例如：角色卡" onChange={e => setUploadFolder(e.target.value)} />
+                                <datalist id="rh-folder-options">
+                                    {(index?.folders ?? []).map(f => <option key={f.name} value={f.name} />)}
+                                </datalist>
+                            </label>
+                            <label>资源名称
+                                <input className="rh-input" value={uploadName} placeholder="例如：唐簪雪" onChange={e => setUploadName(e.target.value)} />
+                            </label>
+                            <label>投稿人（可选）
+                                <input className="rh-input" value={uploadAuthor} onChange={e => setUploadAuthor(e.target.value)} />
+                            </label>
+                            <label>说明文字（可选，会显示在列表里）
+                                <textarea className="rh-input" rows={3} value={uploadDesc} onChange={e => setUploadDesc(e.target.value)} />
+                            </label>
+                            <label className="rh-file-picker">
+                                <span className="rh-btn">选择资源文件{uploadFiles.length > 0 ? `（已选 ${uploadFiles.length} 个）` : ""}</span>
+                                <input type="file" multiple hidden onChange={e => { setUploadFiles(Array.from(e.target.files ?? [])); e.target.value = ""; }} />
+                            </label>
+                            <label className="rh-file-picker">
+                                <span className="rh-btn">选择配图（可选）{uploadImages.length > 0 ? `（已选 ${uploadImages.length} 张）` : ""}</span>
+                                <input type="file" accept="image/*" multiple hidden onChange={e => { setUploadImages(Array.from(e.target.files ?? [])); e.target.value = ""; }} />
+                            </label>
+                            <div className="rh-form-hint">
+                                {uploadCfg.githubToken
+                                    ? "将使用你的 GitHub Token 提交（有仓库权限则直接上架，否则生成待审核投稿）。"
+                                    : "将匿名提交到审核队列，管理员通过后上架。单次总量 ≤5MB。"}
+                            </div>
+                        </div>
+                        <div className="rh-dialog-footer">
+                            <button className="rh-btn" disabled={uploading} onClick={() => setShowUpload(false)}>取消</button>
+                            <button className="rh-btn rh-btn-primary" disabled={uploading} onClick={() => void handleUploadSubmit()}>
+                                {uploading ? "提交中..." : "提交"}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
             {/* 资源仓库设置 */}
             {showSourceEditor && (
                 <div className="rh-dialog-overlay" onClick={() => setShowSourceEditor(false)}>
@@ -324,6 +418,12 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                 <input className="rh-input" value={sourceDraft.branch} placeholder="main" onChange={e => setSourceDraft(prev => ({ ...prev, branch: e.target.value }))} />
                             </label>
                             <div className="rh-form-hint">资源经 jsDelivr CDN 读取，公开仓库无需登录。除非换资源源，一般不用改。</div>
+                            <label>GitHub Token（可选，上传直传用）
+                                <input className="rh-input" type="password" value={uploadCfg.githubToken} placeholder="不填则上传走匿名审核队列" onChange={e => setUploadCfg(prev => ({ ...prev, githubToken: e.target.value }))} />
+                            </label>
+                            <label>上传服务地址
+                                <input className="rh-input" value={uploadCfg.endpoint} onChange={e => setUploadCfg(prev => ({ ...prev, endpoint: e.target.value }))} />
+                            </label>
                         </div>
                         <div className="rh-dialog-footer">
                             <button className="rh-btn" onClick={() => setShowSourceEditor(false)}>取消</button>
@@ -335,6 +435,8 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                 };
                                 if (!next.owner || !next.repo) { onNotice?.("仓库 owner 和名称不能为空"); return; }
                                 saveResourceHubSource(next);
+                                saveUploadConfig(uploadCfg);
+                                setUploadCfg(loadUploadConfig());
                                 setSource(next);
                                 setActiveFolder(null);
                                 setActiveEntry(null);
@@ -649,6 +751,9 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     outline: none;
                 }
                 .rh-form-hint { font-size: calc(10px * var(--app-text-scale, 1)); color: #606060; line-height: 1.6; }
+                .rh-file-picker { cursor: pointer; }
+                .rh-file-picker .rh-btn { display: block; text-align: center; }
+                textarea.rh-input { resize: vertical; font-family: inherit; }
             `}</style>
         </div>
     );

--- a/docs/resource-hub.md
+++ b/docs/resource-hub.md
@@ -58,3 +58,12 @@ ai-virtual-phone-share/
 ## 体积约束
 
 jsDelivr 单文件上限 20MB；图片建议单张 ≤ 300KB。
+
+## 应用内上传
+
+工具条「上传」按钮：填分类（可新建）/名称/说明 + 选文件与配图。提交走两条链路之一：
+
+- **配了 GitHub Token**（标题栏 ⚙ 里填）：有仓库写权限的 token 直接提交 main 立即上架；普通用户 token 自动 fork + 开 PR 待审核
+- **没配 Token**：匿名 POST 到独立部署的上传服务（share 仓库 `netlify/functions/upload.mjs`，从该仓库单独建 Netlify 站点 + 配 `SHARE_BOT_TOKEN` 环境变量），由机器人代开 PR 待审核。默认地址 `https://aivp-share.netlify.app/.netlify/functions/upload`，设置里可改
+
+安全设计：匿名与普通用户的提交都只生成 PR，管理员 merge 才上架；上传服务含单文件/总量体积限制（≤5MB）与 IP 频控。上传服务与主站部署完全隔离。

--- a/lib/resource-hub-upload.ts
+++ b/lib/resource-hub-upload.ts
@@ -1,0 +1,184 @@
+// lib/resource-hub-upload.ts
+// 资源集市上传：
+//  A) GitHub Token 直传 —— 有仓库写权限的 token 直接提交 main（立即上架）；
+//     普通用户 token 自动 fork + 开 PR（待管理员审核）。浏览器直连 api.github.com（支持 CORS）。
+//  B) 免账号代传 —— POST 到独立部署的上传服务（share 仓库里的 Netlify Function），
+//     由机器人 token 代开 PR。
+
+import { kvGet, kvSet, registerKvMigration } from "./kv-db";
+import type { ResourceHubSource } from "./resource-hub-types";
+
+const UPLOAD_CFG_KEY = "ai_phone_resource_hub_upload_cfg_v1";
+registerKvMigration(UPLOAD_CFG_KEY);
+
+export const DEFAULT_UPLOAD_ENDPOINT = "https://aivp-share.netlify.app/.netlify/functions/upload";
+
+export type ResourceHubUploadConfig = {
+    /** 方案 A：用户自己的 GitHub token（可选） */
+    githubToken: string;
+    /** 方案 B：上传服务地址 */
+    endpoint: string;
+};
+
+export function loadUploadConfig(): ResourceHubUploadConfig {
+    try {
+        const raw = kvGet(UPLOAD_CFG_KEY);
+        if (raw) {
+            const parsed = JSON.parse(raw) as Partial<ResourceHubUploadConfig>;
+            return {
+                githubToken: typeof parsed.githubToken === "string" ? parsed.githubToken : "",
+                endpoint: typeof parsed.endpoint === "string" && parsed.endpoint.trim() ? parsed.endpoint : DEFAULT_UPLOAD_ENDPOINT,
+            };
+        }
+    } catch { /* fall through */ }
+    return { githubToken: "", endpoint: DEFAULT_UPLOAD_ENDPOINT };
+}
+
+export function saveUploadConfig(config: ResourceHubUploadConfig): void {
+    kvSet(UPLOAD_CFG_KEY, JSON.stringify({
+        githubToken: config.githubToken.trim(),
+        endpoint: config.endpoint.trim() || DEFAULT_UPLOAD_ENDPOINT,
+    }));
+}
+
+export type UploadPayloadFile = { name: string; contentBase64: string };
+
+export type UploadPayload = {
+    folder: string;
+    name: string;
+    author: string;
+    description: string;
+    /** 资源本体 + 图片，函数侧不区分（图片靠扩展名被索引识别） */
+    files: UploadPayloadFile[];
+};
+
+export type UploadResult = {
+    /** merged=true 表示已直接进 main（立即上架）；否则为待审核 PR */
+    merged: boolean;
+    prUrl?: string;
+};
+
+export async function fileToUploadEntry(file: File): Promise<UploadPayloadFile> {
+    const buffer = await file.arrayBuffer();
+    let binary = "";
+    const bytes = new Uint8Array(buffer);
+    const chunk = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunk) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+    }
+    return { name: file.name, contentBase64: btoa(binary) };
+}
+
+// ── 方案 B：上传服务 ──
+
+export async function uploadViaService(endpoint: string, payload: UploadPayload): Promise<UploadResult> {
+    const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+    });
+    const data = await res.json().catch(() => ({})) as { ok?: boolean; error?: string; prUrl?: string };
+    if (!res.ok || data.ok === false) {
+        throw new Error(data.error || `上传服务返回 HTTP ${res.status}`);
+    }
+    return { merged: false, prUrl: data.prUrl };
+}
+
+// ── 方案 A：GitHub Token 直传 ──
+
+const GH_API = "https://api.github.com";
+
+async function gh<T>(token: string, method: string, path: string, body?: unknown): Promise<T> {
+    const res = await fetch(`${GH_API}${path}`, {
+        method,
+        headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+            ...(body ? { "Content-Type": "application/json" } : {}),
+        },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+        const message = (data as { message?: string })?.message || `GitHub API ${res.status}`;
+        throw new Error(message);
+    }
+    return data as T;
+}
+
+function encodeContentPath(dir: string, file: string): string {
+    return `${dir.split("/").map(encodeURIComponent).join("/")}/${encodeURIComponent(file)}`;
+}
+
+export async function uploadViaToken(token: string, source: ResourceHubSource, payload: UploadPayload): Promise<UploadResult> {
+    const { owner, repo, branch } = source;
+    const dir = `${payload.folder}/${payload.name}`;
+    const toWrite: UploadPayloadFile[] = [...payload.files];
+    if (payload.description.trim()) {
+        toWrite.push({
+            name: "说明.txt",
+            contentBase64: btoa(unescape(encodeURIComponent(payload.description.trim()))),
+        });
+    }
+
+    // 有写权限（仓库主/协作者）→ 直接提交默认分支，立即上架
+    const repoInfo = await gh<{ permissions?: { push?: boolean } }>(token, "GET", `/repos/${owner}/${repo}`);
+    if (repoInfo.permissions?.push) {
+        for (const file of toWrite) {
+            await gh(token, "PUT", `/repos/${owner}/${repo}/contents/${encodeContentPath(dir, file.name)}`, {
+                message: `上架：${dir}/${file.name}`,
+                content: file.contentBase64,
+                branch,
+            });
+        }
+        return { merged: true };
+    }
+
+    // 普通用户 → fork + 分支提交 + 跨仓库 PR
+    const me = await gh<{ login: string }>(token, "GET", "/user");
+    const fork = await gh<{ full_name: string; default_branch: string }>(token, "POST", `/repos/${owner}/${repo}/forks`, {});
+    const [forkOwner, forkRepo] = fork.full_name.split("/");
+
+    // fork 是异步创建的，轮询等它就绪
+    let forkReady = false;
+    for (let i = 0; i < 10; i++) {
+        try {
+            await gh(token, "GET", `/repos/${forkOwner}/${forkRepo}/git/ref/heads/${fork.default_branch || branch}`);
+            forkReady = true;
+            break;
+        } catch {
+            await new Promise(resolve => setTimeout(resolve, 1500));
+        }
+    }
+    if (!forkReady) throw new Error("fork 创建超时，请稍后重试");
+
+    const baseRef = await gh<{ object: { sha: string } }>(token, "GET", `/repos/${forkOwner}/${forkRepo}/git/ref/heads/${fork.default_branch || branch}`);
+    const submitBranch = `submit-${Date.now().toString(36)}`;
+    await gh(token, "POST", `/repos/${forkOwner}/${forkRepo}/git/refs`, {
+        ref: `refs/heads/${submitBranch}`,
+        sha: baseRef.object.sha,
+    });
+    for (const file of toWrite) {
+        await gh(token, "PUT", `/repos/${forkOwner}/${forkRepo}/contents/${encodeContentPath(dir, file.name)}`, {
+            message: `投稿：${dir}/${file.name}`,
+            content: file.contentBase64,
+            branch: submitBranch,
+        });
+    }
+    const pr = await gh<{ html_url: string }>(token, "POST", `/repos/${owner}/${repo}/pulls`, {
+        title: `投稿：${dir}`,
+        head: `${me.login}:${submitBranch}`,
+        base: branch,
+        body: `来自资源集市 App 的投稿。\n\n- 分类：${payload.folder}\n- 名称：${payload.name}\n- 投稿人：${payload.author || me.login}${payload.description.trim() ? `\n\n${payload.description.trim()}` : ""}`,
+    });
+    return { merged: false, prUrl: pr.html_url };
+}
+
+/** 统一入口：配了 token 走直传，否则走上传服务。 */
+export async function uploadResource(source: ResourceHubSource, payload: UploadPayload): Promise<UploadResult> {
+    const config = loadUploadConfig();
+    if (config.githubToken.trim()) {
+        return uploadViaToken(config.githubToken.trim(), source, payload);
+    }
+    return uploadViaService(config.endpoint, payload);
+}


### PR DESCRIPTION
同步自 ai-virtual-phone-clean-（文件在两仓库逐字一致）。

## 内容

工具条新增「上传」：填分类（可新建）/名称/说明，选文件与配图。两条提交链路：

- **配了 GitHub Token**：有仓库写权限直接提交 main 立即上架；普通用户 token 自动 fork + 跨仓库 PR 待审核
- **未配 Token**：匿名 POST 独立部署的上传服务（share 仓库内的 Netlify Function，与主站完全隔离），机器人代开 PR 待审核

所有非管理员提交都只生成 PR，merge 才上架；上传服务含体积限制与 IP 频控。

## 验证

浏览器实测：匿名链路 payload 正确、返回待审核文案；Token 链路 GET 权限 → PUT 直传 main、返回已上架文案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_