### PR TITLE
资源集市：再次点选择器改为追加文件，不再顶掉之前选的

### DIFF
--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -65,6 +65,20 @@ function formatFileSize(bytes: number): string {
     return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
+/**
+ * 再次点选择器时追加到已选清单，而不是把之前选的顶掉——用户没叉掉就不该丢。
+ * 同名文件会原地替换成新选的那份：上传后按文件名落库，留两份同名的必然互相覆盖。
+ */
+function appendPickedFiles(current: File[], incoming: File[]): File[] {
+    const next = [...current];
+    for (const file of incoming) {
+        const at = next.findIndex(f => f.name === file.name);
+        if (at >= 0) next[at] = file;
+        else next.push(file);
+    }
+    return next;
+}
+
 function formatEntryDate(iso: string | null): string {
     if (!iso) return "";
     const d = new Date(iso);
@@ -1011,8 +1025,8 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                 </div>
                             </div>
                             <label className="rh-file-picker">
-                                <span className="rh-btn">添加/替换文件</span>
-                                <input type="file" multiple hidden onChange={e => { setEditAddFiles(Array.from(e.target.files ?? [])); e.target.value = ""; }} />
+                                <span className="rh-btn">{editAddFiles.length > 0 ? "继续添加文件" : "添加/替换文件"}</span>
+                                <input type="file" multiple hidden onChange={e => { const picked = Array.from(e.target.files ?? []); setEditAddFiles(current => appendPickedFiles(current, picked)); e.target.value = ""; }} />
                             </label>
                             {renderPickedFiles(editAddFiles, index => setEditAddFiles(current => current.filter((_, i) => i !== index)))}
                             <div className="rh-form-hint">同名文件会被覆盖；保存后立即生效，索引刷新后所有人可见。</div>
@@ -1091,13 +1105,13 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                 />
                             </div>
                             <label className="rh-file-picker">
-                                <span className="rh-btn">选择资源文件</span>
-                                <input type="file" multiple hidden onChange={e => { setUploadFiles(Array.from(e.target.files ?? [])); e.target.value = ""; }} />
+                                <span className="rh-btn">{uploadFiles.length > 0 ? "继续添加文件" : "选择资源文件"}</span>
+                                <input type="file" multiple hidden onChange={e => { const picked = Array.from(e.target.files ?? []); setUploadFiles(current => appendPickedFiles(current, picked)); e.target.value = ""; }} />
                             </label>
                             {renderPickedFiles(uploadFiles, index => setUploadFiles(current => current.filter((_, i) => i !== index)))}
                             <label className="rh-file-picker">
-                                <span className="rh-btn">选择配图（可选）</span>
-                                <input type="file" accept="image/*" multiple hidden onChange={e => { setUploadImages(Array.from(e.target.files ?? [])); e.target.value = ""; }} />
+                                <span className="rh-btn">{uploadImages.length > 0 ? "继续添加配图" : "选择配图（可选）"}</span>
+                                <input type="file" accept="image/*" multiple hidden onChange={e => { const picked = Array.from(e.target.files ?? []); setUploadImages(current => appendPickedFiles(current, picked)); e.target.value = ""; }} />
                             </label>
                             {renderPickedFiles(uploadImages, index => setUploadImages(current => current.filter((_, i) => i !== index)))}
                             <div className="rh-form-hint">


### PR DESCRIPTION
修一个反直觉的交互：上传资源时先选了一个文件，再点一次「选择资源文件」加第二个，第一个会被静默丢掉——用户明明没叉掉它。配图选择器、编辑弹窗里的「添加/替换文件」同样如此。

原因是每次 `onChange` 都直接用本次选中的整份 `FileList` 替换已选清单。

改动：

- 新增 `appendPickedFiles()`，把本次选中的文件追加到已选清单
- 重名文件原地替换成新选的那份（上传按文件名落库，留两份同名必然互相覆盖），不会出现两行同名
- 已选后按钮文案变成「继续添加文件 / 继续添加配图」，让"可以接着加"这件事看得见
- 单个 ✕ 移除、移除后重新选回同一个文件都照常

`npx tsc --noEmit` 通过；用 Playwright 在 iPhone 13 视口下走了完整流程验证（分两次选、一次选多个含重名、移除、移除后重选）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_