### PR TITLE
资源集市：刷新符号也改为自绘像素图标

### DIFF
--- a/components/resource-hub/pixel-icons.tsx
+++ b/components/resource-hub/pixel-icons.tsx
@@ -286,6 +286,30 @@ export function GearPixelIcon({ size = 15 }: { size?: number }) {
     return renderGrid(GEAR_ICON, size);
 }
 
+// 标题栏的"刷新"。⟳ 在 iOS 的字体里字形本身就画得很小，同样自己画。
+const REFRESH_ICON: PixelGrid = [
+    "................",
+    ".........kkkkkk.",
+    "..........kkkk..",
+    "...........kk...",
+    "...kk.....kkk...",
+    "..kkk......kkk..",
+    "..kk........kk..",
+    "..kk........kk..",
+    "..kk........kk..",
+    "..kk........kk..",
+    "..kkk......kkk..",
+    "...kkk....kkk...",
+    "....kkkkkkkk....",
+    ".....kkkkkk.....",
+    "................",
+    "................",
+];
+
+export function RefreshPixelIcon({ size = 15 }: { size?: number }) {
+    return renderGrid(REFRESH_ICON, size);
+}
+
 // ── 按扩展名生成的文件图标（详情页文件条用）──
 // 统一的"折角文档"底版，"a" 为类型强调色（内容线条区）。
 

--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -45,7 +45,7 @@ import {
 } from "@/lib/resource-hub-identity";
 import { mergeMyUploads } from "@/lib/resource-hub-upload";
 import { DefaultPixelAvatar } from "@/components/resource-hub/pixel-avatar";
-import { DestPixelIcon, FileTypePixelIcon, GearPixelIcon, fileExtension } from "@/components/resource-hub/pixel-icons";
+import { DestPixelIcon, FileTypePixelIcon, GearPixelIcon, RefreshPixelIcon, fileExtension } from "@/components/resource-hub/pixel-icons";
 import { deleteShareEntry } from "@/lib/resource-hub-review";
 import { MediaPreviewOverlay } from "@/components/chat/media-preview-overlay";
 import { fetchFlowerCounts, hasSentFlowerToday, sendFlower, type FlowerCounts } from "@/lib/resource-hub-flowers";
@@ -504,7 +504,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     <span className="rh-titlebar-controls">
                         <button className="rh-tb-btn" aria-label="资源仓库设置" onClick={() => { setSourceDraft(source); setShowSourceEditor(true); }}><GearPixelIcon size={15} /></button>
                         <button className="rh-tb-btn" aria-label="刷新" disabled={loadState === "loading"} onClick={() => reload(source, { purge: true })}>
-                            {loadState === "loading" ? <PixelHourglass size={13} /> : "⟳"}
+                            {loadState === "loading" ? <PixelHourglass size={13} /> : <RefreshPixelIcon size={15} />}
                         </button>
                         <button className="rh-tb-btn" aria-label="关闭" onClick={onClose}>✕</button>
                     </span>


### PR DESCRIPTION
`⟳` 在 iOS 的字体里字形本身就画得很小，和旁边的按钮不成比例。照齿轮的做法画一个 16×16 的带缺口圆环加箭头，各系统一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_