### PR TITLE
图片全屏预览：去掉图片圆角

### DIFF
--- a/components/chat/media-preview-overlay.tsx
+++ b/components/chat/media-preview-overlay.tsx
@@ -41,7 +41,7 @@ export function MediaPreviewOverlay({
             onClick={onClose}
         >
             {imageUrl ? (
-                <img src={imageUrl} alt="" style={{ maxWidth: "90vw", maxHeight: "75vh", objectFit: "contain", borderRadius: 8 }} />
+                <img src={imageUrl} alt="" style={{ maxWidth: "90vw", maxHeight: "75vh", objectFit: "contain" }} />
             ) : description ? (
                 <div
                     style={{ color: "#fff", opacity: 0.9, maxWidth: "min(85vw, 420px)", maxHeight: "60vh", overflowY: "auto", fontSize: "calc(14px*var(--app-text-scale,1))", lineHeight: 1.8, fontStyle: "italic", whiteSpace: "pre-wrap" }}


### PR DESCRIPTION
预览层的 8px 圆角与聊天图片卡片（`rounded-none`）不一致，去掉改为直角；保存按钮仍保持胶囊形。聊天、朋友圈、小卷、资源集市共用此预览层。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_