### PR TITLE
集市审核：新增自动审核开关（仅仓库所有者可改）

### DIFF
--- a/components/settings/moderation-center.tsx
+++ b/components/settings/moderation-center.tsx
@@ -7,11 +7,15 @@ import { useCallback, useEffect, useState } from "react";
 import { Loader2, RefreshCw, Search, ShieldCheck } from "lucide-react";
 
 import { ConfirmDialog } from "../ui/modal";
+import { Toggle } from "../ui/form";
 import { fetchReports, moderationApi, type ContentReport } from "@/lib/moderation-client";
 import { fetchCustomAppMarketAdminItems, reviewCustomAppMarketItem } from "@/lib/custom-app-market-client";
 import type { CustomAppMarketItem } from "@/lib/custom-app-market-types";
 import {
   approveShareSubmission,
+  canManageShareRepo,
+  fetchAutoApprove,
+  setAutoApprove,
   fetchShareSubmissionFiles,
   listShareSubmissions,
   rejectShareSubmission,
@@ -121,6 +125,10 @@ export function ModerationCenter({ onNotice }: { onNotice?: (msg: string) => voi
   const [shareFiles, setShareFiles] = useState<Record<number, ShareSubmissionFile[] | "loading">>({});
   const [shareRejectFor, setShareRejectFor] = useState<number | null>(null);
   const [shareRejectReason, setShareRejectReason] = useState("");
+  // 自动审核：开关存在资源仓库里，只有对仓库有写权限的人才改得动
+  const [autoApprove, setAutoApproveState] = useState(false);
+  const [canManageRepo, setCanManageRepo] = useState(false);
+  const [autoApproveBusy, setAutoApproveBusy] = useState(false);
 
   const loadShareItems = useCallback(async () => {
     setShareLoading(true);
@@ -137,6 +145,34 @@ export function ModerationCenter({ onNotice }: { onNotice?: (msg: string) => voi
   useEffect(() => {
     if (tab === "share") void loadShareItems();
   }, [tab, loadShareItems]);
+
+  useEffect(() => {
+    if (tab !== "share") return;
+    let cancelled = false;
+    void (async () => {
+      const [manage, auto] = await Promise.all([
+        canManageShareRepo(),
+        fetchAutoApprove().catch(() => false),
+      ]);
+      if (cancelled) return;
+      setCanManageRepo(manage);
+      setAutoApproveState(auto);
+    })();
+    return () => { cancelled = true; };
+  }, [tab]);
+
+  const toggleAutoApprove = async (next: boolean) => {
+    setAutoApproveBusy(true);
+    try {
+      await setAutoApprove(next);
+      setAutoApproveState(next);
+      onNotice?.(next ? "已开启自动审核：新投稿会直接上架" : "已关闭自动审核：新投稿重新排队等人工");
+    } catch (error) {
+      onNotice?.(error instanceof Error ? error.message : "改不动这个开关（需要资源仓库的写权限）");
+    } finally {
+      setAutoApproveBusy(false);
+    }
+  };
 
   const toggleShareDetail = async (item: ShareSubmission) => {
     if (shareExpanded === item.number) { setShareExpanded(null); return; }
@@ -322,6 +358,19 @@ export function ModerationCenter({ onNotice }: { onNotice?: (msg: string) => voi
             <span style={subStyle}>资源集市的待审投稿（通过 = 上架；拒绝可留言）</span>
             <button type="button" style={{ ...btnStyle, display: "inline-flex", alignItems: "center", gap: 4 }} onClick={() => void loadShareItems()}><RefreshCw size={12} />刷新</button>
           </div>
+          {canManageRepo ? (
+            <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 12px", marginBottom: 12, borderRadius: 12, background: "var(--surface-inset, rgba(0,0,0,.03))" }}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 13, fontWeight: 600 }}>自动审核</div>
+                <div style={{ ...subStyle, marginTop: 2 }}>
+                  开启后新投稿直接上架、不再排队。任何人传的东西都会立刻公开，只能事后下架。
+                </div>
+              </div>
+              {autoApproveBusy
+                ? <Loader2 size={16} className="animate-spin" />
+                : <Toggle checked={autoApprove} onChange={next => void toggleAutoApprove(next)} />}
+            </div>
+          ) : null}
           {shareLoading ? <p style={subStyle}><Loader2 size={13} className="animate-spin" style={{ verticalAlign: -2 }} /> 加载中…</p> : null}
           {!shareLoading && shareItems.length === 0 ? <p style={subStyle}>没有待审核的投稿。</p> : null}
           {shareItems.map(item => {

--- a/lib/resource-hub-review.ts
+++ b/lib/resource-hub-review.ts
@@ -107,6 +107,55 @@ export async function fetchShareSubmissionFiles(prNumber: number): Promise<Share
     return result;
 }
 
+// ── 自动审核开关 ──
+// 开关存在资源仓库的 _config.json 里：写它需要仓库写权限，所以"只有仓库
+// 所有者能开"是 GitHub 服务端在裁决，前端伪造管理员身份没有任何用。
+
+const CONFIG_FILE = "_config.json";
+
+/** 当前 token 对资源仓库有没有写权限（决定要不要显示自动审核开关） */
+export async function canManageShareRepo(): Promise<boolean> {
+    try {
+        const { token, owner, repo } = getReviewAuth();
+        const info = await gh<{ permissions?: { push?: boolean } }>(token, "GET", `/repos/${owner}/${repo}`);
+        return info.permissions?.push === true;
+    } catch {
+        return false;
+    }
+}
+
+export async function fetchAutoApprove(): Promise<boolean> {
+    const { token, owner, repo } = getReviewAuth();
+    try {
+        const file = await gh<{ content?: string }>(token, "GET", `/repos/${owner}/${repo}/contents/${CONFIG_FILE}`);
+        const cfg = JSON.parse(decodeBase64Utf8(file.content || "")) as { autoApprove?: boolean };
+        return cfg?.autoApprove === true;
+    } catch {
+        // 没配置过/读不到，一律按关闭处理
+        return false;
+    }
+}
+
+/** 写开关。没有仓库写权限的人会被 GitHub 挡在 403。 */
+export async function setAutoApprove(enabled: boolean): Promise<void> {
+    const { token, owner, repo } = getReviewAuth();
+    let sha: string | undefined;
+    let current: Record<string, unknown> = {};
+    try {
+        const file = await gh<{ sha?: string; content?: string }>(token, "GET", `/repos/${owner}/${repo}/contents/${CONFIG_FILE}`);
+        sha = file.sha;
+        current = JSON.parse(decodeBase64Utf8(file.content || "")) as Record<string, unknown>;
+    } catch { /* 首次写入 */ }
+    const body = JSON.stringify({ ...current, autoApprove: enabled }, null, 2);
+    const content = btoa(unescape(encodeURIComponent(body)));
+    await gh(token, "PUT", `/repos/${owner}/${repo}/contents/${CONFIG_FILE}`, {
+        // 带 [skip-index] 免得为一个开关白跑一次索引重建
+        message: `${enabled ? "开启" : "关闭"}自动审核 [skip-index]`,
+        content,
+        ...(sha ? { sha } : {}),
+    });
+}
+
 /** 通过并上架（合并 PR），并强刷索引的 CDN 缓存让新资源尽快可见。 */
 export async function approveShareSubmission(prNumber: number): Promise<void> {
     const { token, owner, repo } = getReviewAuth();


### PR DESCRIPTION
开启后投稿到达上传服务即自动合并上架，不再排队等人工——手机关着也生效。

权限不是靠前端自觉：开关存成资源仓库根目录的 `_config.json`，改它要走 GitHub 内容 API，没有仓库写权限的人一律 403。前端只在 token 确有 push 权限时才显示这个开关，那只是省得别人白点。

服务端合并失败（GitHub 还没算完可合并性、冲突等）会退回人工队列，投稿本身不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_