### PR TITLE
资源集市：投稿者自助删除 + 资源集中 资源/ 目录 + 刷新强刷 CDN

### DIFF
--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -13,6 +13,7 @@ import {
     fetchShareIndex,
     importResourceHubFile,
     loadResourceHubSource,
+    purgeShareIndexCache,
     resolveResourceHubAssetUrl,
     saveResourceHubSource,
 } from "@/lib/resource-hub-client";
@@ -25,7 +26,9 @@ import {
 } from "@/lib/resource-hub-types";
 import {
     fileToUploadEntry,
+    loadMyUploads,
     loadUploadConfig,
+    ownerDeleteViaService,
     saveUploadConfig,
     uploadResource,
     type ResourceHubUploadConfig,
@@ -72,15 +75,22 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     const [uploading, setUploading] = useState(false);
     const [uploadCfg, setUploadCfg] = useState<ResourceHubUploadConfig>(() => loadUploadConfig());
 
-    const reload = useCallback((activeSource: ResourceHubSource) => {
+    const reload = useCallback((activeSource: ResourceHubSource, options?: { purge?: boolean }) => {
         setLoadState("loading");
         setLoadError("");
-        fetchShareIndex(activeSource)
+        const run = () => fetchShareIndex(activeSource)
             .then(data => { setIndex(data); setLoadState("ready"); })
             .catch(err => {
                 setLoadError(err instanceof Error ? err.message : String(err));
                 setLoadState("error");
             });
+        if (options?.purge) {
+            // 手动刷新时先强刷 CDN，让新上架的资源尽快可见
+            purgeShareIndexCache(activeSource);
+            setTimeout(run, 1500);
+        } else {
+            void run();
+        }
     }, []);
 
     useEffect(() => { reload(source); }, [reload, source]);
@@ -154,7 +164,13 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     const handleDeleteEntry = useCallback(async (entry: ShareIndexEntry) => {
         setDeleting(true);
         try {
-            await deleteShareEntry(entry.path);
+            // 本人上传的用删除凭证走上传服务；否则按管理员 Token 直删
+            const myRecord = loadMyUploads().find(r => r.path === entry.path);
+            if (myRecord) {
+                await ownerDeleteViaService(loadUploadConfig().endpoint, myRecord);
+            } else {
+                await deleteShareEntry(entry.path);
+            }
             setConfirmDeleteEntry(null);
             setActiveEntry(null);
             // 乐观更新本地目录，CDN 缓存刷新前列表就正确
@@ -231,7 +247,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     <span className="rh-titlebar-text">{title} - 资源集市</span>
                     <span className="rh-titlebar-controls">
                         <button className="rh-tb-btn" aria-label="资源仓库设置" onClick={() => { setSourceDraft(source); setShowSourceEditor(true); }}>⚙</button>
-                        <button className="rh-tb-btn" aria-label="刷新" onClick={() => reload(source)}>⟳</button>
+                        <button className="rh-tb-btn" aria-label="刷新" onClick={() => reload(source, { purge: true })}>⟳</button>
                         <button className="rh-tb-btn" aria-label="关闭" onClick={onClose}>✕</button>
                     </span>
                 </div>
@@ -351,7 +367,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                         <button className="rh-btn rh-btn-primary rh-action-half" disabled={!selectedFile || busyFile === selectedFile} onClick={() => selectedFile && setImportFile(selectedFile)}>
                                             {busyFile === selectedFile ? "处理中..." : "导入"}
                                         </button>
-                                        {uploadCfg.githubToken.trim() && (
+                                        {(uploadCfg.githubToken.trim() || loadMyUploads().some(r => r.path === activeEntry.path)) && (
                                             <button className="rh-btn rh-action-del" onClick={() => setConfirmDeleteEntry(activeEntry)}>删除</button>
                                         )}
                                     </div>

--- a/lib/resource-hub-client.ts
+++ b/lib/resource-hub-client.ts
@@ -154,30 +154,36 @@ function stripHiddenFolders(index: ShareIndex): ShareIndex {
     };
 }
 
+/** 资源统一存放的仓库根目录 */
+export const RESOURCE_ROOT = "资源";
+
 /** 兜底：_index.json 不可用时，用 jsDelivr data API 的文件树现场构建索引（无时间与说明）。 */
 async function buildIndexFromTree(source: ResourceHubSource): Promise<ShareIndex> {
     const { owner, repo, branch } = source;
     const res = await fetchWithTimeout(`https://data.jsdelivr.com/v1/packages/gh/${owner}/${repo}@${branch}?structure=flat`);
     if (!res.ok) throw new Error(`文件树获取失败（HTTP ${res.status}）`);
     const data = await res.json() as { files?: Array<{ name?: string }> };
+    // 只认 资源/ 下的内容：资源/<分类>/<资源子文件夹或孤立文件>
     const paths = (data.files ?? [])
         .map(f => (f.name || "").replace(/^\/+/, ""))
-        .filter(p => p && !p.startsWith(".") && !p.startsWith("_") && !p.startsWith("scripts/"));
+        .filter(p => p.startsWith(`${RESOURCE_ROOT}/`));
 
     const folderMap = new Map<string, Map<string, ShareIndexEntry>>();
     for (const p of paths) {
         const segments = p.split("/");
-        if (segments.length < 2) continue; // 根目录孤立文件不算资源
-        const folder = segments[0];
-        if (folder.startsWith(".")) continue;
+        if (segments.length < 3) continue; // 资源/ 下的孤立文件不算资源
+        const folder = segments[1];
+        if (!folder || folder.startsWith(".") || HIDDEN_FOLDERS.has(folder)) continue;
+        const base = segments[segments.length - 1];
+        if (base.startsWith(".")) continue; // .owner 等隐藏文件
         if (!folderMap.has(folder)) folderMap.set(folder, new Map());
         const entryMap = folderMap.get(folder)!;
-        if (segments.length === 2) {
+        if (segments.length === 3) {
             // 孤立文件式资源
             const key = `file:${p}`;
             entryMap.set(key, {
                 folder,
-                name: segments[1].replace(/\.[^.]+$/, ""),
+                name: segments[2].replace(/\.[^.]+$/, ""),
                 type: "file",
                 path: p,
                 files: [p],
@@ -186,13 +192,13 @@ async function buildIndexFromTree(source: ResourceHubSource): Promise<ShareIndex
                 updatedAt: null,
             });
         } else {
-            // 子文件夹式资源（取第二层为资源名，深层文件归并进来）
-            const entryPath = `${segments[0]}/${segments[1]}`;
+            // 子文件夹式资源（取第三层为资源名，深层文件归并进来）
+            const entryPath = `${segments[0]}/${segments[1]}/${segments[2]}`;
             const key = `dir:${entryPath}`;
             if (!entryMap.has(key)) {
                 entryMap.set(key, {
                     folder,
-                    name: segments[1],
+                    name: segments[2],
                     type: "dir",
                     path: entryPath,
                     files: [],
@@ -202,7 +208,6 @@ async function buildIndexFromTree(source: ResourceHubSource): Promise<ShareIndex
                 });
             }
             const entry = entryMap.get(key)!;
-            const base = segments[segments.length - 1];
             if (IMAGE_RE.test(base)) entry.images.push(p);
             else if (!DESC_NAME_RE.test(base)) entry.files.push(p);
         }
@@ -215,6 +220,13 @@ async function buildIndexFromTree(source: ResourceHubSource): Promise<ShareIndex
         entries.push(...entryMap.values());
     }
     return { schema: "ai_phone_share_index", schemaVersion: 0, folders, entries };
+}
+
+/** 强刷 CDN 缓存（fire-and-forget；no-cors 下拿不到响应但清缓存已生效）。 */
+export function purgeShareIndexCache(source: ResourceHubSource): void {
+    if (typeof fetch === "undefined") return;
+    const url = `https://purge.jsdelivr.net/gh/${source.owner}/${source.repo}@${source.branch}/_index.json`;
+    fetch(url, { mode: "no-cors" }).catch(() => { /* 尽力而为 */ });
 }
 
 export async function fetchShareIndex(source: ResourceHubSource): Promise<ShareIndex> {

--- a/lib/resource-hub-review.ts
+++ b/lib/resource-hub-review.ts
@@ -3,7 +3,7 @@
 // 在应用内预览与通过/拒绝。前端直连 GitHub API，权限由 GitHub 服务端裁决——
 // token 没有仓库写权限时合并/关闭会被 403，界面伪造无意义。
 
-import { loadResourceHubSource } from "./resource-hub-client";
+import { loadResourceHubSource, purgeShareIndexCache } from "./resource-hub-client";
 import { loadUploadConfig } from "./resource-hub-upload";
 
 const GH_API = "https://api.github.com";
@@ -107,10 +107,13 @@ export async function fetchShareSubmissionFiles(prNumber: number): Promise<Share
     return result;
 }
 
-/** 通过并上架（合并 PR）。 */
+/** 通过并上架（合并 PR），并强刷索引的 CDN 缓存让新资源尽快可见。 */
 export async function approveShareSubmission(prNumber: number): Promise<void> {
     const { token, owner, repo } = getReviewAuth();
     await gh(token, "PUT", `/repos/${owner}/${repo}/pulls/${prNumber}/merge`, { merge_method: "merge" });
+    // 索引由资源仓库的 Actions 在合并后重建（约 1 分钟），这里先把 CDN 缓存清掉
+    setTimeout(() => purgeShareIndexCache(loadResourceHubSource()), 90_000);
+    purgeShareIndexCache(loadResourceHubSource());
 }
 
 /**

--- a/lib/resource-hub-upload.ts
+++ b/lib/resource-hub-upload.ts
@@ -6,10 +6,13 @@
 //     由机器人 token 代开 PR。
 
 import { kvGet, kvSet, registerKvMigration } from "./kv-db";
+import { RESOURCE_ROOT } from "./resource-hub-client";
 import type { ResourceHubSource } from "./resource-hub-types";
 
 const UPLOAD_CFG_KEY = "ai_phone_resource_hub_upload_cfg_v1";
+const MY_UPLOADS_KEY = "ai_phone_resource_hub_my_uploads_v1";
 registerKvMigration(UPLOAD_CFG_KEY);
+registerKvMigration(MY_UPLOADS_KEY);
 
 export const DEFAULT_UPLOAD_ENDPOINT = "https://floatshare.netlify.app/.netlify/functions/upload";
 
@@ -58,6 +61,48 @@ export type UploadResult = {
     prUrl?: string;
 };
 
+// ── 我的上传记录（含自助删除凭证，只存在本机）──
+
+export type MyUploadRecord = {
+    /** 仓库内路径：资源/<分类>/<资源名> */
+    path: string;
+    name: string;
+    /** 自助删除凭证（哈希已随投稿写进仓库 .owner，凭证本体只在本机） */
+    ownerKey: string;
+    uploadedAt: string;
+};
+
+export function loadMyUploads(): MyUploadRecord[] {
+    try {
+        const raw = kvGet(MY_UPLOADS_KEY);
+        const parsed = raw ? JSON.parse(raw) as MyUploadRecord[] : [];
+        return Array.isArray(parsed) ? parsed.filter(r => r && typeof r.path === "string" && typeof r.ownerKey === "string") : [];
+    } catch { return []; }
+}
+
+function saveMyUploads(records: MyUploadRecord[]): void {
+    kvSet(MY_UPLOADS_KEY, JSON.stringify(records.slice(0, 200)));
+}
+
+function recordMyUpload(record: MyUploadRecord): void {
+    saveMyUploads([record, ...loadMyUploads().filter(r => r.path !== record.path)]);
+}
+
+export function removeMyUploadRecord(path: string): void {
+    saveMyUploads(loadMyUploads().filter(r => r.path !== path));
+}
+
+function generateOwnerKey(): string {
+    const bytes = new Uint8Array(24);
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes, b => b.toString(16).padStart(2, "0")).join("");
+}
+
+async function sha256Hex(text: string): Promise<string> {
+    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+    return Array.from(new Uint8Array(digest), b => b.toString(16).padStart(2, "0")).join("");
+}
+
 export async function fileToUploadEntry(file: File): Promise<UploadPayloadFile> {
     const buffer = await file.arrayBuffer();
     let binary = "";
@@ -72,16 +117,38 @@ export async function fileToUploadEntry(file: File): Promise<UploadPayloadFile> 
 // ── 方案 B：上传服务 ──
 
 export async function uploadViaService(endpoint: string, payload: UploadPayload): Promise<UploadResult> {
+    const ownerKey = generateOwnerKey();
+    const ownerKeyHash = await sha256Hex(ownerKey);
     const res = await fetch(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ ...payload, ownerKeyHash }),
     });
     const data = await res.json().catch(() => ({})) as { ok?: boolean; error?: string; prUrl?: string };
     if (!res.ok || data.ok === false) {
         throw new Error(data.error || `上传服务返回 HTTP ${res.status}`);
     }
+    recordMyUpload({
+        path: `${RESOURCE_ROOT}/${payload.folder}/${payload.name}`,
+        name: payload.name,
+        ownerKey,
+        uploadedAt: new Date().toISOString(),
+    });
     return { merged: false, prUrl: data.prUrl };
+}
+
+/** 投稿者自助下架：把本机保存的删除凭证发给上传服务比对后删除。 */
+export async function ownerDeleteViaService(endpoint: string, record: MyUploadRecord): Promise<void> {
+    const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "delete", path: record.path, ownerKey: record.ownerKey }),
+    });
+    const data = await res.json().catch(() => ({})) as { ok?: boolean; error?: string };
+    if (!res.ok || data.ok === false) {
+        throw new Error(data.error || `删除服务返回 HTTP ${res.status}`);
+    }
+    removeMyUploadRecord(record.path);
 }
 
 // ── 方案 A：GitHub Token 直传 ──
@@ -112,7 +179,8 @@ function encodeContentPath(dir: string, file: string): string {
 
 export async function uploadViaToken(token: string, source: ResourceHubSource, payload: UploadPayload): Promise<UploadResult> {
     const { owner, repo, branch } = source;
-    const dir = `${payload.folder}/${payload.name}`;
+    const dir = `${RESOURCE_ROOT}/${payload.folder}/${payload.name}`;
+    const ownerKey = generateOwnerKey();
     const toWrite: UploadPayloadFile[] = [...payload.files];
     if (payload.description.trim()) {
         toWrite.push({
@@ -120,6 +188,8 @@ export async function uploadViaToken(token: string, source: ResourceHubSource, p
             contentBase64: btoa(unescape(encodeURIComponent(payload.description.trim()))),
         });
     }
+    // 删除凭证哈希写进资源文件夹，凭证本体只留在本机
+    toWrite.push({ name: ".owner", contentBase64: btoa(await sha256Hex(ownerKey)) });
 
     // 有写权限（仓库主/协作者）→ 直接提交默认分支，立即上架
     const repoInfo = await gh<{ permissions?: { push?: boolean } }>(token, "GET", `/repos/${owner}/${repo}`);
@@ -131,6 +201,7 @@ export async function uploadViaToken(token: string, source: ResourceHubSource, p
                 branch,
             });
         }
+        recordMyUpload({ path: dir, name: payload.name, ownerKey, uploadedAt: new Date().toISOString() });
         return { merged: true };
     }
 
@@ -171,6 +242,7 @@ export async function uploadViaToken(token: string, source: ResourceHubSource, p
         base: branch,
         body: `来自资源集市 App 的投稿。\n\n- 分类：${payload.folder}\n- 名称：${payload.name}\n- 投稿人：${payload.author || me.login}${payload.description.trim() ? `\n\n${payload.description.trim()}` : ""}`,
     });
+    recordMyUpload({ path: dir, name: payload.name, ownerKey, uploadedAt: new Date().toISOString() });
     return { merged: false, prUrl: pr.html_url };
 }
 


### PR DESCRIPTION
1. **投稿者自助删除**：上传时客户端生成删除凭证（哈希写入资源文件夹 `.owner`，凭证本体只在投稿者设备），详情页对"我的上传"显示删除按钮，经上传服务哈希比对后由机器人下架；错误凭证 403
2. **资源集中**：仓库结构改为 `资源/<分类>/<资源>`，与服务代码彻底分开（share 仓库已迁移）
3. **刷新强刷 CDN**：刷新按钮与审核通过后自动 purge jsDelivr 缓存，新资源尽快可见

真实环境端到端验证：上传→merge→错误凭证被拒→正确凭证删除→仓库确认文件消失。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_