### PR TITLE
资源集市：上传编辑器改为所见即所得

### DIFF
--- a/components/resource-hub/pixel-stickers.tsx
+++ b/components/resource-hub/pixel-stickers.tsx
@@ -320,6 +320,34 @@ export function isStickerName(name: string): boolean {
     return Object.prototype.hasOwnProperty.call(STICKERS, name);
 }
 
+/** 同色连续像素合并成 rect 列表（SVG 元素与字符串两种输出共用） */
+function gridRuns(grid: PixelGrid): Array<{ x: number; y: number; w: number; fill: string }> {
+    const runs: Array<{ x: number; y: number; w: number; fill: string }> = [];
+    grid.forEach((row, y) => {
+        let x = 0;
+        while (x < row.length) {
+            const ch = row[x];
+            if (ch === "." || !PALETTE[ch]) { x++; continue; }
+            let end = x + 1;
+            while (end < row.length && row[end] === ch) end++;
+            runs.push({ x, y, w: end - x, fill: PALETTE[ch] });
+            x = end;
+        }
+    });
+    return runs;
+}
+
+/** 贴纸的 data URL（富文本编辑器里当作一个整体字符插入 <img>） */
+export function stickerDataUrl(name: string): string {
+    const grid = STICKERS[name];
+    if (!grid) return "";
+    const rects = gridRuns(grid)
+        .map(r => `<rect x="${r.x}" y="${r.y}" width="${r.w}" height="1" fill="${r.fill}"/>`)
+        .join("");
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" shape-rendering="crispEdges">${rects}</svg>`;
+    return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}
+
 function renderGrid(grid: PixelGrid, size: number | string) {
     const rects: React.ReactNode[] = [];
     grid.forEach((row, y) => {

--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -39,6 +39,7 @@ import { MediaPreviewOverlay } from "@/components/chat/media-preview-overlay";
 import { fetchFlowerCounts, hasSentFlowerToday, sendFlower, type FlowerCounts } from "@/lib/resource-hub-flowers";
 import { STICKER_NAMES, StickerPixelIcon } from "@/components/resource-hub/pixel-stickers";
 import { RICH_COLORS, RichText } from "@/components/resource-hub/rich-text";
+import { RichEditor, type RichEditorHandle } from "@/components/resource-hub/rich-editor";
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -87,48 +88,23 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     const [uploadImages, setUploadImages] = useState<File[]>([]);
     const [uploading, setUploading] = useState(false);
     const [uploadCfg, setUploadCfg] = useState<ResourceHubUploadConfig>(() => loadUploadConfig());
-    // 排版编辑器：贴纸选择器（标题/正文两处）、颜色面板；预览在有标记时自动显示
+    // 所见即所得编辑器：贴纸选择器（标题/正文两处）、颜色面板
     const [stickerPickerFor, setStickerPickerFor] = useState<"title" | "desc" | null>(null);
     const [showColorPicker, setShowColorPicker] = useState(false);
-    const uploadNameRef = useRef<HTMLInputElement | null>(null);
-    const uploadDescRef = useRef<HTMLTextAreaElement | null>(null);
+    const uploadNameRef = useRef<RichEditorHandle | null>(null);
+    const uploadDescRef = useRef<RichEditorHandle | null>(null);
 
-    // 在光标处插入标记 / 用标记包住选中文字，随后恢复焦点
     const showToast = useCallback((msg: string) => {
         setToast(msg);
         window.setTimeout(() => setToast(current => (current === msg ? null : current)), 2600);
     }, []);
 
-    const applyMarkup = useCallback((
-        ref: React.RefObject<HTMLInputElement | HTMLTextAreaElement | null>,
-        setter: (value: string) => void,
-        before: string,
-        after = "",
-    ) => {
-        const el = ref.current;
-        if (!el) return;
-        const start = el.selectionStart ?? el.value.length;
-        const end = el.selectionEnd ?? start;
-        const next = el.value.slice(0, start) + before + el.value.slice(start, end) + after + el.value.slice(end);
-        setter(next);
-        requestAnimationFrame(() => {
-            el.focus();
-            const pos = start + before.length + (end - start) + after.length;
-            el.setSelectionRange(pos, pos);
-        });
-    }, []);
-
-    // 颜色/字号/加粗都是"选中文字再操作"：没选中就提示，不产生空标记
+    // 颜色/字号/加粗都是"选中文字再操作"：没选中就提示
     const wrapDescTag = useCallback((tag: string) => {
-        const el = uploadDescRef.current;
-        if (!el || (el.selectionStart ?? 0) === (el.selectionEnd ?? 0)) {
-            showToast("先选中要排版的文字，再点按钮");
-            return;
-        }
-        applyMarkup(uploadDescRef, setUploadDesc, `[${tag}]`, `[/${tag}]`);
-    }, [applyMarkup, showToast]);
+        if (!uploadDescRef.current?.applyTag(tag)) showToast("先选中要排版的文字，再点按钮");
+    }, [showToast]);
 
-    // 工具栏按钮按下时不抢走输入框焦点，选区才能保住（iOS 上尤其关键）
+    // 工具栏按钮按下时不抢走编辑器焦点，选区才能保住（iOS 上尤其关键）
     const keepSelection = useCallback((e: React.PointerEvent) => e.preventDefault(), []);
 
     const reload = useCallback((activeSource: ResourceHubSource, options?: { purge?: boolean }) => {
@@ -289,7 +265,8 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                 files,
             });
             setShowUpload(false);
-            setUploadName(""); setUploadDesc(""); setUploadFiles([]); setUploadImages([]); setUploadFolderCustom("");
+            uploadNameRef.current?.setMarkup(""); uploadDescRef.current?.setMarkup("");
+            setUploadFiles([]); setUploadImages([]); setUploadFolderCustom("");
             onNotice?.(result.merged
                 ? `「${name}」已上架（CDN 缓存刷新后可见）`
                 : `「${name}」已提交，等待管理员审核上架`);
@@ -305,8 +282,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
         <div className="rh-sticker-panel">
             {STICKER_NAMES.map(name => (
                 <button key={name} type="button" className="rh-sticker-btn" title={name} onPointerDown={keepSelection} onClick={() => {
-                    if (stickerPickerFor === "title") applyMarkup(uploadNameRef, setUploadName, `[${name}]`);
-                    else applyMarkup(uploadDescRef, setUploadDesc, `[${name}]`);
+                    (stickerPickerFor === "title" ? uploadNameRef : uploadDescRef).current?.insertSticker(name);
                     setStickerPickerFor(null);
                 }}>
                     <StickerPixelIcon name={name} size={24} />
@@ -680,8 +656,15 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                             <div className="rh-form-field">
                                 <span>资源名称（可加像素贴纸）</span>
                                 <div className="rh-input-row">
-                                    <input ref={uploadNameRef} className="rh-input" value={uploadName} placeholder="例如：唐簪雪" onChange={e => setUploadName(e.target.value)} />
-                                    <button type="button" className="rh-fmt-btn" data-active={stickerPickerFor === "title" ? "1" : undefined}
+                                    <RichEditor
+                                        ref={uploadNameRef}
+                                        className="rh-input rh-editor rh-editor-line"
+                                        placeholder="例如：唐簪雪"
+                                        ariaLabel="资源名称"
+                                        singleLine
+                                        onChange={setUploadName}
+                                    />
+                                    <button type="button" className="rh-fmt-btn" data-active={stickerPickerFor === "title" ? "1" : undefined} onPointerDown={keepSelection}
                                         onClick={() => { setStickerPickerFor(current => current === "title" ? null : "title"); setShowColorPicker(false); }}>贴纸</button>
                                 </div>
                                 {stickerPickerFor === "title" && stickerPanel}
@@ -702,17 +685,13 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                 </div>
                                 {stickerPickerFor === "desc" && stickerPanel}
                                 {showColorPicker && colorPanel}
-                                <textarea ref={uploadDescRef} className="rh-input" rows={3} value={uploadDesc} onChange={e => setUploadDesc(e.target.value)} />
-                                {/* 用了标记才出现的实时预览，纯文字用户不被打扰 */}
-                                {(uploadName + uploadDesc).includes("[") && (
-                                    <div className="rh-desc-preview">
-                                        <div className="rh-preview-label">效果预览</div>
-                                        {uploadName.includes("[") && (
-                                            <div className="rh-preview-title"><RichText text={uploadName} mode="sticker" /></div>
-                                        )}
-                                        {uploadDesc && <RichText text={uploadDesc} mode="full" />}
-                                    </div>
-                                )}
+                                <RichEditor
+                                    ref={uploadDescRef}
+                                    className="rh-input rh-editor rh-editor-area"
+                                    placeholder="写点介绍吧～选中文字可以改颜色、字号、加粗"
+                                    ariaLabel="说明文字"
+                                    onChange={setUploadDesc}
+                                />
                             </div>
                             <label className="rh-file-picker">
                                 <span className="rh-btn">选择资源文件{uploadFiles.length > 0 ? `（已选 ${uploadFiles.length} 个）` : ""}</span>
@@ -1308,6 +1287,23 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     white-space: pre-wrap;
                     color: #000;
                 }
+                /* 所见即所得编辑器：外观与 rh-input 一致，内容直接显示排版效果 */
+                .rh-editor {
+                    line-height: 1.7;
+                    word-break: break-word;
+                    white-space: pre-wrap;
+                    -webkit-user-select: text;
+                    user-select: text;
+                    cursor: text;
+                }
+                .rh-editor-line { min-height: calc(20px * var(--app-text-scale, 1)); overflow-x: auto; white-space: nowrap; }
+                .rh-editor-area { min-height: calc(66px * var(--app-text-scale, 1)); max-height: 40vh; overflow-y: auto; }
+                .rh-editor[data-empty]::before {
+                    content: attr(data-placeholder);
+                    color: #a0a0a0;
+                    pointer-events: none;
+                }
+                .rh-editor img { display: inline; vertical-align: -0.22em; }
                 .rh-preview-label {
                     font-size: calc(10px * var(--app-text-scale, 1));
                     color: #808080;

--- a/components/resource-hub/rich-editor.tsx
+++ b/components/resource-hub/rich-editor.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+// 资源集市所见即所得编辑器：编辑时直接看到颜色/字号/加粗/贴纸的实际效果，
+// 用户永远看不到 [红]...[/红] 这类原始标记——标记只是对外存储格式，
+// 提交时由 DOM 序列化产生（详情页仍用 RichText 安全渲染回来）。
+//
+// 实现要点：
+// - contentEditable 完全非受控：React 只在打开时写一次 innerHTML，之后不再碰内容，
+//   否则中文输入法组词会被打断、光标会乱跳（移动端尤其明显）。
+// - 加粗/颜色/字号走 execCommand：浏览器自己处理选区拆分与"再点一次取消"，
+//   比手写 Range 手术在 iOS 上稳得多；产出的样式在序列化时统一归一化。
+// - 粘贴强制纯文本，外部 HTML 进不来；序列化只认识我们自己的几种标记，
+//   所以存进仓库的内容天然是干净的。
+
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from "react";
+import { RICH_COLORS } from "./rich-text";
+import { STICKERS, stickerDataUrl } from "./pixel-stickers";
+
+/** 字号标记 ↔ CSS。编辑器统一用 em，与详情页的显示效果一致；
+ *  execCommand 产出的是 x-large/small 关键字，插入后会被归一化成 em。 */
+const CSS_BY_SIZE_TAG: Record<string, string> = { 大: "1.3em", 小: "0.85em" };
+const SIZE_TAG_BY_CSS: Record<string, string> = {
+    "1.3em": "大", "0.85em": "小",
+    "x-large": "大", small: "小",
+};
+/** execCommand fontSize 的档位（1-7） */
+const EXEC_SIZE_LEVEL: Record<string, string> = { 大: "5", 小: "2" };
+
+export type RichEditorHandle = {
+    /** 取当前内容的标记文本（提交/校验用） */
+    getMarkup: () => string;
+    /** 覆盖内容（打开对话框、清空时用） */
+    setMarkup: (markup: string) => void;
+    /** 对选中文字套用标记；没选中返回 false */
+    applyTag: (tag: string) => boolean;
+    /** 在光标处插入贴纸 */
+    insertSticker: (name: string) => void;
+    focus: () => void;
+};
+
+// ── 标记 → HTML（编辑器初始内容） ──
+
+function escapeHtml(text: string): string {
+    return text.replace(/[&<>"]/g, ch => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[ch]!));
+}
+
+function openTagHtml(tag: string): string | null {
+    if (RICH_COLORS[tag]) return `<span style="color: ${RICH_COLORS[tag]};">`;
+    if (tag === "粗") return `<span style="font-weight: bold;">`;
+    if (CSS_BY_SIZE_TAG[tag]) return `<span style="font-size: ${CSS_BY_SIZE_TAG[tag]};">`;
+    return null;
+}
+
+const TOKEN_RE = /\[(\/?)([^[\]/\s]{1,6})\]/g;
+
+export function markupToHtml(markup: string): string {
+    let html = "";
+    const stack: string[] = [];
+    let cursor = 0;
+    let match: RegExpExecArray | null;
+    TOKEN_RE.lastIndex = 0;
+    while ((match = TOKEN_RE.exec(markup)) !== null) {
+        const [raw, slash, tag] = match;
+        html += escapeHtml(markup.slice(cursor, match.index)).replace(/\n/g, "<br>");
+        cursor = match.index + raw.length;
+        if (!slash && STICKERS[tag]) {
+            html += `<img data-sticker="${escapeHtml(tag)}" src="${stickerDataUrl(tag)}" alt="${escapeHtml(tag)}" style="display:inline;height:1.25em;vertical-align:-0.22em;">`;
+            continue;
+        }
+        const open = openTagHtml(tag);
+        if (!open) { html += escapeHtml(raw); continue; }   // 未注册标记原样显示
+        if (!slash) { stack.push(tag); html += open; }
+        else if (stack[stack.length - 1] === tag) { stack.pop(); html += "</span>"; }
+        else html += escapeHtml(raw);
+    }
+    html += escapeHtml(markup.slice(cursor)).replace(/\n/g, "<br>");
+    while (stack.length) { stack.pop(); html += "</span>"; }
+    return html;
+}
+
+// ── HTML → 标记（提交时序列化） ──
+
+function normalizeColor(value: string): string {
+    const rgb = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i.exec(value);
+    if (rgb) {
+        return "#" + [rgb[1], rgb[2], rgb[3]]
+            .map(n => Number(n).toString(16).padStart(2, "0")).join("");
+    }
+    const hex = value.trim().toLowerCase();
+    if (/^#[0-9a-f]{6}$/.test(hex)) return hex;
+    if (/^#[0-9a-f]{3}$/.test(hex)) return "#" + hex.slice(1).split("").map(c => c + c).join("");
+    return "";
+}
+
+const COLOR_TAG_BY_HEX: Record<string, string> = Object.fromEntries(
+    Object.entries(RICH_COLORS).map(([tag, hex]) => [hex.toLowerCase(), tag]));
+
+/** 元素上生效的标记（同时认识 execCommand 的产物与我们自己写的样式） */
+function tagsForElement(el: HTMLElement): string[] {
+    const tags: string[] = [];
+    const weight = el.style.fontWeight;
+    if (el.tagName === "B" || el.tagName === "STRONG"
+        || weight === "bold" || (weight !== "" && Number(weight) >= 600)) {
+        tags.push("粗");
+    }
+    const colorTag = COLOR_TAG_BY_HEX[normalizeColor(el.style.color || el.getAttribute("color") || "")];
+    if (colorTag) tags.push(colorTag);
+    const sizeTag = SIZE_TAG_BY_CSS[el.style.fontSize];
+    if (sizeTag) tags.push(sizeTag);
+    return tags;
+}
+
+const BLOCK_TAGS = new Set(["DIV", "P", "LI", "TR"]);
+
+function serialize(node: Node): string {
+    if (node.nodeType === Node.TEXT_NODE) return (node.nodeValue ?? "").replace(/ /g, " ");
+    if (node.nodeType !== Node.ELEMENT_NODE) return "";
+    const el = node as HTMLElement;
+    if (el.tagName === "BR") return "\n";
+    const sticker = el.dataset.sticker;
+    if (sticker) return STICKERS[sticker] ? `[${sticker}]` : "";
+    let inner = Array.from(el.childNodes).map(serialize).join("");
+    for (const tag of tagsForElement(el).reverse()) inner = `[${tag}]${inner}[/${tag}]`;
+    // 浏览器在回车时会造 <div> 块，等价于换行
+    return BLOCK_TAGS.has(el.tagName) ? `\n${inner}` : inner;
+}
+
+export function htmlToMarkup(root: HTMLElement): string {
+    const text = Array.from(root.childNodes).map(serialize).join("");
+    return text.replace(/^\n/, "");
+}
+
+// ── 选区操作 ──
+
+/** 把 execCommand 产出的 x-large/small 换成 em，编辑器所见与详情页一致 */
+function normalizeSizes(root: HTMLElement): void {
+    for (const el of Array.from(root.querySelectorAll<HTMLElement>("[style*='font-size']"))) {
+        const tag = SIZE_TAG_BY_CSS[el.style.fontSize];
+        if (tag) el.style.fontSize = CSS_BY_SIZE_TAG[tag];
+    }
+}
+
+function selectionInside(root: HTMLElement): Range | null {
+    const selection = typeof window === "undefined" ? null : window.getSelection();
+    if (!selection || selection.rangeCount === 0) return null;
+    const range = selection.getRangeAt(0);
+    return root.contains(range.commonAncestorContainer) ? range : null;
+}
+
+export const RichEditor = forwardRef<RichEditorHandle, {
+    className?: string;
+    placeholder?: string;
+    singleLine?: boolean;
+    ariaLabel?: string;
+    /** 内容变化时回传标记（供外部做校验/提交，不回写 DOM） */
+    onChange?: (markup: string) => void;
+}>(function RichEditor({ className, placeholder, singleLine, ariaLabel, onChange }, ref) {
+    const rootRef = useRef<HTMLDivElement | null>(null);
+    const composingRef = useRef(false);
+
+    const emit = useCallback(() => {
+        const root = rootRef.current;
+        if (!root || composingRef.current) return;
+        const markup = htmlToMarkup(root);
+        // 空态标记给 CSS 用：浏览器会在"空"的编辑区留一个 <br>，:empty 靠不住
+        root.toggleAttribute("data-empty", markup.trim() === "");
+        onChange?.(markup);
+    }, [onChange]);
+
+    // 挂载时同步一次，保证外部状态与（空的）编辑器一致
+    useEffect(() => { emit(); }, [emit]);
+
+    useImperativeHandle(ref, () => ({
+        getMarkup: () => (rootRef.current ? htmlToMarkup(rootRef.current) : ""),
+        setMarkup: (markup: string) => {
+            if (rootRef.current) rootRef.current.innerHTML = markupToHtml(markup);
+            emit();
+        },
+        focus: () => rootRef.current?.focus(),
+        applyTag: (tag: string) => {
+            const root = rootRef.current;
+            if (!root) return false;
+            const range = selectionInside(root);
+            if (!range || range.collapsed) return false;
+            root.focus();
+            try { document.execCommand("styleWithCSS", false, "true"); } catch { /* 老浏览器忽略 */ }
+            if (tag === "粗") {
+                document.execCommand("bold");
+            } else if (RICH_COLORS[tag]) {
+                document.execCommand("foreColor", false, RICH_COLORS[tag]);
+            } else if (EXEC_SIZE_LEVEL[tag]) {
+                document.execCommand("fontSize", false, EXEC_SIZE_LEVEL[tag]);
+                normalizeSizes(root);
+            } else {
+                return false;
+            }
+            emit();
+            return true;
+        },
+        insertSticker: (name: string) => {
+            const root = rootRef.current;
+            if (!root || !STICKERS[name]) return;
+            const img = document.createElement("img");
+            img.dataset.sticker = name;
+            img.src = stickerDataUrl(name);
+            img.alt = name;
+            // 全局样式里 img 是 block，贴纸必须显式改回 inline 才能跟文字同行
+            img.style.display = "inline";
+            img.style.height = "1.25em";
+            img.style.verticalAlign = "-0.22em";
+
+            root.focus();
+            const range = selectionInside(root);
+            if (range) {
+                range.deleteContents();
+                range.insertNode(img);
+                range.setStartAfter(img);
+                range.collapse(true);
+                const selection = window.getSelection();
+                selection?.removeAllRanges();
+                selection?.addRange(range);
+            } else {
+                root.appendChild(img);
+            }
+            emit();
+        },
+    }), [emit, onChange]);
+
+    return (
+        <div
+            ref={rootRef}
+            className={className}
+            contentEditable
+            suppressContentEditableWarning
+            role="textbox"
+            aria-label={ariaLabel}
+            data-placeholder={placeholder}
+            onInput={emit}
+            onCompositionStart={() => { composingRef.current = true; }}
+            onCompositionEnd={() => { composingRef.current = false; emit(); }}
+            onBlur={emit}
+            onKeyDown={e => { if (singleLine && e.key === "Enter") e.preventDefault(); }}
+            onPaste={e => {
+                // 只收纯文本，外部富文本/HTML 一律不进编辑器
+                e.preventDefault();
+                const text = e.clipboardData.getData("text/plain");
+                document.execCommand("insertText", false, singleLine ? text.replace(/\s*\n\s*/g, " ") : text);
+            }}
+        />
+    );
+});


### PR DESCRIPTION
用户不再看到 `[红]...[/红]` 这类原始标记，选中文字点按钮就直接变色/变粗/改字号，像 Word 一样。标记只作为对外存储格式，在提交时由 DOM 序列化产生，详情页仍用 RichText 安全渲染回来。

- 新增 RichEditor（contentEditable 非受控）：React 不回写内容，避免中文输入法组词被打断、光标乱跳；加粗/颜色/字号走 execCommand，选区拆分与再点取消由浏览器处理，比手写 Range 手术在 iOS 上稳
- execCommand 产出的 x-large/small 归一化为 em，编辑器所见即详情页所得
- 贴纸以 `<img>` 形式内嵌（全局 img 为 block，显式改回 inline 才能与文字同行）
- 粘贴强制纯文本；序列化只认识我们自己的标记，存进仓库的内容天然干净
- 移除单独的效果预览块（所见即所得后已多余）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_