### PR TITLE
桌面默认布局改成实机三页版式

### DIFF
--- a/lib/desktop-config.ts
+++ b/lib/desktop-config.ts
@@ -54,7 +54,7 @@ export const PAGE_2_DEFAULT: IconId[] = [
   "mapmode"
 ];
 
-// 第三页默认图标（居中放置，位置见 createDefaultDesktopIconLayout）
+// 第三页默认图标：右半边 2×2 排布（左半边留给日历组件），位置见 createDefaultDesktopIconLayout
 export const PAGE_3_DEFAULT: IconId[] = ["worldbuilder", "qa", "resource_hub"];
 
 export const DOCK_DEFAULT: IconId[] = ["settings", "theme", "resources", "characters"];

--- a/lib/desktop-layout-storage.ts
+++ b/lib/desktop-layout-storage.ts
@@ -101,16 +101,17 @@ export function createDefaultDesktopIconLayout(_widgets: WidgetInstance[] = []):
       row: 5 + Math.floor(i / GRID_COLS),
       col: (i % GRID_COLS) + 1,
     })),
+    // 第二页：第 4 行留给 iOS 操作菜单组件，图标从第 5 行开始
     page2: PAGE_2_DEFAULT.map((id, i) => ({
       id,
-      row: 4 + Math.floor(i / GRID_COLS),
+      row: 5 + Math.floor(i / GRID_COLS),
       col: (i % GRID_COLS) + 1,
     })),
-    // 第三页：水平居中排在中间那行（第 3 行）。单个图标居中于 col2，两个则 col2、col3。
+    // 第三页：右半边 2×2（第 4~5 行、第 3~4 列），左半边留给日历组件
     page3: PAGE_3_DEFAULT.map((id, i) => ({
       id,
-      row: 3,
-      col: Math.floor((GRID_COLS - PAGE_3_DEFAULT.length) / 2) + 1 + i,
+      row: 4 + Math.floor(i / 2),
+      col: 3 + (i % 2),
     })),
   } as DesktopIconLayout;
 }

--- a/lib/widget-storage.ts
+++ b/lib/widget-storage.ts
@@ -16,9 +16,15 @@ const DIY_TEMPLATES_KEY = "ai_phone_diy_templates_v1";
 registerKvMigration(DIY_TEMPLATES_KEY);
 
 const DEFAULT_WIDGETS: WidgetInstance[] = [
+  // 第一页：大时钟 + 心情气泡
   { id: "default_widget_large_time", type: "largeTime", size: "2x4", page: 1, row: 1, col: 1 },
   { id: "default_widget_mood_pill", type: "moodPill", size: "1x4", page: 1, row: 3, col: 1 },
+  // 第二页：个人名片 + iOS 操作菜单
   { id: "default_widget_my_space", type: "mySpace", size: "3x4", page: 2, row: 1, col: 1 },
+  { id: "default_widget_ios_menu", type: "iosMenu", size: "1x4", page: 2, row: 4, col: 1 },
+  // 第三页：天气卡 + 日历（日历占左半边，右半边是四个图标）
+  { id: "default_widget_weather", type: "freestyleFrame68", size: "2x4", page: 3, row: 2, col: 1 },
+  { id: "default_widget_calendar", type: "calendar", size: "2x2", page: 3, row: 4, col: 1 },
 ];
 
 export function createDefaultWidgets(): WidgetInstance[] {


### PR DESCRIPTION
把新用户的桌面默认布局调整成实机使用的三页版式。

- 第一页：大时钟 + 心情气泡，图标下移到第 5~6 行
- 第二页：个人名片 + iOS 操作菜单（第 4 行），图标从第 4 行改到第 5 行开始
- 第三页：顶部天气卡（自由 · 天气关注）+ 左下日历，右半边 2×2 排布第三页图标

只改默认值，已有用户保存的布局不受影响。`npx tsc --noEmit` 通过。

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_