### PR TITLE
资源集市：导入弹窗图标改为手绘像素画

### DIFF
--- a/components/resource-hub/pixel-icons.tsx
+++ b/components/resource-hub/pixel-icons.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+// 资源集市像素图标：16×16 像素网格手绘，渲染为锐边 SVG。
+// 零图片资源，Win98 经典配色，缩放不糊。
+// 网格字符 → 颜色见 PALETTE；"." 为透明。
+
+import type { ImportDestination } from "@/lib/resource-hub-types";
+
+const PALETTE: Record<string, string> = {
+    k: "#1a1a1a", // 黑（描边）
+    w: "#ffffff", // 白
+    g: "#c6c6c6", // 浅灰
+    d: "#7a7a7a", // 深灰
+    y: "#f8d838", // 黄
+    r: "#d84848", // 红
+    b: "#4868d8", // 蓝
+    B: "#203890", // 深蓝
+    c: "#38a8a0", // 青
+    t: "#e8c890", // 皮肤/纸箱
+    n: "#000080", // 藏青
+    p: "#b868d0", // 紫
+    o: "#c88030", // 橙（纸箱）
+};
+
+type PixelGrid = string[];
+
+const DEST_ICONS: Record<ImportDestination, PixelGrid> = {
+    // 调音台滑杆
+    preset: [
+        "................",
+        "....bb..........",
+        "..ddBBdddddddd..",
+        "....bb..........",
+        "................",
+        ".........bb.....",
+        "..dddddddBBddd..",
+        ".........bb.....",
+        "................",
+        "......bb........",
+        "..ddddBBdddddd..",
+        "......bb........",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    // 剪刀
+    regex: [
+        "................",
+        "................",
+        "..kk........kk..",
+        "..kkk......kkk..",
+        "...kkk....kkk...",
+        "....kkk..kkk....",
+        ".....kkkkkk.....",
+        "......kkkk......",
+        ".....kkkkkk.....",
+        "....kkk..kkk....",
+        "...rrr....rrr...",
+        "..rrrr....rrrr..",
+        "..rrr......rrr..",
+        "................",
+        "................",
+        "................",
+    ],
+    // 打开的书
+    worldbook: [
+        "................",
+        "................",
+        "..kkkkkk.kkkkk..",
+        ".kwwwwwkkwwwwwk.",
+        ".kwwwwwkkwwwwwk.",
+        ".kwddwwkkwwddwk.",
+        ".kwwwwwkkwwwwwk.",
+        ".kwddwwkkwwddwk.",
+        ".kwwwwwkkwwwwwk.",
+        ".kwwwwwkkwwwwwk.",
+        ".kpppppkkpppppk.",
+        ".kkkkkkkkkkkkkk.",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    // 角色卡
+    character: [
+        "................",
+        ".kkkkkkkkkkkkk..",
+        ".kwwwwwwwwwwwk..",
+        ".kwwwwwttwwwwk..",
+        ".kwwwwttttwwwk..",
+        ".kwwwwttttwwwk..",
+        ".kwwwwwttwwwwk..",
+        ".kwwwbbbbbbwwk..",
+        ".kwwbbbbbbbbwk..",
+        ".kwwbbbbbbbbwk..",
+        ".kwwwwwwwwwwwk..",
+        ".kkkkkkkkkkkkk..",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    // 对话气泡
+    chat_session_css: [
+        "................",
+        "................",
+        "..kkkkkkkkkkk...",
+        ".kwwwwwwwwwwwk..",
+        ".kwddddddwwwwk..",
+        ".kwwwwwwwwwwwk..",
+        ".kwddddddddwwk..",
+        ".kwwwwwwwwwwwk..",
+        "..kkkkkkkkkkk...",
+        "....kkw.........",
+        "...kkw..........",
+        "...kk...........",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    // 手机
+    chat_app_css: [
+        "................",
+        "....kkkkkkkk....",
+        "....kwwwwwwk....",
+        "....kwbbbbwk....",
+        "....kwbbbbwk....",
+        "....kwbbbbwk....",
+        "....kwbbbbwk....",
+        "....kwbbbbwk....",
+        "....kwbbbbwk....",
+        "....kwwwwwwk....",
+        "....kwwddwwk....",
+        "....kkkkkkkk....",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    // 调色盘
+    global_css: [
+        "................",
+        "................",
+        "....kkkkkkk.....",
+        "..kkwwwwwwwkk...",
+        ".kwwrrwwyywwwk..",
+        ".kwwrrwwyywwwk..",
+        ".kwwwwwwwwwbbk..",
+        ".kwccwwwwwwbbk..",
+        ".kwccwwwkkwwwk..",
+        "..kwwwwwkkwwk...",
+        "...kkwwwwwkk....",
+        ".....kkkkk......",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    // 纸箱
+    custom_app: [
+        "................",
+        "................",
+        "..kkkkkkkkkkkk..",
+        "..kooooyyooook..",
+        "..kooooyyooook..",
+        "..kyyyyyyyyyyk..",
+        "..kooooyyooook..",
+        "..kooooyyooook..",
+        "..kooooyyooook..",
+        "..kooooyyooook..",
+        "..kkkkkkkkkkkk..",
+        "................",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    // 街机摇杆
+    game: [
+        "................",
+        "......rrrr......",
+        ".....rrrrrr.....",
+        ".....rrrrrr.....",
+        "......rrrr......",
+        ".......kk.......",
+        ".......kk.......",
+        ".......kk.......",
+        "...kkkkkkkkkk...",
+        "..kggggggggggk..",
+        "..kgyyggggddgk..",
+        "..kgyyggggddgk..",
+        "..kkkkkkkkkkkk..",
+        "................",
+        "................",
+        "................",
+    ],
+    // 剧场（幕布 + 星）
+    theater: [
+        "................",
+        ".kkkkkkkkkkkkkk.",
+        ".krrrrrrrrrrrrk.",
+        ".krrrknnnnkrrrk.",
+        ".krrknnnnnnkrrk.",
+        ".krrknnnnnnkrrk.",
+        ".krrknnyynnkrrk.",
+        ".krrknnyynnkrrk.",
+        ".krrknnnnnnkrrk.",
+        ".krrknnnnnnkrrk.",
+        ".kkkkkkkkkkkkkk.",
+        "................",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    // 拼图块
+    plugin: [
+        "................",
+        "......kkkk......",
+        "......kcck......",
+        "..kkkkkcckkkkk..",
+        "..kcccccccccck..",
+        "..kcccccccccck..",
+        "..kcccccccccck..",
+        "..kcccccccccck..",
+        "..kcccccccccck..",
+        "..kcccccccccck..",
+        "..kkkkkkkkkkkk..",
+        "................",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+};
+
+function renderGrid(grid: PixelGrid, size: number, className?: string) {
+    const rects: React.ReactNode[] = [];
+    grid.forEach((row, y) => {
+        // 同色连续像素合并成一个 rect，减少节点数
+        let x = 0;
+        while (x < row.length) {
+            const ch = row[x];
+            if (ch === "." || !PALETTE[ch]) { x++; continue; }
+            let end = x + 1;
+            while (end < row.length && row[end] === ch) end++;
+            rects.push(<rect key={`${x},${y}`} x={x} y={y} width={end - x} height={1} fill={PALETTE[ch]} />);
+            x = end;
+        }
+    });
+    return (
+        <svg viewBox="0 0 16 16" width={size} height={size} className={className} shapeRendering="crispEdges" aria-hidden>
+            {rects}
+        </svg>
+    );
+}
+
+export function DestPixelIcon({ dest, size = 34 }: { dest: ImportDestination; size?: number }) {
+    return renderGrid(DEST_ICONS[dest], size);
+}

--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -30,6 +30,7 @@ import {
     uploadResource,
     type ResourceHubUploadConfig,
 } from "@/lib/resource-hub-upload";
+import { DestPixelIcon } from "@/components/resource-hub/pixel-icons";
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -320,7 +321,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                         <div className="rh-dialog-body rh-dest-grid">
                             {IMPORT_DESTINATIONS.map(dest => (
                                 <button key={dest.key} className="rh-dest-tile" title={dest.hint} onClick={() => handlePickDestination(dest.key)}>
-                                    <span className="rh-dest-tile-icon">{dest.icon}</span>
+                                    <DestPixelIcon dest={dest.key} />
                                     <span className="rh-dest-tile-label">{dest.label}</span>
                                 </button>
                             ))}
@@ -736,11 +737,6 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     cursor: pointer;
                 }
                 .rh-dest-tile:active { border-color: #000080; background: #e4ecf7; }
-                .rh-dest-tile-icon {
-                    font-size: 30px;
-                    line-height: 1;
-                    filter: saturate(0.85);
-                }
                 .rh-dest-tile-label {
                     font-size: calc(11px * var(--app-text-scale, 1));
                     color: #000;

--- a/lib/resource-hub-types.ts
+++ b/lib/resource-hub-types.ts
@@ -61,16 +61,16 @@ export type ImportDestination =
     | "theater"
     | "plugin";
 
-export const IMPORT_DESTINATIONS: Array<{ key: ImportDestination; label: string; hint: string; icon: string }> = [
-    { key: "preset", label: "预设", hint: "预设管理页导出的 JSON", icon: "🎛️" },
-    { key: "regex", label: "正则", hint: "正则管理页导出的 JSON", icon: "✂️" },
-    { key: "worldbook", label: "世界书", hint: "世界书管理页导出的 JSON", icon: "📖" },
-    { key: "character", label: "角色卡", hint: "角色卡 JSON 或 PNG", icon: "🎴" },
-    { key: "chat_session_css", label: "聊天室CSS", hint: "需选择应用到哪个角色", icon: "💬" },
-    { key: "chat_app_css", label: "聊天主页CSS", hint: "应用到聊天主页", icon: "📱" },
-    { key: "global_css", label: "全局CSS", hint: "应用到外观页全局样式", icon: "🎨" },
-    { key: "custom_app", label: "应用", hint: "应用市场 zip 安装包或单 HTML", icon: "📦" },
-    { key: "game", label: "游戏", hint: "游戏草稿箱导出的 JSON", icon: "🕹️" },
-    { key: "theater", label: "黑市剧场", hint: "剧场草稿箱导出的 JSON", icon: "🎭" },
-    { key: "plugin", label: "插件", hint: "聊天插件 JS 源码文件", icon: "🧩" },
+export const IMPORT_DESTINATIONS: Array<{ key: ImportDestination; label: string; hint: string }> = [
+    { key: "preset", label: "预设", hint: "预设管理页导出的 JSON" },
+    { key: "regex", label: "正则", hint: "正则管理页导出的 JSON" },
+    { key: "worldbook", label: "世界书", hint: "世界书管理页导出的 JSON" },
+    { key: "character", label: "角色卡", hint: "角色卡 JSON 或 PNG" },
+    { key: "chat_session_css", label: "聊天室CSS", hint: "需选择应用到哪个角色" },
+    { key: "chat_app_css", label: "聊天主页CSS", hint: "应用到聊天主页" },
+    { key: "global_css", label: "全局CSS", hint: "应用到外观页全局样式" },
+    { key: "custom_app", label: "应用", hint: "应用市场 zip 安装包或单 HTML" },
+    { key: "game", label: "游戏", hint: "游戏草稿箱导出的 JSON" },
+    { key: "theater", label: "黑市剧场", hint: "剧场草稿箱导出的 JSON" },
+    { key: "plugin", label: "插件", hint: "聊天插件 JS 源码文件" },
 ];


### PR DESCRIPTION
11 个导入目的地图标以 16×16 像素网格手绘（Win98 配色），渲染为 crispEdges SVG，零图片资源。首页文件夹与列表图标保持原样。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_