### PR TITLE
资源集市：详情页图片水平居中

### DIFF
--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -672,7 +672,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     max-height: 240px;
                     width: auto;
                     height: auto;
-                    align-self: flex-start;
+                    align-self: center;
                     border: 1px solid #808080;
                 }
                 .rh-detail2-desc {


### PR DESCRIPTION
详情页图片 `align-self` 从 flex-start 改为 center。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_