### PR TITLE
资源集市：标题栏三个按钮改用 lucide 矢量图标

### DIFF
--- a/components/resource-hub/pixel-icons.tsx
+++ b/components/resource-hub/pixel-icons.tsx
@@ -261,55 +261,6 @@ export function DestPixelIcon({ dest, size = 34 }: { dest: ImportDestination; si
     return renderGrid(DEST_ICONS[dest], size);
 }
 
-// 标题栏的"设置"齿轮。用 ⚙ 字符的话，iOS 会当彩色 emoji 画，
-// 和这套复古单色界面完全不搭，所以自己画一个。
-const GEAR_ICON: PixelGrid = [
-    "................",
-    ".......kk.......",
-    ".......kk.......",
-    "...kkkkkkkkkk...",
-    "...kkkkkkkkkk...",
-    "...kkkk..kkkk...",
-    "...kkk....kkk...",
-    ".kkkk......kkkk.",
-    ".kkkk......kkkk.",
-    "...kkk....kkk...",
-    "...kkkk..kkkk...",
-    "...kkkkkkkkkk...",
-    "...kkkkkkkkkk...",
-    ".......kk.......",
-    ".......kk.......",
-    "................",
-];
-
-export function GearPixelIcon({ size = 15 }: { size?: number }) {
-    return renderGrid(GEAR_ICON, size);
-}
-
-// 标题栏的"刷新"。⟳ 在 iOS 的字体里字形本身就画得很小，同样自己画。
-const REFRESH_ICON: PixelGrid = [
-    "................",
-    ".........kkkkkk.",
-    "..........kkkk..",
-    "...........kk...",
-    "...kk.....kkk...",
-    "..kkk......kkk..",
-    "..kk........kk..",
-    "..kk........kk..",
-    "..kk........kk..",
-    "..kk........kk..",
-    "..kkk......kkk..",
-    "...kkk....kkk...",
-    "....kkkkkkkk....",
-    ".....kkkkkk.....",
-    "................",
-    "................",
-];
-
-export function RefreshPixelIcon({ size = 15 }: { size?: number }) {
-    return renderGrid(REFRESH_ICON, size);
-}
-
 // ── 按扩展名生成的文件图标（详情页文件条用）──
 // 统一的"折角文档"底版，"a" 为类型强调色（内容线条区）。
 

--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -45,7 +45,10 @@ import {
 } from "@/lib/resource-hub-identity";
 import { mergeMyUploads } from "@/lib/resource-hub-upload";
 import { DefaultPixelAvatar } from "@/components/resource-hub/pixel-avatar";
-import { DestPixelIcon, FileTypePixelIcon, GearPixelIcon, RefreshPixelIcon, fileExtension } from "@/components/resource-hub/pixel-icons";
+import { DestPixelIcon, FileTypePixelIcon, fileExtension } from "@/components/resource-hub/pixel-icons";
+// 标题栏图标用 lucide 矢量图：⚙/⟳ 这些字符在 iOS 上会被当彩色 emoji 画、
+// 或者字形本身偏小，各设备长相不一；矢量图标则处处一致且小尺寸清晰。
+import { RotateCw, Settings, X } from "lucide-react";
 import { deleteShareEntry } from "@/lib/resource-hub-review";
 import { MediaPreviewOverlay } from "@/components/chat/media-preview-overlay";
 import { fetchFlowerCounts, hasSentFlowerToday, sendFlower, type FlowerCounts } from "@/lib/resource-hub-flowers";
@@ -502,11 +505,11 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     <span className="rh-titlebar-icon">🗂️</span>
                     <span className="rh-titlebar-text"><RichText text={title} mode="sticker" /> - 资源集市</span>
                     <span className="rh-titlebar-controls">
-                        <button className="rh-tb-btn" aria-label="资源仓库设置" onClick={() => { setSourceDraft(source); setShowSourceEditor(true); }}><GearPixelIcon size={15} /></button>
+                        <button className="rh-tb-btn" aria-label="资源仓库设置" onClick={() => { setSourceDraft(source); setShowSourceEditor(true); }}><Settings size={15} strokeWidth={2.25} /></button>
                         <button className="rh-tb-btn" aria-label="刷新" disabled={loadState === "loading"} onClick={() => reload(source, { purge: true })}>
-                            {loadState === "loading" ? <PixelHourglass size={13} /> : <RefreshPixelIcon size={15} />}
+                            {loadState === "loading" ? <PixelHourglass size={13} /> : <RotateCw size={15} strokeWidth={2.25} />}
                         </button>
-                        <button className="rh-tb-btn" aria-label="关闭" onClick={onClose}>✕</button>
+                        <button className="rh-tb-btn" aria-label="关闭" onClick={onClose}><X size={15} strokeWidth={2.75} /></button>
                     </span>
                 </div>
 


### PR DESCRIPTION
上一版手绘的像素齿轮/刷新太糙。改用项目里已在用的 lucide 图标（`Settings` / `RotateCw` / `X`）：专业绘制、小尺寸清晰、跟随 currentColor，且完全不依赖系统字体，iOS 上不会再被当彩色 emoji 画或画得偏小。`✕` 一并换掉，三个按钮的粗细与大小才统一。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_