### PR TITLE
资源集市：送花系统 + 像素贴纸与正文排版

### DIFF
--- a/components/resource-hub/pixel-stickers.tsx
+++ b/components/resource-hub/pixel-stickers.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+// 资源集市像素贴纸：16×16 手绘网格 → 锐边 SVG，标题/正文里用 [花] 这类标记引用。
+// 与 pixel-icons 同一渲染思路，但配色更丰富（贴纸要可爱）。
+// 注意：贴纸经常出现在白底上，不要画纯白的主体。
+
+const PALETTE: Record<string, string> = {
+    k: "#1a1a1a", // 黑
+    w: "#ffffff", // 白（只做高光）
+    l: "#c6c6c6", // 浅灰
+    d: "#7a7a7a", // 深灰
+    r: "#d84848", // 红
+    p: "#f088b0", // 粉
+    P: "#d84890", // 深粉
+    y: "#f8d838", // 黄
+    o: "#e89028", // 橙
+    g: "#48a838", // 绿
+    b: "#4868d8", // 蓝
+    s: "#78b8e8", // 天蓝
+    t: "#e8c890", // 米
+    n: "#8a5828", // 棕
+};
+
+type PixelGrid = string[];
+
+export const STICKERS: Record<string, PixelGrid> = {
+    花: [
+        "................",
+        "................",
+        "......pppp......",
+        "......pppp......",
+        "..pp..yyyy..pp..",
+        "..ppppyyyypppp..",
+        "..ppppyyyypppp..",
+        "..pp..yyyy..pp..",
+        "......pppp......",
+        "......pppp......",
+        ".......gg.......",
+        ".......gg.g.....",
+        ".......gggg.....",
+        ".......gg.......",
+        "................",
+        "................",
+    ],
+    爱心: [
+        "................",
+        "................",
+        "................",
+        "..rrrr..rrrr....",
+        ".rrrrrrrrrrrr...",
+        ".rwwrrrrrrrrr...",
+        ".rwrrrrrrrrrr...",
+        "..rrrrrrrrrr....",
+        "...rrrrrrrr.....",
+        "....rrrrrr......",
+        ".....rrrr.......",
+        "......rr........",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    星星: [
+        "................",
+        "................",
+        ".......yy.......",
+        ".......yy.......",
+        "......yyyy......",
+        "......yyyy......",
+        ".yyyyyyyyyyyyyy.",
+        "..yyyyyyyyyyyy..",
+        "....yyyyyyyy....",
+        ".....yyyyyy.....",
+        "....yyy..yyy....",
+        "...yyy....yyy...",
+        "...yy......yy...",
+        "................",
+        "................",
+        "................",
+    ],
+    笑脸: [
+        "................",
+        "................",
+        ".....yyyyyy.....",
+        "....yyyyyyyy....",
+        "...yyyyyyyyyy...",
+        "..yyyyyyyyyyyy..",
+        "..yykkyyyykkyy..",
+        "..yykkyyyykkyy..",
+        "..yyyyyyyyyyyy..",
+        "..yykyyyyyykyy..",
+        "...yykkkkkkyy...",
+        "...yyyyyyyyyy...",
+        "....yyyyyyyy....",
+        ".....yyyyyy.....",
+        "................",
+        "................",
+    ],
+    小猫: [
+        "................",
+        "................",
+        "..oo........oo..",
+        "..ooo......ooo..",
+        "..oooooooooooo..",
+        "..oooooooooooo..",
+        "..ookkoooookkoo.",
+        "..oooooooooooo..",
+        "..oooooppooooo..",
+        "..oooooooooooo..",
+        "...oooooooooo...",
+        "................",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    音符: [
+        "................",
+        "................",
+        "....bbbbbbbb....",
+        "....bbbbbbbb....",
+        "....bb....bb....",
+        "....bb....bb....",
+        "....bb....bb....",
+        "....bb....bb....",
+        "..bbbb..bbbb....",
+        ".bbbbbb.bbbbbb..",
+        "..bbbb..bbbb....",
+        "................",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    闪光: [
+        "................",
+        "................",
+        ".......yy.......",
+        ".......yy.......",
+        "......yyyy......",
+        "..y..yyyyyy..y..",
+        ".yyyyyywwyyyyyy.",
+        "..y..yyyyyy..y..",
+        "......yyyy......",
+        ".......yy.......",
+        ".......yy.......",
+        "................",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    彩虹: [
+        "................",
+        "................",
+        "................",
+        "................",
+        "....rrrrrrrr....",
+        "..rrrrrrrrrrrr..",
+        "..rryyyyyyyyrr..",
+        ".rryyyyyyyyyyrr.",
+        ".ryyggggggggyyr.",
+        ".ryyggbbbbggyyr.",
+        ".ryggbb..bbggyr.",
+        ".ryggbb..bbggyr.",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    蝴蝶结: [
+        "................",
+        "................",
+        "................",
+        "................",
+        "..pp........pp..",
+        ".pppp......pppp.",
+        ".pppppp..pppppp.",
+        ".pppppppppppppp.",
+        ".ppppppPPpppppp.",
+        ".pppppppppppppp.",
+        ".pppppp..pppppp.",
+        ".pppp......pppp.",
+        "..pp........pp..",
+        "................",
+        "................",
+        "................",
+    ],
+    樱桃: [
+        "................",
+        "................",
+        ".......gg.......",
+        "......ggg.......",
+        ".....gg.gg......",
+        "....gg...gg.....",
+        "..rrrr...rrrr...",
+        ".rrrrrr.rrrrrr..",
+        ".rwrrrr.rwrrrr..",
+        ".rrrrrr.rrrrrr..",
+        "..rrrr...rrrr...",
+        "................",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    月亮: [
+        "................",
+        "................",
+        ".....yyyy.......",
+        "....yyyyyy......",
+        "...yyyy.....y...",
+        "..yyyy..........",
+        "..yyy...........",
+        "..yyy...........",
+        "..yyy...........",
+        "..yyyy..........",
+        "...yyyy.........",
+        "....yyyyyy......",
+        ".....yyyy.......",
+        "................",
+        "................",
+        "................",
+    ],
+    太阳: [
+        "................",
+        ".......yy.......",
+        "..y....yy....y..",
+        "...y..yyyy..y...",
+        "....yyyyyyyy....",
+        "....yyyyyyyy....",
+        ".yy.yyyyyyyy.yy.",
+        "....yyyyyyyy....",
+        "....yyyyyyyy....",
+        "...y..yyyy..y...",
+        "..y....yy....y..",
+        ".......yy.......",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    雪花: [
+        "................",
+        "................",
+        ".......ss.......",
+        "...s...ss...s...",
+        "....s..ss..s....",
+        ".....s.ss.s.....",
+        ".......ss.......",
+        ".ssssssssssssss.",
+        ".....s.ss.s.....",
+        "....s..ss..s....",
+        "...s...ss...s...",
+        ".......ss.......",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+    蘑菇: [
+        "................",
+        "................",
+        "................",
+        ".....rrrrrr.....",
+        "...rrrrrrrrrr...",
+        "..rrwwrrrrwwrr..",
+        "..rrwwrrrrwwrr..",
+        ".rrrrrrrrrrrrrr.",
+        ".rrrrrwwrrrrrrr.",
+        "....tttttttt....",
+        "....tttttttt....",
+        "....tttttttt....",
+        "...tttttttttt...",
+        "................",
+        "................",
+        "................",
+    ],
+    幽灵: [
+        "................",
+        "................",
+        "................",
+        ".....ssssss.....",
+        "....ssssssss....",
+        "...ssssssssss...",
+        "...skkssssskks..",  // 眼睛
+        "...skkssssskks..",
+        "...ssssssssss...",
+        "...ssssssssss...",
+        "...ssssssssss...",
+        "...ssssssssss...",
+        "...ss.ss.ss.s...",
+        "................",
+        "................",
+        "................",
+    ],
+    皇冠: [
+        "................",
+        "................",
+        "................",
+        "................",
+        "..yy...yy...yy..",
+        "..yy...yy...yy..",
+        "..yyy.yyyy.yyy..",
+        "..yyyyyyyyyyyy..",
+        "..yyyyyyyyyyyy..",
+        "..yyrryyyyrryy..",
+        "..yyyyyyyyyyyy..",
+        "..oooooooooooo..",
+        "................",
+        "................",
+        "................",
+        "................",
+    ],
+};
+
+export const STICKER_NAMES = Object.keys(STICKERS);
+
+export function isStickerName(name: string): boolean {
+    return Object.prototype.hasOwnProperty.call(STICKERS, name);
+}
+
+function renderGrid(grid: PixelGrid, size: number | string) {
+    const rects: React.ReactNode[] = [];
+    grid.forEach((row, y) => {
+        let x = 0;
+        while (x < row.length) {
+            const ch = row[x];
+            if (ch === "." || !PALETTE[ch]) { x++; continue; }
+            let end = x + 1;
+            while (end < row.length && row[end] === ch) end++;
+            rects.push(<rect key={`${x},${y}`} x={x} y={y} width={end - x} height={1} fill={PALETTE[ch]} />);
+            x = end;
+        }
+    });
+    return (
+        <svg viewBox="0 0 16 16" width={size} height={size} shapeRendering="crispEdges" aria-hidden
+            style={{ display: "inline-block", verticalAlign: "-0.22em" }}>
+            {rects}
+        </svg>
+    );
+}
+
+/** 独立贴纸（选择器等处用，size 为像素数） */
+export function StickerPixelIcon({ name, size = 24 }: { name: string; size?: number }) {
+    const grid = STICKERS[name];
+    return grid ? renderGrid(grid, size) : null;
+}
+
+/** 行内贴纸（跟随文字大小） */
+export function StickerInline({ name, scale = 1.25 }: { name: string; scale?: number }) {
+    const grid = STICKERS[name];
+    return grid ? renderGrid(grid, `${scale}em`) : null;
+}

--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -4,7 +4,7 @@
 // 首页自动显示仓库根目录的文件夹（仿文件管理器），文件夹页为古早论坛式列表，
 // 资源可下载或导入（导入时选择目的地）。整体为复古 Windows 风格。
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { loadCharacters } from "@/lib/character-storage";
 import { loadChatContacts } from "@/lib/chat-storage";
 import {
@@ -36,6 +36,9 @@ import {
 import { DestPixelIcon, FileTypePixelIcon, fileExtension } from "@/components/resource-hub/pixel-icons";
 import { deleteShareEntry } from "@/lib/resource-hub-review";
 import { MediaPreviewOverlay } from "@/components/chat/media-preview-overlay";
+import { fetchFlowerCounts, hasSentFlowerToday, sendFlower, type FlowerCounts } from "@/lib/resource-hub-flowers";
+import { STICKER_NAMES, StickerPixelIcon } from "@/components/resource-hub/pixel-stickers";
+import { RICH_COLORS, RichText } from "@/components/resource-hub/rich-text";
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -62,6 +65,9 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     const [viewMode, setViewMode] = useState<"market" | "mine">("market");
     // 图片全屏预览（点开可保存）
     const [previewImage, setPreviewImage] = useState<string | null>(null);
+    // 送花：各资源花数（我的货摊展示用）+ 非阻塞小提示
+    const [flowerCounts, setFlowerCounts] = useState<FlowerCounts | null>(null);
+    const [toast, setToast] = useState<string | null>(null);
     const [busyFile, setBusyFile] = useState<string | null>(null);
     // 导入流程：选文件 → 选目的地 →（聊天室CSS再选角色）
     const [importFile, setImportFile] = useState<string | null>(null);
@@ -79,6 +85,32 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     const [uploadImages, setUploadImages] = useState<File[]>([]);
     const [uploading, setUploading] = useState(false);
     const [uploadCfg, setUploadCfg] = useState<ResourceHubUploadConfig>(() => loadUploadConfig());
+    // 排版编辑器：贴纸选择器（标题/正文两处）、颜色面板、实时预览
+    const [stickerPickerFor, setStickerPickerFor] = useState<"title" | "desc" | null>(null);
+    const [showColorPicker, setShowColorPicker] = useState(false);
+    const [showDescPreview, setShowDescPreview] = useState(false);
+    const uploadNameRef = useRef<HTMLInputElement | null>(null);
+    const uploadDescRef = useRef<HTMLTextAreaElement | null>(null);
+
+    // 在光标处插入标记 / 用标记包住选中文字，随后恢复焦点
+    const applyMarkup = useCallback((
+        ref: React.RefObject<HTMLInputElement | HTMLTextAreaElement | null>,
+        setter: (value: string) => void,
+        before: string,
+        after = "",
+    ) => {
+        const el = ref.current;
+        if (!el) return;
+        const start = el.selectionStart ?? el.value.length;
+        const end = el.selectionEnd ?? start;
+        const next = el.value.slice(0, start) + before + el.value.slice(start, end) + after + el.value.slice(end);
+        setter(next);
+        requestAnimationFrame(() => {
+            el.focus();
+            const pos = start + before.length + (end - start) + after.length;
+            el.setSelectionRange(pos, pos);
+        });
+    }, []);
 
     const reload = useCallback((activeSource: ResourceHubSource, options?: { purge?: boolean }) => {
         setLoadState("loading");
@@ -99,6 +131,14 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     }, []);
 
     useEffect(() => { reload(source); }, [reload, source]);
+
+    // 切到我的货摊时拉取花数（仅作者本人可见的统计）
+    useEffect(() => {
+        if (viewMode !== "mine") return;
+        let cancelled = false;
+        void fetchFlowerCounts(source).then(counts => { if (!cancelled) setFlowerCounts(counts); });
+        return () => { cancelled = true; };
+    }, [viewMode, source, index]);
 
     const folderEntries = useMemo(() => {
         if (!index || !activeFolder) return [];
@@ -140,16 +180,30 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
         }));
     }, [pickCharacterFor]);
 
+    const showToast = useCallback((msg: string) => {
+        setToast(msg);
+        window.setTimeout(() => setToast(current => (current === msg ? null : current)), 2600);
+    }, []);
+
+    // 手动送花（详情页按钮）。自动送花复用同一函数。
+    const handleSendFlower = useCallback(async (entryPath: string, silent = false) => {
+        const sent = await sendFlower(loadUploadConfig().endpoint, entryPath);
+        if (sent) showToast("已送出一朵花 🌸");
+        else if (!silent) showToast("今天已经给它送过花啦");
+    }, [showToast]);
+
     const handleDownload = useCallback(async (path: string) => {
         setBusyFile(path);
         try {
             await downloadResourceHubFile(source, path);
+            // 下载成功默认送出一朵花（今天送过则静默跳过，失败不影响下载）
+            if (activeEntry) void handleSendFlower(activeEntry.path, true);
         } catch (err) {
             onNotice?.(`下载失败：${err instanceof Error ? err.message : String(err)}`);
         } finally {
             setBusyFile(null);
         }
-    }, [onNotice, source]);
+    }, [activeEntry, handleSendFlower, onNotice, source]);
 
     const runImport = useCallback(async (path: string, destination: ImportDestination, contactId?: string) => {
         setImportFile(null);
@@ -232,6 +286,29 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
         }
     }, [onNotice, source, uploadAuthor, uploadDesc, uploadFiles, uploadFolder, uploadImages, uploadName]);
 
+    // 贴纸/颜色选择面板（上传弹窗的排版工具栏用）
+    const stickerPanel = (
+        <div className="rh-sticker-panel">
+            {STICKER_NAMES.map(name => (
+                <button key={name} type="button" className="rh-sticker-btn" title={name} onClick={() => {
+                    if (stickerPickerFor === "title") applyMarkup(uploadNameRef, setUploadName, `[${name}]`);
+                    else applyMarkup(uploadDescRef, setUploadDesc, `[${name}]`);
+                    setStickerPickerFor(null);
+                }}>
+                    <StickerPixelIcon name={name} size={24} />
+                </button>
+            ))}
+        </div>
+    );
+    const colorPanel = (
+        <div className="rh-color-panel">
+            {Object.entries(RICH_COLORS).map(([name, hex]) => (
+                <button key={name} type="button" className="rh-color-chip" style={{ background: hex }} title={name}
+                    onClick={() => { applyMarkup(uploadDescRef, setUploadDesc, `[${name}]`, `[/${name}]`); setShowColorPicker(false); }} />
+            ))}
+        </div>
+    );
+
     const title = activeEntry ? activeEntry.name : activeFolder ? activeFolder : "资源集市";
     const handleBack = activeEntry
         ? () => setActiveEntry(null)
@@ -239,7 +316,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
             ? () => setActiveFolder(null)
             : onClose;
 
-    const renderEntryRow = (entry: ShareIndexEntry, showFolder = false) => (
+    const renderEntryRow = (entry: ShareIndexEntry, showFolder = false, flowers?: number) => (
         <button key={entry.path} className="rh-entry" onClick={() => { setActiveEntry(entry); setSelectedFile(entry.files[0] ?? null); }}>
             {entry.images.length > 0 ? (
                 // eslint-disable-next-line @next/next/no-img-element
@@ -248,10 +325,11 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                 <span className="rh-entry-thumb rh-entry-thumb-blank">📄</span>
             )}
             <span className="rh-entry-main">
-                <span className="rh-entry-title">{entry.name}</span>
-                {entry.description && <span className="rh-entry-desc">{entry.description}</span>}
+                <span className="rh-entry-title"><RichText text={entry.name} mode="sticker" /></span>
+                {entry.description && <span className="rh-entry-desc"><RichText text={entry.description} mode="inline" /></span>}
                 <span className="rh-entry-meta">
-                    {[showFolder ? entry.folder : "", formatEntryDate(entry.updatedAt), `${entry.files.length} 个文件`].filter(Boolean).join(" · ")}
+                    {[showFolder ? entry.folder : "", formatEntryDate(entry.updatedAt), `${entry.files.length} 个文件`,
+                        flowers !== undefined ? `🌸 ${flowers}` : ""].filter(Boolean).join(" · ")}
                 </span>
             </span>
         </button>
@@ -263,7 +341,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
             <div className="rh-window">
                 <div className="rh-titlebar">
                     <span className="rh-titlebar-icon">🗂️</span>
-                    <span className="rh-titlebar-text">{title} - 资源集市</span>
+                    <span className="rh-titlebar-text"><RichText text={title} mode="sticker" /> - 资源集市</span>
                     <span className="rh-titlebar-controls">
                         <button className="rh-tb-btn" aria-label="资源仓库设置" onClick={() => { setSourceDraft(source); setShowSourceEditor(true); }}>⚙</button>
                         <button className="rh-tb-btn" aria-label="刷新" onClick={() => reload(source, { purge: true })}>⟳</button>
@@ -306,12 +384,17 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     {loadState === "ready" && viewMode === "mine" && !activeEntry && (
                         (myStall.published.length > 0 || myStall.pending.length > 0) ? (
                             <div className="rh-entry-list">
-                                {myStall.published.map(entry => renderEntryRow(entry, true))}
+                                {myStall.published.length > 0 && (
+                                    <div className="rh-stall-flowers">
+                                        🌸 共收到 {myStall.published.reduce((sum, e) => sum + (flowerCounts?.[e.path] ?? 0), 0)} 朵花
+                                    </div>
+                                )}
+                                {myStall.published.map(entry => renderEntryRow(entry, true, flowerCounts?.[entry.path] ?? 0))}
                                 {myStall.pending.map(item => (
                                     <div key={item.name + item.uploadedAt} className="rh-entry rh-entry-pending">
                                         <span className="rh-entry-thumb rh-entry-thumb-blank">⏳</span>
                                         <span className="rh-entry-main">
-                                            <span className="rh-entry-title">{item.name}</span>
+                                            <span className="rh-entry-title"><RichText text={item.name} mode="sticker" /></span>
                                             <span className="rh-entry-meta">待管理员审核，或索引尚未更新</span>
                                         </span>
                                     </div>
@@ -380,10 +463,10 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     {loadState === "ready" && activeEntry && (
                         <div className="rh-detail2">
                             <div className="rh-detail2-main">
-                                {/* 发帖式排版：标题 → 正文 → 图片 */}
-                                <div className="rh-detail2-title">{activeEntry.name}</div>
+                                {/* 发帖式排版：标题 → 正文 → 图片（标记语法经 RichText 安全渲染） */}
+                                <div className="rh-detail2-title"><RichText text={activeEntry.name} mode="sticker" /></div>
                                 {activeEntry.description
-                                    ? <div className="rh-detail2-desc">{activeEntry.description}</div>
+                                    ? <div className="rh-detail2-desc"><RichText text={activeEntry.description} mode="full" /></div>
                                     : <div className="rh-detail2-desc rh-detail2-desc-empty">（该资源没有说明文字）</div>}
                                 {activeEntry.images.map(img => {
                                     const url = resolveResourceHubAssetUrl(source, img);
@@ -415,6 +498,14 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                         })}
                                     </div>
                                     <div className="rh-detail2-actions">
+                                        <button
+                                            className="rh-btn rh-flower-btn"
+                                            disabled={hasSentFlowerToday(activeEntry.path)}
+                                            title="给作者送一朵花"
+                                            onClick={() => void handleSendFlower(activeEntry.path)}
+                                        >
+                                            {hasSentFlowerToday(activeEntry.path) ? "已送🌸" : "送花🌸"}
+                                        </button>
                                         <button className="rh-btn rh-action-half" disabled={!selectedFile || busyFile === selectedFile} onClick={() => selectedFile && handleDownload(selectedFile)}>
                                             下载
                                         </button>
@@ -546,15 +637,41 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                     {(index?.folders ?? []).map(f => <option key={f.name} value={f.name} />)}
                                 </datalist>
                             </label>
-                            <label>资源名称
-                                <input className="rh-input" value={uploadName} placeholder="例如：唐簪雪" onChange={e => setUploadName(e.target.value)} />
-                            </label>
+                            <div className="rh-form-field">
+                                <span>资源名称（可加像素贴纸）</span>
+                                <div className="rh-input-row">
+                                    <input ref={uploadNameRef} className="rh-input" value={uploadName} placeholder="例如：唐簪雪" onChange={e => setUploadName(e.target.value)} />
+                                    <button type="button" className="rh-fmt-btn" data-active={stickerPickerFor === "title" ? "1" : undefined}
+                                        onClick={() => { setStickerPickerFor(current => current === "title" ? null : "title"); setShowColorPicker(false); }}>贴纸</button>
+                                </div>
+                                {stickerPickerFor === "title" && stickerPanel}
+                            </div>
                             <label>投稿人（可选）
                                 <input className="rh-input" value={uploadAuthor} onChange={e => setUploadAuthor(e.target.value)} />
                             </label>
-                            <label>说明文字（可选，会显示在列表里）
-                                <textarea className="rh-input" rows={3} value={uploadDesc} onChange={e => setUploadDesc(e.target.value)} />
-                            </label>
+                            <div className="rh-form-field">
+                                <span>说明文字（可选，会显示在列表里，支持贴纸与排版）</span>
+                                <div className="rh-fmt-bar">
+                                    <button type="button" className="rh-fmt-btn" data-active={stickerPickerFor === "desc" ? "1" : undefined}
+                                        onClick={() => { setStickerPickerFor(current => current === "desc" ? null : "desc"); setShowColorPicker(false); }}>贴纸</button>
+                                    <button type="button" className="rh-fmt-btn" data-active={showColorPicker ? "1" : undefined}
+                                        onClick={() => { setShowColorPicker(v => !v); setStickerPickerFor(null); }}>颜色</button>
+                                    <button type="button" className="rh-fmt-btn" onClick={() => applyMarkup(uploadDescRef, setUploadDesc, "[大]", "[/大]")}>大</button>
+                                    <button type="button" className="rh-fmt-btn" onClick={() => applyMarkup(uploadDescRef, setUploadDesc, "[小]", "[/小]")}>小</button>
+                                    <button type="button" className="rh-fmt-btn rh-fmt-bold" onClick={() => applyMarkup(uploadDescRef, setUploadDesc, "[粗]", "[/粗]")}>粗</button>
+                                    <button type="button" className="rh-fmt-btn" data-active={showDescPreview ? "1" : undefined}
+                                        onClick={() => setShowDescPreview(v => !v)}>预览</button>
+                                </div>
+                                {stickerPickerFor === "desc" && stickerPanel}
+                                {showColorPicker && colorPanel}
+                                <textarea ref={uploadDescRef} className="rh-input" rows={3} value={uploadDesc} onChange={e => setUploadDesc(e.target.value)} />
+                                {showDescPreview && (
+                                    <div className="rh-desc-preview">
+                                        <div className="rh-preview-title"><RichText text={uploadName || "（标题预览）"} mode="sticker" /></div>
+                                        <RichText text={uploadDesc || "（正文预览）"} mode="full" />
+                                    </div>
+                                )}
+                            </div>
                             <label className="rh-file-picker">
                                 <span className="rh-btn">选择资源文件{uploadFiles.length > 0 ? `（已选 ${uploadFiles.length} 个）` : ""}</span>
                                 <input type="file" multiple hidden onChange={e => { setUploadFiles(Array.from(e.target.files ?? [])); e.target.value = ""; }} />
@@ -623,6 +740,9 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     </div>
                 </div>
             )}
+
+            {/* 非阻塞小提示（送花等轻量反馈） */}
+            {toast && <div className="rh-toast">{toast}</div>}
 
             {/* 图片全屏预览（与聊天/动态页一致，含保存按钮） */}
             {previewImage && (
@@ -936,6 +1056,32 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                 }
                 .rh-action-half { flex: 1; padding: 8px 0; }
                 .rh-action-del { color: #a01818; font-weight: 700; padding: 8px 10px; }
+                .rh-flower-btn { padding: 8px 8px; }
+                /* 我的货摊：花数汇总行 */
+                .rh-stall-flowers {
+                    padding: 8px 10px;
+                    font-size: calc(12px * var(--app-text-scale, 1));
+                    font-weight: 700;
+                    color: #a04060;
+                    background: #fff0f4;
+                    border-bottom: 1px solid #d4d0c8;
+                }
+                /* 非阻塞小提示 */
+                .rh-toast {
+                    position: absolute;
+                    left: 50%;
+                    bottom: 60px;
+                    transform: translateX(-50%);
+                    z-index: 70;
+                    background: #ffffe1;
+                    color: #000;
+                    font-size: calc(12px * var(--app-text-scale, 1));
+                    padding: 6px 16px;
+                    border: 1px solid #000;
+                    box-shadow: 2px 2px 0 #000;
+                    white-space: nowrap;
+                    pointer-events: none;
+                }
                 .rh-search-row {
                     display: flex;
                     gap: 6px;
@@ -1052,12 +1198,63 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                 .rh-dest-label { font-size: calc(13px * var(--app-text-scale, 1)); color: #000; font-weight: 700; }
                 .rh-dest-hint { font-size: calc(10px * var(--app-text-scale, 1)); color: #808080; }
                 .rh-form { flex-direction: column; align-items: stretch; gap: 8px; }
-                .rh-form label {
+                .rh-form label, .rh-form-field {
                     display: flex;
                     flex-direction: column;
                     gap: 3px;
                     font-size: calc(11px * var(--app-text-scale, 1));
                     color: #000;
+                }
+                /* 排版工具栏（上传弹窗：贴纸/颜色/字号/加粗/预览） */
+                .rh-input-row { display: flex; gap: 4px; }
+                .rh-input-row .rh-input { flex: 1; min-width: 0; }
+                .rh-fmt-bar { display: flex; gap: 4px; flex-wrap: wrap; }
+                .rh-fmt-btn {
+                    background: #c0c0c0;
+                    color: #000;
+                    font-size: calc(11px * var(--app-text-scale, 1));
+                    padding: 2px 8px;
+                    border: 2px solid;
+                    border-color: #ffffff #404040 #404040 #ffffff;
+                    cursor: pointer;
+                }
+                .rh-fmt-btn:active, .rh-fmt-btn[data-active] { border-color: #404040 #ffffff #ffffff #404040; background: #d8d8d8; }
+                .rh-fmt-bold { font-weight: 700; }
+                .rh-sticker-panel {
+                    display: grid;
+                    grid-template-columns: repeat(8, 1fr);
+                    gap: 2px;
+                    padding: 4px;
+                    background: #fff;
+                    border: 1px solid #808080;
+                }
+                .rh-sticker-btn {
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    padding: 3px;
+                    background: none;
+                    border: 1px dotted transparent;
+                    cursor: pointer;
+                }
+                .rh-sticker-btn:active { border-color: #000080; background: #e4ecf7; }
+                .rh-color-panel { display: flex; gap: 4px; padding: 4px; background: #fff; border: 1px solid #808080; }
+                .rh-color-chip { width: 20px; height: 20px; border: 1px solid #404040; cursor: pointer; padding: 0; }
+                .rh-desc-preview {
+                    background: #fff;
+                    border: 1px solid #808080;
+                    padding: 8px;
+                    font-size: calc(12px * var(--app-text-scale, 1));
+                    line-height: 1.7;
+                    white-space: pre-wrap;
+                    color: #000;
+                }
+                .rh-preview-title {
+                    font-weight: 700;
+                    font-size: calc(14px * var(--app-text-scale, 1));
+                    border-bottom: 1px solid #d4d0c8;
+                    padding-bottom: 4px;
+                    margin-bottom: 6px;
                 }
                 .rh-input {
                     background: #fff;

--- a/components/resource-hub/rich-text.tsx
+++ b/components/resource-hub/rich-text.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+// 资源集市富文本：安全的轻量标记 → React 元素（绝无 HTML 注入面）。
+// 语法（方括号标记，未注册的原样显示，老资源纯文本完全不受影响）：
+//   贴纸        [花] [爱心] ...（见 pixel-stickers，标题和正文都能用）
+//   颜色（正文）[红]文字[/红]，共 红橙黄绿蓝紫粉灰 八色
+//   字号（正文）[大]文字[/大]、[小]文字[/小]
+//   加粗（正文）[粗]文字[/粗]
+// 三种渲染模式：
+//   full    详情正文：全部生效
+//   inline  列表摘要：贴纸/颜色/加粗生效，字号忽略（保持行高整齐）
+//   sticker 标题：只认贴纸，其它标记原样显示
+
+import type { CSSProperties, ReactNode } from "react";
+import { StickerInline, isStickerName } from "./pixel-stickers";
+
+// 颜色都取偏深的档位，保证白底可读
+export const RICH_COLORS: Record<string, string> = {
+    红: "#c02020",
+    橙: "#c05e10",
+    黄: "#9a7d00",
+    绿: "#0f7020",
+    蓝: "#1040b0",
+    紫: "#7020a0",
+    粉: "#c8407e",
+    灰: "#707070",
+};
+
+const RICH_SIZES: Record<string, string> = { 大: "1.3em", 小: "0.85em" };
+
+export type RichTextMode = "full" | "inline" | "sticker";
+
+function styleForTag(tag: string, mode: RichTextMode): CSSProperties | null {
+    if (mode === "sticker") return null;
+    if (RICH_COLORS[tag]) return { color: RICH_COLORS[tag] };
+    if (tag === "粗") return { fontWeight: 700 };
+    if (RICH_SIZES[tag]) {
+        // inline 模式认识字号标记（不至于原样显示出来），但不改变字号
+        return mode === "full" ? { fontSize: RICH_SIZES[tag] } : {};
+    }
+    return null;
+}
+
+const TOKEN_RE = /\[(\/?)([^\[\]/\s]{1,6})\]/g;
+
+export function renderRichText(text: string, mode: RichTextMode): ReactNode[] {
+    type Frame = { tag: string; style: CSSProperties; nodes: ReactNode[] };
+    const root: Frame = { tag: "", style: {}, nodes: [] };
+    const stack: Frame[] = [root];
+    let key = 0;
+    const top = () => stack[stack.length - 1];
+    const pushText = (s: string) => { if (s) top().nodes.push(s); };
+    const closeFrame = () => {
+        const frame = stack.pop()!;
+        top().nodes.push(<span key={key++} style={frame.style}>{frame.nodes}</span>);
+    };
+
+    TOKEN_RE.lastIndex = 0;
+    let cursor = 0;
+    let match: RegExpExecArray | null;
+    while ((match = TOKEN_RE.exec(text)) !== null) {
+        const [raw, slash, tag] = match;
+        pushText(text.slice(cursor, match.index));
+        cursor = match.index + raw.length;
+        if (!slash && isStickerName(tag)) {
+            top().nodes.push(<StickerInline key={key++} name={tag} />);
+            continue;
+        }
+        const style = styleForTag(tag, mode);
+        if (style === null) { pushText(raw); continue; } // 未注册标记原样显示
+        if (!slash) {
+            stack.push({ tag, style, nodes: [] });
+        } else if (top().tag === tag) {
+            closeFrame();
+        } else {
+            pushText(raw); // 闭合标记对不上，原样显示
+        }
+    }
+    pushText(text.slice(cursor));
+    while (stack.length > 1) closeFrame(); // 忘写闭合标记：样式作用到结尾（截断摘要也能优雅降级）
+    return root.nodes;
+}
+
+export function RichText({ text, mode = "full" }: { text: string; mode?: RichTextMode }) {
+    return <>{renderRichText(text, mode)}</>;
+}

--- a/lib/resource-hub-flowers.ts
+++ b/lib/resource-hub-flowers.ts
@@ -1,0 +1,75 @@
+// lib/resource-hub-flowers.ts
+// 资源集市送花：下载成功自动送一朵，详情页也可手动送。
+// 计数存在资源仓库根目录 _flowers.json（由上传服务的机器人维护），
+// 数量只在「我的货摊」里展示给作者本人。
+// 去重双保险：服务端按 IP+资源+天限 1 朵；本机也记录当天已送过的资源。
+
+import { kvGet, kvSet, registerKvMigration } from "./kv-db";
+import { fetchResourceHubText } from "./resource-hub-client";
+import type { ResourceHubSource } from "./resource-hub-types";
+
+const FLOWERS_SENT_KEY = "ai_phone_resource_hub_flowers_sent_v1";
+registerKvMigration(FLOWERS_SENT_KEY);
+
+const FLOWERS_FILE = "_flowers.json";
+
+export type FlowerCounts = Record<string, number>;
+
+function today(): string {
+    return new Date().toISOString().slice(0, 10);
+}
+
+function loadSentMap(): Record<string, string> {
+    try {
+        const parsed = JSON.parse(kvGet(FLOWERS_SENT_KEY) || "{}") as Record<string, string>;
+        return parsed && typeof parsed === "object" ? parsed : {};
+    } catch { return {}; }
+}
+
+/** 今天是否已给该资源送过花（本机记录） */
+export function hasSentFlowerToday(path: string): boolean {
+    return loadSentMap()[path] === today();
+}
+
+function recordFlowerSent(path: string): void {
+    const map = loadSentMap();
+    const day = today();
+    // 只保留今天的记录，表不会无限膨胀
+    const next: Record<string, string> = {};
+    for (const [key, value] of Object.entries(map)) {
+        if (value === day) next[key] = value;
+    }
+    next[path] = day;
+    kvSet(FLOWERS_SENT_KEY, JSON.stringify(next));
+}
+
+/**
+ * 送一朵花。返回 true 表示这朵真的送出去了（今天第一次）。
+ * 网络失败静默返回 false —— 送花永远不该打断下载主流程。
+ */
+export async function sendFlower(endpoint: string, path: string): Promise<boolean> {
+    if (hasSentFlowerToday(path)) return false;
+    try {
+        const res = await fetch(endpoint, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ action: "flower", path }),
+        });
+        const data = await res.json().catch(() => ({})) as { ok?: boolean; already?: boolean };
+        if (!res.ok || data.ok === false) return false;
+        recordFlowerSent(path);
+        return !data.already;
+    } catch {
+        return false;
+    }
+}
+
+/** 读取全部资源的花数（走 CDN，SHA 定位保证新鲜）。文件不存在时返回空表。 */
+export async function fetchFlowerCounts(source: ResourceHubSource): Promise<FlowerCounts> {
+    try {
+        const text = await fetchResourceHubText(source, FLOWERS_FILE);
+        const parsed = JSON.parse(text) as FlowerCounts;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
+    } catch { /* 没有人送过花或网络失败，一律按空表 */ }
+    return {};
+}


### PR DESCRIPTION
同步闭源仓库的资源集市新功能：

**送花系统**
- 下载成功自动送一朵花（同 IP 同资源每天 1 朵，计入资源仓库 _flowers.json）
- 详情页手动「送花🌸」按钮，当天送过则禁用
- 我的货摊显示每条资源收到的花与总数（仅作者本人可见）

**像素贴纸与正文排版**（轻量标记 → React 安全渲染，无 HTML 注入面）
- 内置 16 个 16×16 像素贴纸（[花][爱心][星星]……），标题和正文均可用
- 正文支持八色、[大][小] 字号、[粗] 加粗；未注册标记原样显示，老资源不受影响
- 上传弹窗排版工具栏（贴纸选择器/颜色面板/字号/加粗/实时预览）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_