### PR TITLE
资源集市：摊主钥匙可跨设备，并纳入数据备份

### DIFF
--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -36,6 +36,14 @@ import {
     type ResourceHubUploadConfig,
 } from "@/lib/resource-hub-upload";
 import { avatarBase64, fileToAvatarDataUrl, loadHubProfile, saveHubProfile, type HubProfile } from "@/lib/resource-hub-profile";
+import {
+    ensureIdentityKey,
+    exportKeyBundle,
+    parseKeyBundle,
+    setIdentityKey,
+    sha256Hex,
+} from "@/lib/resource-hub-identity";
+import { mergeMyUploads } from "@/lib/resource-hub-upload";
 import { DefaultPixelAvatar } from "@/components/resource-hub/pixel-avatar";
 import { DestPixelIcon, FileTypePixelIcon, fileExtension } from "@/components/resource-hub/pixel-icons";
 import { deleteShareEntry } from "@/lib/resource-hub-review";
@@ -77,6 +85,12 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     // 摊主资料（昵称 + 头像，本机存；上传/编辑时头像一并发布）
     const [profile, setProfile] = useState<HubProfile>(() => loadHubProfile());
     const [editingNickname, setEditingNickname] = useState(false);
+    // 摊主钥匙与它的指纹：指纹用来在索引里认领"哪些资源是我发的"。
+    // 钥匙只在这个 effect 里取一次（要等存储加载完），渲染期一律读这份状态。
+    const [identityKey, setIdentityKeyState] = useState("");
+    const [identityHash, setIdentityHash] = useState("");
+    const [showKeyDialog, setShowKeyDialog] = useState(false);
+    const [keyImportText, setKeyImportText] = useState("");
     // 作者编辑已发布资源
     const [editEntry, setEditEntry] = useState<ShareIndexEntry | null>(null);
     const [editRecord, setEditRecord] = useState<MyUploadRecord | null>(null);
@@ -116,9 +130,19 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     const uploadNameRef = useRef<RichEditorHandle | null>(null);
     const uploadDescRef = useRef<RichEditorHandle | null>(null);
 
-    /** 这条资源是不是本机发布的（有删除/编辑凭证） */
-    const myRecordFor = useCallback((path: string): MyUploadRecord | null =>
-        loadMyUploads().find(r => r.path === path) ?? null, []);
+    /**
+     * 这条资源是不是我发的：先看本机记录，再看索引里的钥匙指纹是否与本机钥匙吻合。
+     * 后者让换了设备、只导入了钥匙的人也能直接编辑/删除自己的旧发布。
+     */
+    const myRecordFor = useCallback((path: string): MyUploadRecord | null => {
+        const local = loadMyUploads().find(r => r.path === path);
+        if (local) return local;
+        const entry = index?.entries.find(e => e.path === path);
+        if (identityHash && identityKey && entry?.ownerHash && entry.ownerHash === identityHash) {
+            return { path, name: entry.name, ownerKey: identityKey, uploadedAt: entry.updatedAt || "" };
+        }
+        return null;
+    }, [identityHash, identityKey, index]);
 
     const showToast = useCallback((msg: string) => {
         setToast(msg);
@@ -132,6 +156,19 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
 
     // 工具栏按钮按下时不抢走编辑器焦点，选区才能保住（iOS 上尤其关键）
     const keepSelection = useCallback((e: React.PointerEvent) => e.preventDefault(), []);
+
+    // 本机钥匙取一次就够（钥匙不变）。必须等 kv 从 IndexedDB 加载完再判断，
+    // 否则冷启动瞬间会误判成"没有钥匙"而新生成一把，把原来的覆盖掉。
+    useEffect(() => {
+        let cancelled = false;
+        void ensureIdentityKey().then(async key => {
+            if (cancelled) return;
+            setIdentityKeyState(key);
+            const hash = await sha256Hex(key);
+            if (!cancelled) setIdentityHash(hash);
+        });
+        return () => { cancelled = true; };
+    }, []);
 
     // 编辑弹窗打开时把现有标题/正文灌进所见即所得编辑器（编辑器是非受控的）
     useEffect(() => {
@@ -190,14 +227,24 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
         const records = loadMyUploads();
         const published: ShareIndexEntry[] = [];
         const pending: { name: string; uploadedAt: string }[] = [];
+        const claimed = new Set<string>();
         for (const record of records) {
             const entry = index?.entries.find(e => e.path === record.path);
-            if (entry) published.push(entry);
+            if (entry) { published.push(entry); claimed.add(entry.path); }
             else pending.push({ name: record.name, uploadedAt: record.uploadedAt });
+        }
+        // 换设备后本机没有记录，但索引里的钥匙指纹对得上，一样是我的摊位
+        if (identityHash) {
+            for (const entry of index?.entries ?? []) {
+                if (!claimed.has(entry.path) && entry.ownerHash && entry.ownerHash === identityHash) {
+                    published.push(entry);
+                    claimed.add(entry.path);
+                }
+            }
         }
         return { published, pending };
         // index 变化或切到货摊时重算
-    }, [index, viewMode]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [index, viewMode, identityHash]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const chatContacts = useMemo(() => {
         if (pickCharacterFor === null) return [];
@@ -529,6 +576,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                             <span>收到 <b>{flowerCounts
                                                 ? myStall.published.reduce((sum, e) => sum + (flowerCounts[e.path] ?? 0), 0)
                                                 : "…"}</b> 🌸</span>
+                                            <button className="rh-key-link" onClick={() => { setKeyImportText(""); setShowKeyDialog(true); }}>🔑 摊主钥匙</button>
                                         </div>
                                     </div>
                                 </div>
@@ -580,6 +628,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                             <span>已发布 <b>0</b></span>
                                             <span>待审核 <b>0</b></span>
                                             <span>收到 <b>0</b> 🌸</span>
+                                            <button className="rh-key-link" onClick={() => { setKeyImportText(""); setShowKeyDialog(true); }}>🔑 摊主钥匙</button>
                                         </div>
                                     </div>
                                 </div>
@@ -843,6 +892,64 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                             <button className="rh-btn rh-action-del" disabled={deleting} onClick={() => void handleDeleteEntry(confirmDeleteEntry)}>
                                 {deleting ? <><PixelHourglass size={13} /> 删除中…</> : "确认删除"}
                             </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* 摊主钥匙：换设备时带走它，就能继续管理自己的发布 */}
+            {showKeyDialog && (
+                <div className="rh-dialog-overlay" onClick={() => setShowKeyDialog(false)}>
+                    <div className="rh-dialog" onClick={e => e.stopPropagation()}>
+                        <div className="rh-titlebar">
+                            <span className="rh-titlebar-text">摊主钥匙</span>
+                            <span className="rh-titlebar-controls">
+                                <button className="rh-tb-btn" onClick={() => setShowKeyDialog(false)}>✕</button>
+                            </span>
+                        </div>
+                        <div className="rh-dialog-body rh-form">
+                            <div className="rh-key-warning">
+                                🔑 这串码就是你对自己所有发布的所有权证明。<b>换手机/重装前请存好</b>，
+                                在新设备粘贴它，货摊和编辑权限就都回来了。<b>不要发给任何人</b>——
+                                拿到的人能改能删你的全部资源。
+                            </div>
+                            <div className="rh-form-field">
+                                <span>我的钥匙（长按可复制）</span>
+                                <textarea className="rh-input rh-key-text" readOnly rows={3} value={exportKeyBundle(identityKey)}
+                                    onFocus={e => e.currentTarget.select()} />
+                            </div>
+                            <button className="rh-btn" onClick={async () => {
+                                try {
+                                    await navigator.clipboard.writeText(exportKeyBundle(identityKey));
+                                    showToast("钥匙已复制，找个安全地方存好");
+                                } catch {
+                                    showToast("复制失败，请长按上面的文字手动复制");
+                                }
+                            }}>复制钥匙</button>
+                            <div className="rh-form-field">
+                                <span>在新设备上：粘贴钥匙并导入</span>
+                                <textarea className="rh-input rh-key-text" rows={3} value={keyImportText}
+                                    placeholder="粘贴从旧设备复制的钥匙…"
+                                    onChange={e => setKeyImportText(e.target.value)} />
+                            </div>
+                            <button className="rh-btn rh-btn-primary" disabled={!keyImportText.trim()} onClick={() => {
+                                try {
+                                    const parsed = parseKeyBundle(keyImportText);
+                                    setIdentityKey(parsed.identity);
+                                    setIdentityKeyState(parsed.identity);
+                                    if (parsed.legacy.length) mergeMyUploads(parsed.legacy);
+                                    void sha256Hex(parsed.identity).then(setIdentityHash);
+                                    setShowKeyDialog(false);
+                                    setKeyImportText("");
+                                    onNotice?.("钥匙已导入，你的发布正在认领回来");
+                                } catch (err) {
+                                    showToast(err instanceof Error ? err.message : "导入失败");
+                                }
+                            }}>导入钥匙</button>
+                            <div className="rh-form-hint">
+                                导入后本机原来的钥匙会被替换。如果两台设备都发过资源，
+                                请先在另一台导出、这里导入，两边的发布才会合并到一把钥匙下管理。
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -1394,6 +1501,30 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     color: #404040;
                 }
                 .rh-profile-stats b { color: #000; font-size: calc(13px * var(--app-text-scale, 1)); }
+                /* 摊主钥匙 */
+                .rh-key-link {
+                    background: none;
+                    border: none;
+                    padding: 0;
+                    font-size: calc(11px * var(--app-text-scale, 1));
+                    color: #000080;
+                    text-decoration: underline;
+                    cursor: pointer;
+                }
+                .rh-key-warning {
+                    background: #ffffe1;
+                    border: 1px solid #808080;
+                    padding: 8px;
+                    font-size: calc(11px * var(--app-text-scale, 1));
+                    line-height: 1.7;
+                    color: #000;
+                }
+                .rh-key-text {
+                    font-family: Consolas, "Courier New", monospace;
+                    font-size: calc(10px * var(--app-text-scale, 1));
+                    word-break: break-all;
+                    resize: none;
+                }
                 /* 编辑弹窗的文件清单 */
                 .rh-edit-files { display: flex; flex-direction: column; gap: 3px; }
                 .rh-edit-file {

--- a/components/settings/data-management.tsx
+++ b/components/settings/data-management.tsx
@@ -15,6 +15,7 @@ import {
   Settings2,
   Smartphone,
   Sparkles,
+  Store,
   Trash2,
   Upload,
   UserRound,
@@ -95,6 +96,7 @@ const MODULE_ICONS: Record<DataModuleId, LucideIcon> = {
   memory: Brain,
   social: UsersRound,
   apps: Smartphone,
+  resource_hub: Store,
   creative: Sparkles,
   cache: Archive,
 };
@@ -107,6 +109,7 @@ const MODULE_ACCENTS: Record<DataModuleId, string> = {
   memory: BINDING_ACCENTS.memory,
   social: CONTENT_APP_ACCENTS.moments,
   apps: CONTENT_APP_ACCENTS.calendar,
+  resource_hub: CONTENT_APP_ACCENTS.shopping,
   creative: CONTENT_APP_ACCENTS.story,
   cache: BINDING_ACCENTS.regex,
 };

--- a/lib/data-management/modules.ts
+++ b/lib/data-management/modules.ts
@@ -234,6 +234,27 @@ export const DATA_MODULES: DataModuleDefinition[] = [
     ],
   },
   {
+    id: "resource_hub",
+    label: "资源集市",
+    description: "摊主钥匙（自己发布资源的所有权凭证）、昵称头像与集市设置",
+    variant: "teal",
+    sources: [
+      {
+        type: "kv",
+        label: "摊主身份与集市设置",
+        keys: [
+          // 钥匙丢了就再也管不了自己发过的资源，必须跟着备份走
+          "ai_phone_resource_hub_identity_v1",
+          "ai_phone_resource_hub_my_uploads_v1",
+          "ai_phone_resource_hub_profile_v1",
+          "ai_phone_resource_hub_upload_cfg_v1",
+          "ai_phone_resource_hub_source_v1",
+          "ai_phone_resource_hub_flowers_sent_v1",
+        ],
+      },
+    ],
+  },
+  {
     id: "creative",
     label: "创作与玩法",
     description: "故事、漫卷、地图、住宅、黑市、查手机快照与世界构建素材",

--- a/lib/data-management/types.ts
+++ b/lib/data-management/types.ts
@@ -6,6 +6,7 @@ export type DataModuleId =
   | "memory"
   | "social"
   | "apps"
+  | "resource_hub"
   | "creative"
   | "cache";
 

--- a/lib/resource-hub-client.ts
+++ b/lib/resource-hub-client.ts
@@ -157,6 +157,7 @@ function normalizeIndex(raw: unknown): ShareIndex {
             description: typeof item.description === "string" ? item.description : "",
             author: typeof item.author === "string" ? item.author : "",
             avatar: typeof item.avatar === "string" ? item.avatar : "",
+            ownerHash: typeof item.ownerHash === "string" ? item.ownerHash.toLowerCase() : "",
             updatedAt: typeof item.updatedAt === "string" ? item.updatedAt : null,
         });
     }

--- a/lib/resource-hub-identity.ts
+++ b/lib/resource-hub-identity.ts
@@ -1,0 +1,107 @@
+// lib/resource-hub-identity.ts
+// 「摊主钥匙」：一台设备一把（可导出到别的设备），所有发布共用。
+//
+// 为什么这么设计：集市不要求注册登录，服务端没有可认的身份，所以用
+// "谁拿得出钥匙谁就是作者"。仓库里只存钥匙的 SHA-256 指纹（.owner），
+// 钥匙本体永远不离开用户设备——服务端每次现算现比，比完就扔。
+//
+// 换设备时把钥匙带过去即可：索引里带着每条资源的指纹，新设备拿钥匙
+// 一算就知道哪些是自己的，「我的货摊」自动认领回来。
+
+import { hydrateKvDb, kvGet, kvSet, registerKvMigration } from "./kv-db";
+import { loadMyUploads, type MyUploadRecord } from "./resource-hub-upload";
+
+const IDENTITY_KEY = "ai_phone_resource_hub_identity_v1";
+registerKvMigration(IDENTITY_KEY);
+
+const KEY_RE = /^[a-f0-9]{48}$/i;
+
+/**
+ * 取本机钥匙，没有就生成一把（48 位十六进制 = 192 bit 随机）。
+ *
+ * 必须先等存储层加载完再判断"有没有"：kv 是 IndexedDB 撑的，冷启动那一小会儿
+ * 读出来是空的，若此时就生成新钥匙，会把用户原来的钥匙覆盖掉——等于把他
+ * 已发布资源的所有权凭空丢掉。所以这个函数是异步的，且只有它能创建钥匙。
+ */
+export async function ensureIdentityKey(): Promise<string> {
+    await hydrateKvDb();
+    const existing = peekIdentityKey();
+    if (existing) return existing;
+    const bytes = new Uint8Array(24);
+    crypto.getRandomValues(bytes);
+    const key = Array.from(bytes, b => b.toString(16).padStart(2, "0")).join("");
+    kvSet(IDENTITY_KEY, key);
+    return key;
+}
+
+/** 只读取，不生成（判断有没有设置过） */
+export function peekIdentityKey(): string {
+    const existing = (kvGet(IDENTITY_KEY) || "").trim().toLowerCase();
+    return KEY_RE.test(existing) ? existing : "";
+}
+
+export function setIdentityKey(key: string): void {
+    const clean = key.trim().toLowerCase();
+    if (!KEY_RE.test(clean)) throw new Error("钥匙格式不对（应为 48 位字母数字）");
+    kvSet(IDENTITY_KEY, clean);
+}
+
+export async function sha256Hex(text: string): Promise<string> {
+    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+    return Array.from(new Uint8Array(digest), b => b.toString(16).padStart(2, "0")).join("");
+}
+
+// ── 导出 / 导入 ──
+
+const EXPORT_PREFIX = "FLOATKEY1:";
+
+type KeyBundle = {
+    v: 1;
+    /** 摊主钥匙 */
+    id: string;
+    /** 早期发布用的一资源一钥匙，一并带走免得旧资源失联 */
+    legacy: Array<{ path: string; key: string }>;
+};
+
+/** 导出成一行短码：钥匙 + 早期的单资源凭证 */
+export function exportKeyBundle(identityKey: string): string {
+    const bundle: KeyBundle = {
+        v: 1,
+        id: identityKey,
+        legacy: loadMyUploads()
+            .filter(r => r.ownerKey && r.ownerKey.toLowerCase() !== identityKey)
+            .map(r => ({ path: r.path, key: r.ownerKey })),
+    };
+    const json = JSON.stringify(bundle);
+    // 用 base64 包一层，避免用户复制时被换行/空格弄坏
+    const base64 = btoa(unescape(encodeURIComponent(json)));
+    return EXPORT_PREFIX + base64;
+}
+
+export type ImportResult = { identity: string; legacy: MyUploadRecord[] };
+
+/** 解析导出码；也接受直接粘贴 48 位钥匙本体 */
+export function parseKeyBundle(text: string): ImportResult {
+    const clean = text.trim();
+    if (KEY_RE.test(clean)) return { identity: clean.toLowerCase(), legacy: [] };
+    if (!clean.startsWith(EXPORT_PREFIX)) throw new Error("这不是一串有效的摊主钥匙");
+    let bundle: KeyBundle;
+    try {
+        bundle = JSON.parse(decodeURIComponent(escape(atob(clean.slice(EXPORT_PREFIX.length))))) as KeyBundle;
+    } catch {
+        throw new Error("钥匙内容已损坏，请重新复制");
+    }
+    if (!bundle || !KEY_RE.test(bundle.id || "")) throw new Error("钥匙内容不完整");
+    const legacy = Array.isArray(bundle.legacy) ? bundle.legacy : [];
+    return {
+        identity: bundle.id.toLowerCase(),
+        legacy: legacy
+            .filter(item => item && typeof item.path === "string" && typeof item.key === "string")
+            .map(item => ({
+                path: item.path,
+                name: item.path.split("/").pop() || item.path,
+                ownerKey: item.key,
+                uploadedAt: new Date(0).toISOString(),
+            })),
+    };
+}

--- a/lib/resource-hub-types.ts
+++ b/lib/resource-hub-types.ts
@@ -27,6 +27,8 @@ export type ShareIndexEntry = {
     author?: string;
     /** 投稿人头像的仓库路径（.avatar.png，可为空） */
     avatar?: string;
+    /** 发布者钥匙的 SHA-256 指纹（.owner 内容），用于换设备认领 */
+    ownerHash?: string;
     /** 最近更新时间（ISO），索引生成时来自 git log */
     updatedAt: string | null;
 };

--- a/lib/resource-hub-upload.ts
+++ b/lib/resource-hub-upload.ts
@@ -6,6 +6,7 @@
 //     由机器人 token 代开 PR。
 
 import { kvGet, kvSet, registerKvMigration } from "./kv-db";
+import { ensureIdentityKey } from "./resource-hub-identity";
 import { RESOURCE_ROOT } from "./resource-hub-client";
 import type { ResourceHubSource } from "./resource-hub-types";
 
@@ -107,10 +108,17 @@ export function removeMyUploadRecord(path: string): void {
     saveMyUploads(loadMyUploads().filter(r => r.path !== path));
 }
 
-function generateOwnerKey(): string {
-    const bytes = new Uint8Array(24);
-    crypto.getRandomValues(bytes);
-    return Array.from(bytes, b => b.toString(16).padStart(2, "0")).join("");
+// 发布用的钥匙 = 本机「摊主钥匙」。以前是一个资源一把随机钥匙，换设备就全丢；
+// 现在全部资源共用一把，导出这一行短码就能在新设备上认领回所有发布。
+function generateOwnerKey(): Promise<string> {
+    return ensureIdentityKey();
+}
+
+/** 导入钥匙时把早期的单资源凭证并进本机记录（同路径以已有的为准） */
+export function mergeMyUploads(records: MyUploadRecord[]): void {
+    const existing = loadMyUploads();
+    const known = new Set(existing.map(r => r.path));
+    saveMyUploads([...existing, ...records.filter(r => !known.has(r.path))]);
 }
 
 async function sha256Hex(text: string): Promise<string> {
@@ -132,7 +140,7 @@ export async function fileToUploadEntry(file: File): Promise<UploadPayloadFile> 
 // ── 方案 B：上传服务 ──
 
 export async function uploadViaService(endpoint: string, payload: UploadPayload): Promise<UploadResult> {
-    const ownerKey = generateOwnerKey();
+    const ownerKey = await generateOwnerKey();
     const ownerKeyHash = await sha256Hex(ownerKey);
     const res = await fetch(endpoint, {
         method: "POST",
@@ -221,7 +229,7 @@ export async function uploadViaToken(token: string, source: ResourceHubSource, p
     const { owner, repo, branch } = source;
     const dirName = safeSegment(payload.name);
     const dir = `${RESOURCE_ROOT}/${payload.folder}/${dirName}`;
-    const ownerKey = generateOwnerKey();
+    const ownerKey = await generateOwnerKey();
     const toWrite: UploadPayloadFile[] = [...payload.files];
     if (payload.description.trim()) {
         toWrite.push({


### PR DESCRIPTION
原来每发一个资源就生成一把随机钥匙、只存在本机，换设备等于把自己所有发布的所有权丢掉。现在：

- 改为每人一把「摊主钥匙」，所有发布共用；索引带上钥匙指纹（`ownerHash`），新设备粘贴钥匙即可自动认领回全部发布，编辑/删除权限一并恢复
- 我的货摊资料卡加「🔑 摊主钥匙」：一行短码导出/导入，附醒目风险提示；导出码里带上早期的一资源一钥匙，旧发布不会失联
- 集市数据（钥匙、上传记录、昵称头像、设置）纳入 data-management 备份模块，整机备份/恢复与云备份都会带上——之前是唯一漏掉的模块

顺带修掉一个会丢所有权的真 bug：钥匙原先在 kv 从 IndexedDB 加载完之前就被读取，冷启动瞬间会误判"没有钥匙"而新生成一把覆盖掉原来的。现在创建钥匙必须先 `await hydrateKvDb()`，渲染期一律只读已解析出的状态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_