### PR TITLE
资源集市/集市审核：给联网按钮补加载态

### DIFF
--- a/components/chat/media-preview-overlay.tsx
+++ b/components/chat/media-preview-overlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CSSProperties } from "react";
+import { useState, type CSSProperties } from "react";
 import { createPortal } from "react-dom";
 
 const ACTION_BUTTON_STYLE: CSSProperties = {
@@ -34,6 +34,8 @@ export function MediaPreviewOverlay({
     regenerating?: boolean;
     onClose: () => void;
 }) {
+    // 保存要重新拉一次图片，慢网络下会卡一下——按钮上给个状态
+    const [saving, setSaving] = useState(false);
     if (typeof document === "undefined") return null;
     return createPortal(
         <div
@@ -54,15 +56,21 @@ export function MediaPreviewOverlay({
                 {imageUrl && saveFilename && (
                     <button
                         onPointerDown={e => e.stopPropagation()}
+                        disabled={saving}
                         onClick={async e => {
                             e.stopPropagation();
                             e.preventDefault();
-                            const { downloadUrl } = await import("@/lib/download-utils");
-                            await downloadUrl(imageUrl, saveFilename);
+                            setSaving(true);
+                            try {
+                                const { downloadUrl } = await import("@/lib/download-utils");
+                                await downloadUrl(imageUrl, saveFilename);
+                            } finally {
+                                setSaving(false);
+                            }
                         }}
                         style={ACTION_BUTTON_STYLE}
                     >
-                        保存图片
+                        {saving ? "保存中…" : "保存图片"}
                     </button>
                 )}
                 {onRegenerate && (

--- a/components/pixel-hourglass.tsx
+++ b/components/pixel-hourglass.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect } from "react";
+
+// 像素沙漏：复古 Windows 风的"正在忙"指示，用在资源集市那类联网按钮里。
+// 四帧 16×16 网格（上室沙子减少 → 颈部落沙 → 下室堆积），纯 CSS 轮播，
+// 不用 JS 定时器，所以不会引起重渲染。
+
+const PALETTE: Record<string, string> = {
+    k: "#1a1a1a", // 外框
+    w: "#ffffff", // 空腔
+    y: "#f8d838", // 沙子
+};
+
+const FRAMES: string[][] = [
+    [
+        "..kkkkkkkkkkkk..",
+        "..kyyyyyyyyyyk..",
+        "..kyyyyyyyyyyk..",
+        "...kyyyyyyyyk...",
+        "....kyyyyyyk....",
+        ".....kyyyyk.....",
+        "......kyyk......",
+        "......kwwk......",
+        "......kwwk......",
+        ".....kwwwwk.....",
+        "....kwwwwwwk....",
+        "...kwwwwwwwwk...",
+        "..kwwwwwwwwwwk..",
+        "..kwwwwwwwwwwk..",
+        "..kkkkkkkkkkkk..",
+        "................",
+    ],
+    [
+        "..kkkkkkkkkkkk..",
+        "..kwwwwwwwwwwk..",
+        "..kyyyyyyyyyyk..",
+        "...kyyyyyyyyk...",
+        "....kyyyyyyk....",
+        ".....kyyyyk.....",
+        "......kyyk......",
+        "......kywk......",
+        "......kywk......",
+        ".....kwwwwk.....",
+        "....kwwwwwwk....",
+        "...kwwwwwwwwk...",
+        "..kwwwwwwwwwwk..",
+        "..kyyyyyyyyyyk..",
+        "..kkkkkkkkkkkk..",
+        "................",
+    ],
+    [
+        "..kkkkkkkkkkkk..",
+        "..kwwwwwwwwwwk..",
+        "..kwwwwwwwwwwk..",
+        "...kyyyyyyyyk...",
+        "....kyyyyyyk....",
+        ".....kyyyyk.....",
+        "......kyyk......",
+        "......kywk......",
+        "......kywk......",
+        ".....kwwwwk.....",
+        "....kwwwwwwk....",
+        "...kwwwwwwwwk...",
+        "..kyyyyyyyyyyk..",
+        "..kyyyyyyyyyyk..",
+        "..kkkkkkkkkkkk..",
+        "................",
+    ],
+    [
+        "..kkkkkkkkkkkk..",
+        "..kwwwwwwwwwwk..",
+        "..kwwwwwwwwwwk..",
+        "...kwwwwwwwwk...",
+        "....kyyyyyyk....",
+        ".....kyyyyk.....",
+        "......kyyk......",
+        "......kwwk......",
+        "......kwwk......",
+        ".....kwwwwk.....",
+        "....kwwwwwwk....",
+        "...kyyyyyyyyk...",
+        "..kyyyyyyyyyyk..",
+        "..kyyyyyyyyyyk..",
+        "..kkkkkkkkkkkk..",
+        "................",
+    ],
+];
+
+function frameRects(grid: string[]) {
+    const rects: React.ReactNode[] = [];
+    grid.forEach((row, y) => {
+        let x = 0;
+        while (x < row.length) {
+            const ch = row[x];
+            if (!PALETTE[ch]) { x++; continue; }
+            let end = x + 1;
+            while (end < row.length && row[end] === ch) end++;
+            rects.push(<rect key={`${x},${y}`} x={x} y={y} width={end - x} height={1} fill={PALETTE[ch]} />);
+            x = end;
+        }
+    });
+    return rects;
+}
+
+// 关键帧只往文档里注入一次：写在 SVG 里的话每个实例都带一份，
+// 还会混进元素的 textContent。
+const STYLE_ID = "aivp-hourglass-style";
+
+function ensureKeyframes(): void {
+    if (typeof document === "undefined" || document.getElementById(STYLE_ID)) return;
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+        @keyframes aivp-hourglass { 0%, 24.99% { opacity: 1 } 25%, 100% { opacity: 0 } }
+        .aivp-hg-frame { animation: aivp-hourglass 1s linear infinite; }
+        @media (prefers-reduced-motion: reduce) { .aivp-hg-frame { animation: none } }
+    `;
+    document.head.appendChild(style);
+}
+
+/** 正在忙的像素沙漏（size 为像素边长） */
+export function PixelHourglass({ size = 14 }: { size?: number }) {
+    useEffect(ensureKeyframes, []);
+    return (
+        <svg
+            viewBox="0 0 16 16"
+            width={size}
+            height={size}
+            shapeRendering="crispEdges"
+            role="img"
+            aria-label="处理中"
+            style={{ display: "inline-block", verticalAlign: "-0.15em", flexShrink: 0 }}
+        >
+            {/* 四帧各显示 1/4 周期，靠 animation-delay 错开——同一时刻只有一帧可见。
+                行内 opacity 是关键帧就位前（以及降低动效偏好下）的兜底：只显示第一帧。 */}
+            {FRAMES.map((grid, index) => (
+                <g
+                    key={index}
+                    className="aivp-hg-frame"
+                    style={{ opacity: index === 0 ? 1 : 0, animationDelay: `${index * 0.25}s` }}
+                >
+                    {frameRects(grid)}
+                </g>
+            ))}
+        </svg>
+    );
+}

--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -40,6 +40,7 @@ import { fetchFlowerCounts, hasSentFlowerToday, sendFlower, type FlowerCounts } 
 import { STICKER_NAMES, StickerPixelIcon } from "@/components/resource-hub/pixel-stickers";
 import { RICH_COLORS, RichText } from "@/components/resource-hub/rich-text";
 import { RichEditor, type RichEditorHandle } from "@/components/resource-hub/rich-editor";
+import { PixelHourglass } from "@/components/pixel-hourglass";
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -69,6 +70,9 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     // 送花：各资源花数（我的货摊展示用）+ 非阻塞小提示
     const [flowerCounts, setFlowerCounts] = useState<FlowerCounts | null>(null);
     const [toast, setToast] = useState<string | null>(null);
+    // 联网中的按钮（各自显示像素沙漏）
+    const [sendingFlower, setSendingFlower] = useState(false);
+    const [importingTo, setImportingTo] = useState<string | null>(null);
     const [busyFile, setBusyFile] = useState<string | null>(null);
     // 导入流程：选文件 → 选目的地 →（聊天室CSS再选角色）
     const [importFile, setImportFile] = useState<string | null>(null);
@@ -177,9 +181,14 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
 
     // 手动送花（详情页按钮）。自动送花复用同一函数。
     const handleSendFlower = useCallback(async (entryPath: string, silent = false) => {
-        const sent = await sendFlower(loadUploadConfig().endpoint, entryPath);
-        if (sent) showToast("已送出一朵花 🌸");
-        else if (!silent) showToast("今天已经给它送过花啦");
+        if (!silent) setSendingFlower(true);
+        try {
+            const sent = await sendFlower(loadUploadConfig().endpoint, entryPath);
+            if (sent) showToast("已送出一朵花 🌸");
+            else if (!silent) showToast("今天已经给它送过花啦");
+        } finally {
+            if (!silent) setSendingFlower(false);
+        }
     }, [showToast]);
 
     const handleDownload = useCallback(async (path: string) => {
@@ -195,10 +204,11 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
         }
     }, [activeEntry, handleSendFlower, onNotice, source]);
 
+    // 导入时弹窗不立刻关闭：在刚点的那个图标上转沙漏，做完再关，
+    // 免得反馈跑到别的位置去（用户看不到自己点的东西有反应）
     const runImport = useCallback(async (path: string, destination: ImportDestination, contactId?: string) => {
-        setImportFile(null);
-        setPickCharacterFor(null);
         setBusyFile(path);
+        setImportingTo(contactId ?? destination);
         try {
             const message = await importResourceHubFile(source, path, destination, { contactId });
             onNotice?.(message);
@@ -206,6 +216,9 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
             onNotice?.(`导入失败：${err instanceof Error ? err.message : String(err)}`);
         } finally {
             setBusyFile(null);
+            setImportingTo(null);
+            setImportFile(null);
+            setPickCharacterFor(null);
         }
     }, [onNotice, source]);
 
@@ -312,7 +325,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
             ? () => setActiveFolder(null)
             : onClose;
 
-    const renderEntryRow = (entry: ShareIndexEntry, showFolder = false, flowers?: number) => (
+    const renderEntryRow = (entry: ShareIndexEntry, showFolder = false, flowers?: number | "loading") => (
         <button key={entry.path} className="rh-entry" onClick={() => { setActiveEntry(entry); setSelectedFile(entry.files[0] ?? null); }}>
             {entry.images.length > 0 ? (
                 // eslint-disable-next-line @next/next/no-img-element
@@ -325,7 +338,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                 {entry.description && <span className="rh-entry-desc"><RichText text={entry.description} mode="inline" /></span>}
                 <span className="rh-entry-meta">
                     {[showFolder ? entry.folder : "", formatEntryDate(entry.updatedAt), `${entry.files.length} 个文件`,
-                        flowers !== undefined ? `🌸 ${flowers}` : ""].filter(Boolean).join(" · ")}
+                        flowers === undefined ? "" : `🌸 ${flowers === "loading" ? "…" : flowers}`].filter(Boolean).join(" · ")}
                 </span>
             </span>
         </button>
@@ -340,7 +353,9 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     <span className="rh-titlebar-text"><RichText text={title} mode="sticker" /> - 资源集市</span>
                     <span className="rh-titlebar-controls">
                         <button className="rh-tb-btn" aria-label="资源仓库设置" onClick={() => { setSourceDraft(source); setShowSourceEditor(true); }}>⚙</button>
-                        <button className="rh-tb-btn" aria-label="刷新" onClick={() => reload(source, { purge: true })}>⟳</button>
+                        <button className="rh-tb-btn" aria-label="刷新" disabled={loadState === "loading"} onClick={() => reload(source, { purge: true })}>
+                            {loadState === "loading" ? <PixelHourglass size={13} /> : "⟳"}
+                        </button>
                         <button className="rh-tb-btn" aria-label="关闭" onClick={onClose}>✕</button>
                     </span>
                 </div>
@@ -382,10 +397,12 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                             <div className="rh-entry-list">
                                 {myStall.published.length > 0 && (
                                     <div className="rh-stall-flowers">
-                                        🌸 共收到 {myStall.published.reduce((sum, e) => sum + (flowerCounts?.[e.path] ?? 0), 0)} 朵花
+                                        {flowerCounts
+                                            ? `🌸 共收到 ${myStall.published.reduce((sum, e) => sum + (flowerCounts[e.path] ?? 0), 0)} 朵花`
+                                            : <><PixelHourglass size={13} /> 正在统计收到的花…</>}
                                     </div>
                                 )}
-                                {myStall.published.map(entry => renderEntryRow(entry, true, flowerCounts?.[entry.path] ?? 0))}
+                                {myStall.published.map(entry => renderEntryRow(entry, true, flowerCounts ? (flowerCounts[entry.path] ?? 0) : "loading"))}
                                 {myStall.pending.map(item => (
                                     <div key={item.name + item.uploadedAt} className="rh-entry rh-entry-pending">
                                         <span className="rh-entry-thumb rh-entry-thumb-blank">⏳</span>
@@ -510,17 +527,23 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                     <div className="rh-detail2-actions">
                                         <button
                                             className="rh-btn rh-flower-btn"
-                                            disabled={hasSentFlowerToday(activeEntry.path)}
+                                            disabled={sendingFlower || hasSentFlowerToday(activeEntry.path)}
                                             title="给作者送一朵花"
                                             onClick={() => void handleSendFlower(activeEntry.path)}
                                         >
-                                            {hasSentFlowerToday(activeEntry.path) ? "已送🌸" : "送花🌸"}
+                                            {sendingFlower
+                                                ? <><PixelHourglass size={13} /> 送出中</>
+                                                : hasSentFlowerToday(activeEntry.path) ? "已送🌸" : "送花🌸"}
                                         </button>
                                         <button className="rh-btn rh-action-half" disabled={!selectedFile || busyFile === selectedFile} onClick={() => selectedFile && handleDownload(selectedFile)}>
-                                            下载
+                                            {busyFile === selectedFile && !importingTo
+                                                ? <><PixelHourglass size={13} /> 下载中</>
+                                                : "下载"}
                                         </button>
                                         <button className="rh-btn rh-btn-primary rh-action-half" disabled={!selectedFile || busyFile === selectedFile} onClick={() => selectedFile && setImportFile(selectedFile)}>
-                                            {busyFile === selectedFile ? "处理中..." : "导入"}
+                                            {busyFile === selectedFile && importingTo
+                                                ? <><PixelHourglass size={13} /> 导入中</>
+                                                : "导入"}
                                         </button>
                                         {(uploadCfg.githubToken.trim() || loadMyUploads().some(r => r.path === activeEntry.path)) && (
                                             <button className="rh-btn rh-action-del" onClick={() => setConfirmDeleteEntry(activeEntry)}>删除</button>
@@ -566,21 +589,23 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
 
             {/* 导入目的地选择 */}
             {importFile && (
-                <div className="rh-dialog-overlay" onClick={() => setImportFile(null)}>
+                <div className="rh-dialog-overlay" onClick={importingTo ? undefined : () => setImportFile(null)}>
                     <div className="rh-dialog" onClick={e => e.stopPropagation()}>
                         <div className="rh-titlebar">
                             <span className="rh-titlebar-text">导入到...</span>
                             <span className="rh-titlebar-controls">
-                                <button className="rh-tb-btn" onClick={() => setImportFile(null)}>✕</button>
+                                <button className="rh-tb-btn" disabled={!!importingTo} onClick={() => setImportFile(null)}>✕</button>
                             </span>
                         </div>
                         {/* 文件全名（文件条里显示不全，这里完整展示） */}
                         <div className="rh-import-filename">{importFile.split("/").pop() || importFile}</div>
                         <div className="rh-dialog-body rh-dest-grid">
                             {IMPORT_DESTINATIONS.map(dest => (
-                                <button key={dest.key} className="rh-dest-tile" title={dest.hint} onClick={() => handlePickDestination(dest.key)}>
-                                    <DestPixelIcon dest={dest.key} />
-                                    <span className="rh-dest-tile-label">{dest.label}</span>
+                                <button key={dest.key} className="rh-dest-tile" title={dest.hint}
+                                    disabled={!!importingTo} onClick={() => handlePickDestination(dest.key)}>
+                                    {/* 正在导入的那一格换成沙漏，反馈就在刚点的位置上 */}
+                                    {importingTo === dest.key ? <PixelHourglass size={34} /> : <DestPixelIcon dest={dest.key} />}
+                                    <span className="rh-dest-tile-label">{importingTo === dest.key ? "导入中…" : dest.label}</span>
                                 </button>
                             ))}
                         </div>
@@ -590,18 +615,22 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
 
             {/* 聊天室 CSS：选择角色 */}
             {pickCharacterFor && (
-                <div className="rh-dialog-overlay" onClick={() => setPickCharacterFor(null)}>
+                <div className="rh-dialog-overlay" onClick={importingTo ? undefined : () => setPickCharacterFor(null)}>
                     <div className="rh-dialog" onClick={e => e.stopPropagation()}>
                         <div className="rh-titlebar">
                             <span className="rh-titlebar-text">应用到哪个角色的聊天室？</span>
                             <span className="rh-titlebar-controls">
-                                <button className="rh-tb-btn" onClick={() => setPickCharacterFor(null)}>✕</button>
+                                <button className="rh-tb-btn" disabled={!!importingTo} onClick={() => setPickCharacterFor(null)}>✕</button>
                             </span>
                         </div>
                         <div className="rh-dialog-body rh-dest-list">
                             {chatContacts.length > 0 ? chatContacts.map(contact => (
-                                <button key={contact.contactId} className="rh-dest" onClick={() => void runImport(pickCharacterFor, "chat_session_css", contact.contactId)}>
-                                    <span className="rh-dest-label">{contact.name}</span>
+                                <button key={contact.contactId} className="rh-dest" disabled={!!importingTo}
+                                    onClick={() => void runImport(pickCharacterFor, "chat_session_css", contact.contactId)}>
+                                    <span className="rh-dest-label">
+                                        {importingTo === contact.contactId && <><PixelHourglass size={13} /> </>}
+                                        {contact.name}
+                                    </span>
                                 </button>
                             )) : (
                                 <div className="rh-center-hint">还没有聊天联系人，先去聊天里添加角色吧</div>
@@ -623,7 +652,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                         <div className="rh-dialog-footer">
                             <button className="rh-btn" disabled={deleting} onClick={() => setConfirmDeleteEntry(null)}>取消</button>
                             <button className="rh-btn rh-action-del" disabled={deleting} onClick={() => void handleDeleteEntry(confirmDeleteEntry)}>
-                                {deleting ? "删除中..." : "确认删除"}
+                                {deleting ? <><PixelHourglass size={13} /> 删除中…</> : "确认删除"}
                             </button>
                         </div>
                     </div>
@@ -710,7 +739,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                         <div className="rh-dialog-footer">
                             <button className="rh-btn" disabled={uploading} onClick={() => setShowUpload(false)}>取消</button>
                             <button className="rh-btn rh-btn-primary" disabled={uploading} onClick={() => void handleUploadSubmit()}>
-                                {uploading ? "提交中..." : "提交"}
+                                {uploading ? <><PixelHourglass size={13} /> 提交中…</> : "提交"}
                             </button>
                         </div>
                     </div>
@@ -865,6 +894,8 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     white-space: nowrap;
                 }
                 .rh-btn:active { border-color: #404040 #ffffff #ffffff #404040; }
+                /* 忙碌态：按钮里的沙漏与文字并排居中 */
+                .rh-btn { display: inline-flex; align-items: center; justify-content: center; gap: 4px; }
                 .rh-btn:disabled { color: #808080; text-shadow: 1px 1px 0 #fff; cursor: default; }
                 .rh-btn-primary { font-weight: 700; outline: 1px solid #000; }
                 /* 浏览集市 / 我的货摊 切换（仿 Win98 标签页按钮） */

--- a/components/settings/moderation-center.tsx
+++ b/components/settings/moderation-center.tsx
@@ -115,7 +115,8 @@ export function ModerationCenter({ onNotice }: { onNotice?: (msg: string) => voi
   // ── 集市审核（share 仓库待审投稿；权限由 GitHub 服务端裁决）──
   const [shareItems, setShareItems] = useState<ShareSubmission[]>([]);
   const [shareLoading, setShareLoading] = useState(false);
-  const [shareBusy, setShareBusy] = useState<Record<number, boolean>>({});
+  // 记录正在进行的动作，按钮上好显示「上架中…/拒绝中…」
+  const [shareBusy, setShareBusy] = useState<Record<number, "approve" | "reject">>({});
   const [shareExpanded, setShareExpanded] = useState<number | null>(null);
   const [shareFiles, setShareFiles] = useState<Record<number, ShareSubmissionFile[] | "loading">>({});
   const [shareRejectFor, setShareRejectFor] = useState<number | null>(null);
@@ -153,7 +154,7 @@ export function ModerationCenter({ onNotice }: { onNotice?: (msg: string) => voi
   };
 
   const runShareAction = async (item: ShareSubmission, action: "approve" | "reject", reason?: string) => {
-    setShareBusy(current => ({ ...current, [item.number]: true }));
+    setShareBusy(current => ({ ...current, [item.number]: action }));
     try {
       if (action === "approve") {
         await approveShareSubmission(item.number);
@@ -362,16 +363,24 @@ export function ModerationCenter({ onNotice }: { onNotice?: (msg: string) => voi
                       placeholder="拒绝理由（可选，投稿人可见）"
                       style={{ flex: 1, minWidth: 0, border: "1px solid var(--border-soft, rgba(0,0,0,.1))", borderRadius: 10, padding: "6px 10px", fontSize: 12, background: "var(--surface-inset, rgba(0,0,0,.03))", color: "inherit", outline: "none" }}
                     />
-                    <button type="button" style={dangerBtn} disabled={shareBusy[item.number]} onClick={() => void runShareAction(item, "reject", shareRejectReason)}>确认拒绝</button>
+                    <button type="button" style={dangerBtn} disabled={!!shareBusy[item.number]} onClick={() => void runShareAction(item, "reject", shareRejectReason)}>
+                      {shareBusy[item.number] === "reject"
+                        ? <><Loader2 size={12} className="animate-spin" style={{ verticalAlign: -2 }} /> 拒绝中…</>
+                        : "确认拒绝"}
+                    </button>
                     <button type="button" style={btnStyle} onClick={() => { setShareRejectFor(null); setShareRejectReason(""); }}>取消</button>
                   </div>
                 ) : (
                   <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
-                    <button type="button" style={btnStyle} disabled={shareBusy[item.number]} onClick={() => void toggleShareDetail(item)}>
+                    <button type="button" style={btnStyle} disabled={!!shareBusy[item.number]} onClick={() => void toggleShareDetail(item)}>
                       {expanded ? "收起内容" : "查看内容"}
                     </button>
-                    <button type="button" style={btnStyle} disabled={shareBusy[item.number]} onClick={() => void runShareAction(item, "approve")}>通过并上架</button>
-                    <button type="button" style={dangerBtn} disabled={shareBusy[item.number]} onClick={() => setShareRejectFor(item.number)}>拒绝</button>
+                    <button type="button" style={btnStyle} disabled={!!shareBusy[item.number]} onClick={() => void runShareAction(item, "approve")}>
+                      {shareBusy[item.number] === "approve"
+                        ? <><Loader2 size={12} className="animate-spin" style={{ verticalAlign: -2 }} /> 上架中…</>
+                        : "通过并上架"}
+                    </button>
+                    <button type="button" style={dangerBtn} disabled={!!shareBusy[item.number]} onClick={() => setShareRejectFor(item.number)}>拒绝</button>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
之前只把按钮变灰、文字不变（复古灰按钮上几乎看不出区别），有些干脆没有任何反馈，点下去像卡住了。现在统一用像素沙漏动画（4 帧 16×16，纯 CSS 轮播，关键帧全局只注入一次）。

**资源集市**
- 送花：新增 busy 状态 →「⏳ 送出中」并禁用（原先 1~3 秒完全无反馈）
- 下载：按钮文字改「⏳ 下载中」
- 导入：目的地弹窗不再提前关闭，沙漏显示在刚点的那个图标上，做完自动关；聊天室 CSS 选角色同理
- 刷新 ⟳：按钮本身变沙漏并禁用
- 我的货摊：花数未加载完时显示「正在统计收到的花…」与「🌸 …」，不再先显示错误的 0
- 提交/删除：沿用原文案并加上沙漏

**集市审核**（沿用该页已有的 Loader2 转圈，不混入像素风）
- 通过并上架 →「上架中…」；确认拒绝 →「拒绝中…」

全屏预览的「保存图片」也补了「保存中…」（聊天/动态共用此按钮）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_