### PR TITLE
资源集市：修复详情页作者头像没铺满格子

### DIFF
--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -1392,7 +1392,9 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     justify-content: center;
                     -webkit-tap-highlight-color: rgba(0, 0, 128, 0.15);
                 }
-                .rh-detail2-main img {
+                /* 只作用于配图；写成 .rh-detail2-main img 会连作者头像一起套住，
+                   头像格子才 36px 宽，88% 一算就缩成 31px，右边空出一条 */
+                .rh-detail2-imgwrap img {
                     max-width: min(300px, 88%);
                     max-height: 360px;
                     width: auto;


### PR DESCRIPTION
配图那条 `max-width: min(300px, 88%)` 写在 `.rh-detail2-main img` 上，把同在内容区里的作者头像 `<img>` 也套住了：头像格子内容区只有 36px 宽，88% 一算是 31px，右边就空出一条底色。规则改挂到配图容器 `.rh-detail2-imgwrap` 上，头像恢复填满（36×36，零留白），配图尺寸不变（290px）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_