### PR TITLE
资源集市：「导入到...」弹窗改为桌面图标式网格

### DIFF
--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -317,11 +317,11 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                 <button className="rh-tb-btn" onClick={() => setImportFile(null)}>✕</button>
                             </span>
                         </div>
-                        <div className="rh-dialog-body rh-dest-list">
+                        <div className="rh-dialog-body rh-dest-grid">
                             {IMPORT_DESTINATIONS.map(dest => (
-                                <button key={dest.key} className="rh-dest" onClick={() => handlePickDestination(dest.key)}>
-                                    <span className="rh-dest-label">{dest.label}</span>
-                                    <span className="rh-dest-hint">{dest.hint}</span>
+                                <button key={dest.key} className="rh-dest-tile" title={dest.hint} onClick={() => handlePickDestination(dest.key)}>
+                                    <span className="rh-dest-tile-icon">{dest.icon}</span>
+                                    <span className="rh-dest-tile-label">{dest.label}</span>
                                 </button>
                             ))}
                         </div>
@@ -718,6 +718,36 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     padding: 0 12px 12px;
                 }
                 .rh-dest-list { flex-direction: column; align-items: stretch; gap: 3px; }
+                /* 目的地图标网格（仿桌面图标：图标 + 名字，一行三个） */
+                .rh-dest-grid {
+                    display: grid;
+                    grid-template-columns: 1fr 1fr 1fr;
+                    gap: 6px;
+                    align-items: stretch;
+                }
+                .rh-dest-tile {
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                    gap: 5px;
+                    padding: 12px 4px 9px;
+                    background: none;
+                    border: 1px dotted transparent;
+                    cursor: pointer;
+                }
+                .rh-dest-tile:active { border-color: #000080; background: #e4ecf7; }
+                .rh-dest-tile-icon {
+                    font-size: 30px;
+                    line-height: 1;
+                    filter: saturate(0.85);
+                }
+                .rh-dest-tile-label {
+                    font-size: calc(11px * var(--app-text-scale, 1));
+                    color: #000;
+                    text-align: center;
+                    line-height: 1.3;
+                    word-break: break-all;
+                }
                 .rh-dest {
                     display: flex;
                     flex-direction: column;

--- a/lib/resource-hub-types.ts
+++ b/lib/resource-hub-types.ts
@@ -61,16 +61,16 @@ export type ImportDestination =
     | "theater"
     | "plugin";
 
-export const IMPORT_DESTINATIONS: Array<{ key: ImportDestination; label: string; hint: string }> = [
-    { key: "preset", label: "预设", hint: "预设管理页导出的 JSON" },
-    { key: "regex", label: "正则", hint: "正则管理页导出的 JSON" },
-    { key: "worldbook", label: "世界书", hint: "世界书管理页导出的 JSON" },
-    { key: "character", label: "角色卡", hint: "角色卡 JSON 或 PNG" },
-    { key: "chat_session_css", label: "聊天室自定义CSS", hint: "需选择应用到哪个角色" },
-    { key: "chat_app_css", label: "聊天主页自定义CSS", hint: "应用到聊天主页" },
-    { key: "global_css", label: "全局自定义CSS", hint: "应用到外观页全局样式" },
-    { key: "custom_app", label: "应用", hint: "应用市场 zip 安装包或单 HTML" },
-    { key: "game", label: "游戏", hint: "游戏草稿箱导出的 JSON" },
-    { key: "theater", label: "黑市剧场", hint: "剧场草稿箱导出的 JSON" },
-    { key: "plugin", label: "插件", hint: "聊天插件 JS 源码文件" },
+export const IMPORT_DESTINATIONS: Array<{ key: ImportDestination; label: string; hint: string; icon: string }> = [
+    { key: "preset", label: "预设", hint: "预设管理页导出的 JSON", icon: "🎛️" },
+    { key: "regex", label: "正则", hint: "正则管理页导出的 JSON", icon: "✂️" },
+    { key: "worldbook", label: "世界书", hint: "世界书管理页导出的 JSON", icon: "📖" },
+    { key: "character", label: "角色卡", hint: "角色卡 JSON 或 PNG", icon: "🎴" },
+    { key: "chat_session_css", label: "聊天室CSS", hint: "需选择应用到哪个角色", icon: "💬" },
+    { key: "chat_app_css", label: "聊天主页CSS", hint: "应用到聊天主页", icon: "📱" },
+    { key: "global_css", label: "全局CSS", hint: "应用到外观页全局样式", icon: "🎨" },
+    { key: "custom_app", label: "应用", hint: "应用市场 zip 安装包或单 HTML", icon: "📦" },
+    { key: "game", label: "游戏", hint: "游戏草稿箱导出的 JSON", icon: "🕹️" },
+    { key: "theater", label: "黑市剧场", hint: "剧场草稿箱导出的 JSON", icon: "🎭" },
+    { key: "plugin", label: "插件", hint: "聊天插件 JS 源码文件", icon: "🧩" },
 ];


### PR DESCRIPTION
竖列表改为一行三个的图标网格（图标 + 名字，仿复古桌面图标）；原说明文字收进 title 提示。选角色弹窗保持列表样式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_