### PR TITLE
管理中心：新增「集市审核」tab——应用内审核资源集市投稿

### DIFF
--- a/components/settings/moderation-center.tsx
+++ b/components/settings/moderation-center.tsx
@@ -10,6 +10,14 @@ import { ConfirmDialog } from "../ui/modal";
 import { fetchReports, moderationApi, type ContentReport } from "@/lib/moderation-client";
 import { fetchCustomAppMarketAdminItems, reviewCustomAppMarketItem } from "@/lib/custom-app-market-client";
 import type { CustomAppMarketItem } from "@/lib/custom-app-market-types";
+import {
+  approveShareSubmission,
+  fetchShareSubmissionFiles,
+  listShareSubmissions,
+  rejectShareSubmission,
+  type ShareSubmission,
+  type ShareSubmissionFile,
+} from "@/lib/resource-hub-review";
 
 const TYPE_LABELS: Record<string, string> = {
   market_app: "市场APP",
@@ -19,7 +27,7 @@ const TYPE_LABELS: Record<string, string> = {
   online_room: "联机房间",
 };
 
-type Tab = "reports" | "review" | "users";
+type Tab = "reports" | "review" | "share" | "users";
 
 type FoundUser = { id: string; username: string; displayName: string; status: string };
 
@@ -104,6 +112,67 @@ export function ModerationCenter({ onNotice }: { onNotice?: (msg: string) => voi
     }
   };
 
+  // ── 集市审核（share 仓库待审投稿；权限由 GitHub 服务端裁决）──
+  const [shareItems, setShareItems] = useState<ShareSubmission[]>([]);
+  const [shareLoading, setShareLoading] = useState(false);
+  const [shareBusy, setShareBusy] = useState<Record<number, boolean>>({});
+  const [shareExpanded, setShareExpanded] = useState<number | null>(null);
+  const [shareFiles, setShareFiles] = useState<Record<number, ShareSubmissionFile[] | "loading">>({});
+  const [shareRejectFor, setShareRejectFor] = useState<number | null>(null);
+  const [shareRejectReason, setShareRejectReason] = useState("");
+
+  const loadShareItems = useCallback(async () => {
+    setShareLoading(true);
+    try {
+      setShareItems(await listShareSubmissions());
+    } catch (err) {
+      notice(err instanceof Error ? err.message : "投稿列表加载失败");
+      setShareItems([]);
+    } finally {
+      setShareLoading(false);
+    }
+  }, [notice]);
+
+  useEffect(() => {
+    if (tab === "share") void loadShareItems();
+  }, [tab, loadShareItems]);
+
+  const toggleShareDetail = async (item: ShareSubmission) => {
+    if (shareExpanded === item.number) { setShareExpanded(null); return; }
+    setShareExpanded(item.number);
+    if (!shareFiles[item.number]) {
+      setShareFiles(current => ({ ...current, [item.number]: "loading" }));
+      try {
+        const files = await fetchShareSubmissionFiles(item.number);
+        setShareFiles(current => ({ ...current, [item.number]: files }));
+      } catch (err) {
+        notice(err instanceof Error ? err.message : "内容加载失败");
+        setShareFiles(current => { const next = { ...current }; delete next[item.number]; return next; });
+      }
+    }
+  };
+
+  const runShareAction = async (item: ShareSubmission, action: "approve" | "reject", reason?: string) => {
+    setShareBusy(current => ({ ...current, [item.number]: true }));
+    try {
+      if (action === "approve") {
+        await approveShareSubmission(item.number);
+        notice(`已上架「${item.title}」（CDN 缓存刷新后集市可见）`);
+      } else {
+        await rejectShareSubmission(item.number, reason);
+        notice(`已拒绝「${item.title}」`);
+      }
+      setShareExpanded(null);
+      setShareRejectFor(null);
+      setShareRejectReason("");
+      await loadShareItems();
+    } catch (err) {
+      notice(err instanceof Error ? err.message : "操作失败");
+    } finally {
+      setShareBusy(current => { const next = { ...current }; delete next[item.number]; return next; });
+    }
+  };
+
   // ── 用户管理 ──
   const [userQuery, setUserQuery] = useState("");
   const [foundUser, setFoundUser] = useState<FoundUser | null>(null);
@@ -172,6 +241,7 @@ export function ModerationCenter({ onNotice }: { onNotice?: (msg: string) => voi
       <div style={{ display: "flex", gap: 8, marginBottom: 14 }}>
         <button type="button" style={segStyle(tab === "reports")} onClick={() => setTab("reports")}>举报队列</button>
         <button type="button" style={segStyle(tab === "review")} onClick={() => setTab("review")}>应用审核</button>
+        <button type="button" style={segStyle(tab === "share")} onClick={() => setTab("share")}>集市审核</button>
         <button type="button" style={segStyle(tab === "users")} onClick={() => setTab("users")}>用户管理</button>
       </div>
 
@@ -242,6 +312,72 @@ export function ModerationCenter({ onNotice }: { onNotice?: (msg: string) => voi
               </div>
             </div>
           ))}
+        </div>
+      ) : null}
+
+      {tab === "share" ? (
+        <div>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+            <span style={subStyle}>资源集市的待审投稿（通过 = 上架；拒绝可留言）</span>
+            <button type="button" style={{ ...btnStyle, display: "inline-flex", alignItems: "center", gap: 4 }} onClick={() => void loadShareItems()}><RefreshCw size={12} />刷新</button>
+          </div>
+          {shareLoading ? <p style={subStyle}><Loader2 size={13} className="animate-spin" style={{ verticalAlign: -2 }} /> 加载中…</p> : null}
+          {!shareLoading && shareItems.length === 0 ? <p style={subStyle}>没有待审核的投稿。</p> : null}
+          {shareItems.map(item => {
+            const files = shareFiles[item.number];
+            const expanded = shareExpanded === item.number;
+            return (
+              <div key={item.number} style={cardStyle}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+                  <strong style={{ fontSize: 12.5 }}>{item.title}</strong>
+                  <span style={subStyle}>{new Date(item.createdAt).toLocaleString()}</span>
+                </div>
+                <div style={subStyle}>提交账号：{item.author}</div>
+                {item.body ? <div style={{ margin: "4px 0", whiteSpace: "pre-wrap", wordBreak: "break-all", fontSize: 12 }}>{item.body}</div> : null}
+
+                {expanded && files === "loading" ? <p style={subStyle}><Loader2 size={13} className="animate-spin" style={{ verticalAlign: -2 }} /> 内容加载中…</p> : null}
+                {expanded && Array.isArray(files) ? (
+                  <div style={{ marginTop: 6, display: "flex", flexDirection: "column", gap: 6 }}>
+                    {files.map(file => (
+                      <div key={file.path} style={{ border: "1px solid var(--border-soft, rgba(0,0,0,.08))", borderRadius: 10, padding: "6px 8px" }}>
+                        <div style={{ fontSize: 11.5, fontWeight: 600, wordBreak: "break-all" }}>{file.path}</div>
+                        {file.imageDataUrl ? (
+                          /* eslint-disable-next-line @next/next/no-img-element */
+                          <img src={file.imageDataUrl} alt="" style={{ maxWidth: "100%", maxHeight: 220, borderRadius: 6, marginTop: 4 }} />
+                        ) : null}
+                        {file.textPreview ? (
+                          <pre style={{ margin: "4px 0 0", whiteSpace: "pre-wrap", wordBreak: "break-all", fontSize: 11, maxHeight: 180, overflowY: "auto", fontFamily: "inherit" }}>{file.textPreview}</pre>
+                        ) : null}
+                        {file.note ? <div style={subStyle}>{file.note}</div> : null}
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+
+                {shareRejectFor === item.number ? (
+                  <div style={{ display: "flex", gap: 6, marginTop: 8 }}>
+                    <input
+                      value={shareRejectReason}
+                      onChange={event => setShareRejectReason(event.target.value)}
+                      placeholder="拒绝理由（可选，投稿人可见）"
+                      style={{ flex: 1, minWidth: 0, border: "1px solid var(--border-soft, rgba(0,0,0,.1))", borderRadius: 10, padding: "6px 10px", fontSize: 12, background: "var(--surface-inset, rgba(0,0,0,.03))", color: "inherit", outline: "none" }}
+                    />
+                    <button type="button" style={dangerBtn} disabled={shareBusy[item.number]} onClick={() => void runShareAction(item, "reject", shareRejectReason)}>确认拒绝</button>
+                    <button type="button" style={btnStyle} onClick={() => { setShareRejectFor(null); setShareRejectReason(""); }}>取消</button>
+                  </div>
+                ) : (
+                  <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+                    <button type="button" style={btnStyle} disabled={shareBusy[item.number]} onClick={() => void toggleShareDetail(item)}>
+                      {expanded ? "收起内容" : "查看内容"}
+                    </button>
+                    <button type="button" style={btnStyle} disabled={shareBusy[item.number]} onClick={() => void runShareAction(item, "approve")}>通过并上架</button>
+                    <button type="button" style={dangerBtn} disabled={shareBusy[item.number]} onClick={() => setShareRejectFor(item.number)}>拒绝</button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+          <p style={{ ...subStyle, marginTop: 8 }}>需在资源集市设置（标题栏 ⚙）配置有仓库写权限的 GitHub Token；权限由 GitHub 服务端校验。</p>
         </div>
       ) : null}
 

--- a/lib/resource-hub-review.ts
+++ b/lib/resource-hub-review.ts
@@ -1,0 +1,124 @@
+// lib/resource-hub-review.ts
+// 资源集市审核（管理中心用）：把 share 仓库的待审投稿（open PR）拉下来，
+// 在应用内预览与通过/拒绝。前端直连 GitHub API，权限由 GitHub 服务端裁决——
+// token 没有仓库写权限时合并/关闭会被 403，界面伪造无意义。
+
+import { loadResourceHubSource } from "./resource-hub-client";
+import { loadUploadConfig } from "./resource-hub-upload";
+
+const GH_API = "https://api.github.com";
+const IMAGE_EXT_RE = /\.(jpe?g|png|webp|gif)$/i;
+const TEXT_PREVIEW_MAX = 1500;
+
+export type ShareSubmission = {
+    number: number;
+    title: string;
+    body: string;
+    author: string;
+    createdAt: string;
+};
+
+export type ShareSubmissionFile = {
+    path: string;
+    size: number;
+    /** 图片：data URL 直接预览 */
+    imageDataUrl?: string;
+    /** 文本：截断预览 */
+    textPreview?: string;
+    /** 太大或无法解码时的占位说明 */
+    note?: string;
+};
+
+function getReviewAuth(): { token: string; owner: string; repo: string } {
+    const token = loadUploadConfig().githubToken.trim();
+    if (!token) throw new Error("请先在资源集市设置（标题栏 ⚙）里填入你的 GitHub Token");
+    const source = loadResourceHubSource();
+    return { token, owner: source.owner, repo: source.repo };
+}
+
+async function gh<T>(token: string, method: string, url: string, body?: unknown): Promise<T> {
+    const res = await fetch(url.startsWith("http") ? url : `${GH_API}${url}`, {
+        method,
+        headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+            ...(body ? { "Content-Type": "application/json" } : {}),
+        },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+        const message = (data as { message?: string })?.message || `GitHub API ${res.status}`;
+        throw new Error(res.status === 403 || res.status === 404 ? `没有权限或投稿不存在（${message}）` : message);
+    }
+    return data as T;
+}
+
+function decodeBase64Utf8(b64: string): string {
+    const clean = b64.replace(/\s/g, "");
+    const binary = atob(clean);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return new TextDecoder("utf-8").decode(bytes);
+}
+
+export async function listShareSubmissions(): Promise<ShareSubmission[]> {
+    const { token, owner, repo } = getReviewAuth();
+    const pulls = await gh<Array<{
+        number: number; title: string; body?: string | null;
+        user?: { login?: string } | null; created_at: string;
+    }>>(token, "GET", `/repos/${owner}/${repo}/pulls?state=open&per_page=50`);
+    return pulls.map(pr => ({
+        number: pr.number,
+        title: (pr.title || "").replace(/^投稿[:：]\s*/, ""),
+        body: pr.body || "",
+        author: pr.user?.login || "unknown",
+        createdAt: pr.created_at,
+    }));
+}
+
+export async function fetchShareSubmissionFiles(prNumber: number): Promise<ShareSubmissionFile[]> {
+    const { token, owner, repo } = getReviewAuth();
+    const files = await gh<Array<{ filename: string; contents_url: string; status: string }>>(
+        token, "GET", `/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100`);
+
+    const result: ShareSubmissionFile[] = [];
+    for (const file of files.filter(f => f.status !== "removed")) {
+        const entry: ShareSubmissionFile = { path: file.filename, size: 0 };
+        try {
+            const blob = await gh<{ content?: string; encoding?: string; size?: number }>(token, "GET", file.contents_url);
+            entry.size = blob.size ?? 0;
+            if (blob.encoding === "base64" && blob.content) {
+                if (IMAGE_EXT_RE.test(file.filename)) {
+                    const ext = file.filename.split(".").pop()!.toLowerCase().replace("jpg", "jpeg");
+                    entry.imageDataUrl = `data:image/${ext};base64,${blob.content.replace(/\s/g, "")}`;
+                } else {
+                    const text = decodeBase64Utf8(blob.content);
+                    entry.textPreview = text.slice(0, TEXT_PREVIEW_MAX) + (text.length > TEXT_PREVIEW_MAX ? "\n…（已截断）" : "");
+                }
+            } else {
+                entry.note = `文件较大（${Math.round(entry.size / 1024)}KB），请到 GitHub 查看`;
+            }
+        } catch {
+            entry.note = "内容预览失败";
+        }
+        result.push(entry);
+    }
+    return result;
+}
+
+/** 通过并上架（合并 PR）。 */
+export async function approveShareSubmission(prNumber: number): Promise<void> {
+    const { token, owner, repo } = getReviewAuth();
+    await gh(token, "PUT", `/repos/${owner}/${repo}/pulls/${prNumber}/merge`, { merge_method: "merge" });
+}
+
+/** 拒绝（关闭 PR，可选留言让投稿人看到理由）。 */
+export async function rejectShareSubmission(prNumber: number, reason?: string): Promise<void> {
+    const { token, owner, repo } = getReviewAuth();
+    const trimmed = reason?.trim();
+    if (trimmed) {
+        await gh(token, "POST", `/repos/${owner}/${repo}/issues/${prNumber}/comments`, { body: `审核未通过：${trimmed}` });
+    }
+    await gh(token, "PATCH", `/repos/${owner}/${repo}/pulls/${prNumber}`, { state: "closed" });
+}


### PR DESCRIPTION
同步自 ai-virtual-phone-clean-（moderation-center 在两仓库基线一致，补丁直接应用）。

## 内容

管理中心第四个 tab「集市审核」：列出 share 仓库待审投稿，展开预览文件内容（图片内联、文本截断），「通过并上架」= merge、「拒绝」= 可选留言 + close。复用资源集市设置里的 GitHub Token；权限由 GitHub 服务端裁决，前端伪造 admin 无法越权。

## 验证

浏览器实测（mock GitHub API）：列表/预览/通过（PUT merge）/拒绝（POST 留言 + PATCH close）调用序列与文案全部正确。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_