### PR TITLE
资源集市：详情页改为图文区 + 横滑文件条布局

### DIFF
--- a/components/resource-hub/pixel-icons.tsx
+++ b/components/resource-hub/pixel-icons.tsx
@@ -260,3 +260,68 @@ function renderGrid(grid: PixelGrid, size: number, className?: string) {
 export function DestPixelIcon({ dest, size = 34 }: { dest: ImportDestination; size?: number }) {
     return renderGrid(DEST_ICONS[dest], size);
 }
+
+// ── 按扩展名生成的文件图标（详情页文件条用）──
+// 统一的"折角文档"底版，"a" 为类型强调色（内容线条区）。
+
+const FILE_DOC_TEMPLATE: PixelGrid = [
+    "................",
+    "...kkkkkkkk.....",
+    "...kwwwwwwkk....",
+    "...kwwwwwwkwk...",
+    "...kwwwwwwkkkk..",
+    "...kwaaaawwwwk..",
+    "...kwwwwwwwwwk..",
+    "...kwaaaaaawwk..",
+    "...kwwwwwwwwwk..",
+    "...kwaaaaaawwk..",
+    "...kwwwwwwwwwk..",
+    "...kwaaaawwwwk..",
+    "...kwwwwwwwwwk..",
+    "...kkkkkkkkkkk..",
+    "................",
+    "................",
+];
+
+const FILE_TYPE_COLORS: Record<string, string> = {
+    zip: "#c88030",
+    json: "#4868d8",
+    txt: "#7a7a7a",
+    css: "#b868d0",
+    js: "#d8a828",
+    mjs: "#d8a828",
+    html: "#d84848",
+    htm: "#d84848",
+    png: "#38a8a0",
+    jpg: "#38a8a0",
+    jpeg: "#38a8a0",
+    webp: "#38a8a0",
+    gif: "#38a8a0",
+};
+
+export function fileExtension(filename: string): string {
+    const match = /\.([A-Za-z0-9]+)$/.exec(filename);
+    return match ? match[1].toLowerCase() : "";
+}
+
+export function FileTypePixelIcon({ filename, size = 34 }: { filename: string; size?: number }) {
+    const accent = FILE_TYPE_COLORS[fileExtension(filename)] || "#7a7a7a";
+    const rects: React.ReactNode[] = [];
+    FILE_DOC_TEMPLATE.forEach((row, y) => {
+        let x = 0;
+        while (x < row.length) {
+            const ch = row[x];
+            const fill = ch === "a" ? accent : PALETTE[ch];
+            if (!fill) { x++; continue; }
+            let end = x + 1;
+            while (end < row.length && row[end] === ch) end++;
+            rects.push(<rect key={`${x},${y}`} x={x} y={y} width={end - x} height={1} fill={fill} />);
+            x = end;
+        }
+    });
+    return (
+        <svg viewBox="0 0 16 16" width={size} height={size} shapeRendering="crispEdges" aria-hidden>
+            {rects}
+        </svg>
+    );
+}

--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -30,7 +30,7 @@ import {
     uploadResource,
     type ResourceHubUploadConfig,
 } from "@/lib/resource-hub-upload";
-import { DestPixelIcon } from "@/components/resource-hub/pixel-icons";
+import { DestPixelIcon, FileTypePixelIcon, fileExtension } from "@/components/resource-hub/pixel-icons";
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -49,6 +49,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     const [loadError, setLoadError] = useState("");
     const [activeFolder, setActiveFolder] = useState<string | null>(null);
     const [activeEntry, setActiveEntry] = useState<ShareIndexEntry | null>(null);
+    const [selectedFile, setSelectedFile] = useState<string | null>(null);
     const [busyFile, setBusyFile] = useState<string | null>(null);
     // 导入流程：选文件 → 选目的地 →（聊天室CSS再选角色）
     const [importFile, setImportFile] = useState<string | null>(null);
@@ -193,7 +194,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                 </div>
 
                 {/* 内容区 */}
-                <div className="rh-body">
+                <div className={`rh-body${activeEntry ? " rh-body-detail" : ""}`}>
                     {loadState === "loading" && <div className="rh-center-hint">正在读取目录，请稍候...</div>}
 
                     {loadState === "error" && (
@@ -226,7 +227,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                         folderEntries.length > 0 ? (
                             <div className="rh-entry-list">
                                 {folderEntries.map(entry => (
-                                    <button key={entry.path} className="rh-entry" onClick={() => setActiveEntry(entry)}>
+                                    <button key={entry.path} className="rh-entry" onClick={() => { setActiveEntry(entry); setSelectedFile(entry.files[0] ?? null); }}>
                                         {entry.images.length > 0 ? (
                                             // eslint-disable-next-line @next/next/no-img-element
                                             <img className="rh-entry-thumb" src={resolveResourceHubAssetUrl(source, entry.images[0])} alt="" loading="lazy" />
@@ -248,30 +249,49 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                         )
                     )}
 
-                    {/* 资源详情页 */}
+                    {/* 资源详情页：上=图文内容区，下=横滑文件条 + 操作按钮 */}
                     {loadState === "ready" && activeEntry && (
-                        <div className="rh-detail">
-                            {activeEntry.images.length > 0 && (
-                                <div className="rh-detail-images">
-                                    {activeEntry.images.map(img => (
-                                        // eslint-disable-next-line @next/next/no-img-element
-                                        <img key={img} src={resolveResourceHubAssetUrl(source, img)} alt="" loading="lazy" />
-                                    ))}
-                                </div>
-                            )}
-                            {activeEntry.description && <div className="rh-detail-desc">{activeEntry.description}</div>}
-                            <div className="rh-detail-files-title">文件列表</div>
-                            {activeEntry.files.length > 0 ? activeEntry.files.map(file => (
-                                <div key={file} className="rh-file-row">
-                                    <span className="rh-file-name">📎 {file.split("/").pop()}</span>
-                                    <span className="rh-file-actions">
-                                        <button className="rh-btn" disabled={busyFile === file} onClick={() => handleDownload(file)}>下载</button>
-                                        <button className="rh-btn rh-btn-primary" disabled={busyFile === file} onClick={() => setImportFile(file)}>
-                                            {busyFile === file ? "处理中..." : "导入"}
+                        <div className="rh-detail2">
+                            <div className="rh-detail2-main">
+                                {activeEntry.images.map(img => (
+                                    // eslint-disable-next-line @next/next/no-img-element
+                                    <img key={img} src={resolveResourceHubAssetUrl(source, img)} alt="" loading="lazy" />
+                                ))}
+                                {activeEntry.description
+                                    ? <div className="rh-detail2-desc">{activeEntry.description}</div>
+                                    : activeEntry.images.length === 0 && <div className="rh-detail2-desc rh-detail2-desc-empty">（该资源没有说明文字）</div>}
+                            </div>
+
+                            {activeEntry.files.length > 0 ? (
+                                <>
+                                    <div className="rh-file-strip">
+                                        {activeEntry.files.map(file => {
+                                            const base = file.split("/").pop() || file;
+                                            const ext = fileExtension(base);
+                                            return (
+                                                <button
+                                                    key={file}
+                                                    className="rh-file-tile"
+                                                    data-selected={selectedFile === file ? "1" : undefined}
+                                                    onClick={() => setSelectedFile(file)}
+                                                >
+                                                    <FileTypePixelIcon filename={base} size={36} />
+                                                    <span className="rh-file-tile-ext">{ext ? `.${ext.toUpperCase()}` : "FILE"}</span>
+                                                    <span className="rh-file-tile-name">{base}</span>
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                    <div className="rh-detail2-actions">
+                                        <button className="rh-btn rh-action-half" disabled={!selectedFile || busyFile === selectedFile} onClick={() => selectedFile && handleDownload(selectedFile)}>
+                                            下载
                                         </button>
-                                    </span>
-                                </div>
-                            )) : (
+                                        <button className="rh-btn rh-btn-primary rh-action-half" disabled={!selectedFile || busyFile === selectedFile} onClick={() => selectedFile && setImportFile(selectedFile)}>
+                                            {busyFile === selectedFile ? "处理中..." : "导入"}
+                                        </button>
+                                    </div>
+                                </>
+                            ) : (
                                 <div className="rh-center-hint">该资源没有可下载的文件</div>
                             )}
                         </div>
@@ -630,41 +650,83 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     white-space: pre-line;
                 }
                 .rh-entry-meta { font-size: calc(10px * var(--app-text-scale, 1)); color: #808080; }
-                /* 详情 */
-                .rh-detail { padding: 10px; display: flex; flex-direction: column; gap: 10px; }
-                .rh-detail-images { display: flex; flex-direction: column; gap: 8px; }
-                .rh-detail-images img { max-width: 100%; border: 1px solid #808080; }
-                .rh-detail-desc {
+                /* 详情：上=图文内容区（内部滚动），下=横滑文件条 + 操作按钮（钉底） */
+                .rh-body-detail { overflow: hidden; display: flex; }
+                .rh-detail2 {
+                    flex: 1;
+                    min-height: 0;
+                    display: flex;
+                    flex-direction: column;
+                }
+                .rh-detail2-main {
+                    flex: 1;
+                    min-height: 0;
+                    overflow-y: auto;
+                    padding: 10px;
+                    display: flex;
+                    flex-direction: column;
+                    gap: 10px;
+                }
+                .rh-detail2-main img { max-width: 100%; border: 1px solid #808080; }
+                .rh-detail2-desc {
                     font-size: calc(12px * var(--app-text-scale, 1));
                     line-height: 1.8;
                     white-space: pre-wrap;
                     color: #000;
-                    background: #ffffe1;
-                    border: 1px solid #808080;
-                    padding: 8px 10px;
                 }
-                .rh-detail-files-title {
-                    font-size: calc(12px * var(--app-text-scale, 1));
-                    font-weight: 700;
-                    border-bottom: 1px solid #808080;
-                    padding-bottom: 3px;
-                }
-                .rh-file-row {
+                .rh-detail2-desc-empty { color: #808080; }
+                .rh-file-strip {
+                    flex-shrink: 0;
                     display: flex;
-                    align-items: center;
-                    gap: 8px;
-                    justify-content: space-between;
-                    padding: 4px 0;
+                    gap: 6px;
+                    overflow-x: auto;
+                    padding: 8px;
+                    background: #c0c0c0;
+                    border-top: 2px solid;
+                    border-color: #808080 transparent transparent transparent;
+                    box-shadow: inset 0 1px 0 #404040;
                 }
-                .rh-file-name {
-                    flex: 1;
-                    min-width: 0;
-                    font-size: calc(12px * var(--app-text-scale, 1));
+                .rh-file-tile {
+                    flex-shrink: 0;
+                    width: 84px;
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                    gap: 2px;
+                    padding: 7px 4px 5px;
+                    background: #fff;
+                    border: 2px solid;
+                    border-color: #ffffff #404040 #404040 #ffffff;
+                    cursor: pointer;
+                }
+                .rh-file-tile[data-selected] {
+                    border-color: #000080;
+                    background: #e4ecf7;
+                    outline: 1px solid #000080;
+                }
+                .rh-file-tile-ext {
+                    font-size: calc(9px * var(--app-text-scale, 1));
+                    font-weight: 700;
+                    color: #000080;
+                    letter-spacing: 0.04em;
+                }
+                .rh-file-tile-name {
+                    max-width: 100%;
+                    font-size: calc(10px * var(--app-text-scale, 1));
+                    color: #000;
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
                 }
-                .rh-file-actions { display: flex; gap: 6px; flex-shrink: 0; }
+                .rh-detail2-actions {
+                    flex-shrink: 0;
+                    display: flex;
+                    gap: 8px;
+                    padding: 8px;
+                    background: #c0c0c0;
+                    border-top: 1px solid #fff;
+                }
+                .rh-action-half { flex: 1; padding: 8px 0; }
                 .rh-statusbar {
                     display: flex;
                     justify-content: space-between;


### PR DESCRIPTION
详情页重构：上方内部滚动的图文内容区（无图时纯文字），下方钉底横滑文件条 —— 按扩展名显示配色像素文档图标 + 扩展名徽标 + 文件名，点选高亮（默认选第一个），底部「下载 / 导入」半宽大按钮作用于选中文件。pixel-icons 新增 FileTypePixelIcon。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_