### PR TITLE
资源集市：详情页图片限宽限高

### DIFF
--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -667,7 +667,14 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     flex-direction: column;
                     gap: 10px;
                 }
-                .rh-detail2-main img { max-width: 100%; border: 1px solid #808080; }
+                .rh-detail2-main img {
+                    max-width: min(220px, 62%);
+                    max-height: 240px;
+                    width: auto;
+                    height: auto;
+                    align-self: flex-start;
+                    border: 1px solid #808080;
+                }
                 .rh-detail2-desc {
                     font-size: calc(12px * var(--app-text-scale, 1));
                     line-height: 1.8;


### PR DESCRIPTION
图片从占满整行改为 `max-width: min(220px, 62%)`、`max-height: 240px`，竖图不再显得过大。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_