### PR TITLE
资源集市：设置齿轮改为自绘像素图标

### DIFF
--- a/components/resource-hub/pixel-icons.tsx
+++ b/components/resource-hub/pixel-icons.tsx
@@ -261,6 +261,31 @@ export function DestPixelIcon({ dest, size = 34 }: { dest: ImportDestination; si
     return renderGrid(DEST_ICONS[dest], size);
 }
 
+// 标题栏的"设置"齿轮。用 ⚙ 字符的话，iOS 会当彩色 emoji 画，
+// 和这套复古单色界面完全不搭，所以自己画一个。
+const GEAR_ICON: PixelGrid = [
+    "................",
+    ".......kk.......",
+    ".......kk.......",
+    "...kkkkkkkkkk...",
+    "...kkkkkkkkkk...",
+    "...kkkk..kkkk...",
+    "...kkk....kkk...",
+    ".kkkk......kkkk.",
+    ".kkkk......kkkk.",
+    "...kkk....kkk...",
+    "...kkkk..kkkk...",
+    "...kkkkkkkkkk...",
+    "...kkkkkkkkkk...",
+    ".......kk.......",
+    ".......kk.......",
+    "................",
+];
+
+export function GearPixelIcon({ size = 15 }: { size?: number }) {
+    return renderGrid(GEAR_ICON, size);
+}
+
 // ── 按扩展名生成的文件图标（详情页文件条用）──
 // 统一的"折角文档"底版，"a" 为类型强调色（内容线条区）。
 

--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -45,7 +45,7 @@ import {
 } from "@/lib/resource-hub-identity";
 import { mergeMyUploads } from "@/lib/resource-hub-upload";
 import { DefaultPixelAvatar } from "@/components/resource-hub/pixel-avatar";
-import { DestPixelIcon, FileTypePixelIcon, fileExtension } from "@/components/resource-hub/pixel-icons";
+import { DestPixelIcon, FileTypePixelIcon, GearPixelIcon, fileExtension } from "@/components/resource-hub/pixel-icons";
 import { deleteShareEntry } from "@/lib/resource-hub-review";
 import { MediaPreviewOverlay } from "@/components/chat/media-preview-overlay";
 import { fetchFlowerCounts, hasSentFlowerToday, sendFlower, type FlowerCounts } from "@/lib/resource-hub-flowers";
@@ -502,7 +502,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     <span className="rh-titlebar-icon">🗂️</span>
                     <span className="rh-titlebar-text"><RichText text={title} mode="sticker" /> - 资源集市</span>
                     <span className="rh-titlebar-controls">
-                        <button className="rh-tb-btn" aria-label="资源仓库设置" onClick={() => { setSourceDraft(source); setShowSourceEditor(true); }}>⚙</button>
+                        <button className="rh-tb-btn" aria-label="资源仓库设置" onClick={() => { setSourceDraft(source); setShowSourceEditor(true); }}><GearPixelIcon size={15} /></button>
                         <button className="rh-tb-btn" aria-label="刷新" disabled={loadState === "loading"} onClick={() => reload(source, { purge: true })}>
                             {loadState === "loading" ? <PixelHourglass size={13} /> : "⟳"}
                         </button>


### PR DESCRIPTION
`⚙`（U+2699）在 iOS 上会被当成彩色 emoji 渲染，和这套复古单色标题栏完全不搭，而其它环境落到单色字形上——同一份代码两种长相。改成 16×16 自绘像素齿轮，各系统一致，也和旁边的 `⟳` `✕` 分量相当。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_