### PR TITLE
集市导入的作品只能本机玩，禁止再发布 + 开屏权益提示

### DIFF
--- a/components/game/game-hub-app.tsx
+++ b/components/game/game-hub-app.tsx
@@ -724,6 +724,8 @@ export function GameHubApp({ onClose, autoOpenLocalId }: { onClose: () => void; 
   const [drafts, setDrafts] = useState<GameHallDraft[]>(() => loadGameDrafts());
   const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
   const [editingDraftId, setEditingDraftId] = useState<string | null>(null);
+  // 当前编辑的草稿来自资源集市时是集市路径，否则 null。别人的作品只能本机试玩，不能发布到大厅。
+  const [editingImportedFrom, setEditingImportedFrom] = useState<string | null>(null);
   const [publishing, setPublishing] = useState(false);
   const [publishAnonymously, setPublishAnonymously] = useState(false);
   const [runtimeGame, setRuntimeGame] = useState<GameInstalledItem | null>(null);
@@ -1271,6 +1273,7 @@ export function GameHubApp({ onClose, autoOpenLocalId }: { onClose: () => void; 
 
   function resetDraft(): void {
     setEditingDraftId(null);
+    setEditingImportedFrom(null);
     setEditingTemplateId(null);
     setAdvancedStudioOpen(false);
     setPublishAnonymously(false);
@@ -1309,6 +1312,8 @@ export function GameHubApp({ onClose, autoOpenLocalId }: { onClose: () => void; 
           publishedTemplateId,
           // 关联草稿存了新内容但还没提交更新：卡片在「已发布」旁提示有未发布改动
           hasUnpublishedChanges: publishedTemplateId ? true : undefined,
+          // 来源标记跟着草稿走：改了内容再存也洗不掉，否则禁发布形同虚设
+          importedFrom: editingImportedFrom || existing?.importedFrom,
           createdAt: existing?.createdAt || now,
           updatedAt: now,
         },
@@ -1326,6 +1331,7 @@ export function GameHubApp({ onClose, autoOpenLocalId }: { onClose: () => void; 
   function editDraft(item: GameHallDraft): void {
     setStudioMenuId(null);
     setEditingDraftId(item.id);
+    setEditingImportedFrom(item.importedFrom || null);
     setEditingTemplateId(null);
     setDraft(item.draft);
     setAdvancedStudioOpen(parseGameRoleSlots(item.draft.roleSlotsText).length > 0);
@@ -1362,7 +1368,8 @@ export function GameHubApp({ onClose, autoOpenLocalId }: { onClose: () => void; 
 
   async function exportDraftFile(item: GameHallDraft): Promise<void> {
     try {
-      const payload = { type: "ai-phone-game-draft", version: 1, title: item.title, draft: item.draft };
+      // 带上来源标记：集市来的作品导出再导入依然禁发布，不能靠转一手洗掉出处
+      const payload = { type: "ai-phone-game-draft", version: 1, title: item.title, draft: item.draft, importedFrom: item.importedFrom };
       const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
       await downloadFile(blob, `${item.title.trim() || "游戏草稿"}.json`);
       showNotice("success", "草稿已导出为文件");
@@ -1374,10 +1381,13 @@ export function GameHubApp({ onClose, autoOpenLocalId }: { onClose: () => void; 
   // 导入草稿 JSON：整张创建表单自动填好（与「上传 HTML」共用一个入口，按扩展名分流）
   async function importDraftIntoForm(file: File): Promise<void> {
     try {
-      const payload = JSON.parse(await file.text()) as { type?: string; draft?: Record<string, unknown>; title?: string };
+      const payload = JSON.parse(await file.text()) as { type?: string; draft?: Record<string, unknown>; title?: string; importedFrom?: unknown };
       if (payload?.type !== "ai-phone-game-draft" || !payload.draft || typeof payload.draft !== "object") {
         throw new Error("不是有效的游戏草稿文件（需要从草稿箱「导出文件」生成）");
       }
+      const importedFrom = typeof payload.importedFrom === "string" && payload.importedFrom.trim()
+        ? payload.importedFrom.trim().slice(0, 400)
+        : null;
       // 只吸收与默认草稿同名同类型的字段，忽略其余内容
       const base = createDefaultGameDraft();
       const incoming = payload.draft;
@@ -1388,11 +1398,14 @@ export function GameHubApp({ onClose, autoOpenLocalId }: { onClose: () => void; 
       }
       const nextDraft = importedDraft as GameTemplateDraft;
       setEditingDraftId(null);
+      setEditingImportedFrom(importedFrom);
       setEditingTemplateId(null);
       setDraft(nextDraft);
       setAdvancedStudioOpen(parseGameRoleSlots(nextDraft.roleSlotsText).length > 0);
       const title = (typeof payload.title === "string" && payload.title.trim()) || nextDraft.title.trim() || "导入的游戏";
-      showNotice("success", `已导入草稿「${title}」，检查后可存草稿或发布`);
+      showNotice("success", importedFrom
+        ? `已导入草稿「${title}」，这是集市来的作品，可本机试玩但不能发布到大厅`
+        : `已导入草稿「${title}」，检查后可存草稿或发布`);
     } catch (err) {
       showNotice("error", err instanceof Error ? err.message : "导入失败");
     }
@@ -1409,6 +1422,7 @@ export function GameHubApp({ onClose, autoOpenLocalId }: { onClose: () => void; 
     setStudioMenuId(null);
     setEditingTemplateId(fullTemplate.id);
     setEditingDraftId(null);
+    setEditingImportedFrom(null);
     setDraft(draftFromTemplate(fullTemplate));
     setAdvancedStudioOpen(fullTemplate.roleSlots.length > 0);
     setPublishAnonymously(displayGameAuthorName(fullTemplate.authorName) === "匿名" && !fullTemplate.authorAvatar);
@@ -1550,7 +1564,7 @@ export function GameHubApp({ onClose, autoOpenLocalId }: { onClose: () => void; 
         draftId = createDraftId();
         const title = draft.title.trim() || "未命名游戏";
         setEditingDraftId(draftId);
-        setDrafts(current => saveGameDrafts([{ id: draftId as string, title, draft, createdAt: now, updatedAt: now }, ...current]));
+        setDrafts(current => saveGameDrafts([{ id: draftId as string, title, draft, importedFrom: editingImportedFrom || undefined, createdAt: now, updatedAt: now }, ...current]));
       }
       const result = upsertLocalTestGame(draftId, template);
       if (!result.ok || !result.installedGame) {
@@ -1565,6 +1579,11 @@ export function GameHubApp({ onClose, autoOpenLocalId }: { onClose: () => void; 
   }
 
   async function publishDraft(): Promise<void> {
+    // 集市导入的是别人的作品：本机随便玩，但不能借道这里发到共享大厅
+    if (editingImportedFrom) {
+      showNotice("error", "这是从资源集市导入的作品，只能本机试玩，不能发布到共享大厅");
+      return;
+    }
     setPublishing(true);
     try {
       // 关联发布：修改已发布模式用该模板；否则草稿带关联时解析出已发布条目 → 同步更新同一条目
@@ -2426,7 +2445,9 @@ export function GameHubApp({ onClose, autoOpenLocalId }: { onClose: () => void; 
         <div className="game-studio-list-copy">
           <div>
             <strong>{item.title}</strong>
-            <span data-pub={item.publishedTemplateId ? "yes" : "no"}>{item.publishedTemplateId ? "已发布" : "未发布"}</span>
+            {item.importedFrom
+              ? <span data-pub="no">集市作品·不可发布</span>
+              : <span data-pub={item.publishedTemplateId ? "yes" : "no"}>{item.publishedTemplateId ? "已发布" : "未发布"}</span>}
             {item.publishedTemplateId && item.hasUnpublishedChanges ? <i className="game-dirty-hint">有未发布改动</i> : null}
           </div>
           <time>{formatGameDate(item.updatedAt)}</time>
@@ -3023,11 +3044,16 @@ export function GameHubApp({ onClose, autoOpenLocalId }: { onClose: () => void; 
                   <div className="game-studio-actions">
                     <button type="button" onClick={localTestDraft}><Play size={14} /> 本机测试</button>
                     <button type="button" onClick={saveDraft}><Archive size={14} /> 存草稿</button>
-                    <button type="button" className="is-primary" disabled={publishing} onClick={() => void publishDraft()}>
+                    <button type="button" className="is-primary" disabled={publishing || Boolean(editingImportedFrom)}
+                      title={editingImportedFrom ? "集市导入的作品只能本机试玩" : undefined}
+                      onClick={() => void publishDraft()}>
                       <Send size={14} />
-                      {publishing ? "同步中" : editingTemplate ? "保存修改" : editingDraftLinked ? "更新发布" : "发布共享"}
+                      {editingImportedFrom ? "集市作品·不可发布" : publishing ? "同步中" : editingTemplate ? "保存修改" : editingDraftLinked ? "更新发布" : "发布共享"}
                     </button>
                   </div>
+                  {editingImportedFrom && (
+                    <p className="game-studio-hint">这是从资源集市导入的作品，可以本机试玩、改着自己用，但不能发布到共享大厅。</p>
+                  )}
                 </div>
                 {/* 角色槽位属于旧的模板级选人通路（现行做法是游戏 HTML 内自行选人），
                     入口不再对新草稿开放；仅在编辑已带槽位的存量作品时显示以保持兼容。 */}

--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -5,6 +5,7 @@
 // 资源可下载或导入（导入时选择目的地）。整体为复古 Windows 风格。
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { hydrateKvDb, kvGet, kvSet, registerKvMigration } from "@/lib/kv-db";
 import { loadCharacters } from "@/lib/character-storage";
 import { loadChatContacts } from "@/lib/chat-storage";
 import {
@@ -87,6 +88,10 @@ function formatEntryDate(iso: string | null): string {
     return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
+/** 开屏版权提示的「永不显示」记忆键（值为 "1" 即不再弹）。 */
+const NOTICE_DISMISSED_KEY = "ai_phone_resource_hub_notice_v1";
+registerKvMigration(NOTICE_DISMISSED_KEY);
+
 export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onNotice?: (msg: string) => void }) {
     const [source, setSource] = useState<ResourceHubSource>(() => loadResourceHubSource());
     const [index, setIndex] = useState<ShareIndex | null>(null);
@@ -147,6 +152,8 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     const [uploading, setUploading] = useState(false);
     // 提交前的公开性确认（资源会进公开仓库，先让人心里有数）
     const [confirmUpload, setConfirmUpload] = useState(false);
+    // 开屏版权提示（勾了「永不显示」就不再弹）
+    const [showNotice, setShowNotice] = useState(false);
     const [uploadCfg, setUploadCfg] = useState<ResourceHubUploadConfig>(() => loadUploadConfig());
     // 所见即所得编辑器：贴纸选择器（标题/正文两处）、颜色面板
     const [stickerPickerFor, setStickerPickerFor] = useState<"title" | "desc" | null>(null);
@@ -190,6 +197,16 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
             setIdentityKeyState(key);
             const hash = await sha256Hex(key);
             if (!cancelled) setIdentityHash(hash);
+        });
+        return () => { cancelled = true; };
+    }, []);
+
+    // 开屏版权提示：必须等 kv 从 IndexedDB 加载完再判断，
+    // 否则冷启动瞬间读不到「永不显示」，每次进来都会弹一遍。
+    useEffect(() => {
+        let cancelled = false;
+        void hydrateKvDb().then(() => {
+            if (!cancelled && kvGet(NOTICE_DISMISSED_KEY) !== "1") setShowNotice(true);
         });
         return () => { cancelled = true; };
     }, []);
@@ -1149,6 +1166,28 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                 setUploadAuthor(profile.nickname);
                                 setShowUpload(true);
                             }}>确认</button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* 开屏版权提示：进 app 先说清楚集市作品只能本机用，「永不显示」写进 kv 后不再弹 */}
+            {showNotice && (
+                <div className="rh-dialog-overlay">
+                    <div className="rh-dialog" onClick={e => e.stopPropagation()}>
+                        <div className="rh-titlebar"><span className="rh-titlebar-text">创作者权益提示</span></div>
+                        <div className="rh-dialog-body">
+                            <span className="rh-dialog-icon">📢</span>
+                            <span>
+                                为了保护创作者权益，从资源市场导入的作品，仅限于本地运行，<b>不能发布市场</b>。
+                            </span>
+                        </div>
+                        <div className="rh-dialog-footer">
+                            <button className="rh-btn" onClick={() => {
+                                kvSet(NOTICE_DISMISSED_KEY, "1");
+                                setShowNotice(false);
+                            }}>永不显示</button>
+                            <button className="rh-btn rh-btn-primary" onClick={() => setShowNotice(false)}>确认</button>
                         </div>
                     </div>
                 </div>

--- a/components/shopping/black-market-app.tsx
+++ b/components/shopping/black-market-app.tsx
@@ -146,6 +146,11 @@ type BlackMarketStudioDraft = {
   sourceTemplateTitle?: string;
   /** 关联发布档案后,本机又存过草稿但还没提交更新时为 true;更新发布成功后清除 */
   hasUnpublishedChanges?: boolean;
+  /**
+   * 来源标记:从资源集市导入时记录集市里的文件路径。别人的作品,本机可用,
+   * 但不能上架到黑市。存草稿、导出再导入都会带着它,防止洗掉出处。
+   */
+  importedFrom?: string;
   createdAt: string;
   updatedAt: string;
 };
@@ -797,6 +802,7 @@ function normalizeStudioDraftRecord(value: unknown): BlackMarketStudioDraft | nu
     sourceTemplateId: String(record.sourceTemplateId ?? "").trim() || undefined,
     sourceTemplateTitle: String(record.sourceTemplateTitle ?? "").trim() || undefined,
     hasUnpublishedChanges: record.hasUnpublishedChanges === true ? true : undefined,
+    importedFrom: String(record.importedFrom ?? "").trim().slice(0, 400) || undefined,
     createdAt: String(record.createdAt ?? now),
     updatedAt: String(record.updatedAt ?? now),
   };
@@ -914,6 +920,8 @@ export function BlackMarketApp({ onClose, autoOpenLocalId }: BlackMarketAppProps
   const defaultDraft = useMemo(() => createDefaultDraft(), []);
   const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
   const [editingDraftId, setEditingDraftId] = useState<string | null>(null);
+  // 当前编辑的草稿来自资源集市时是集市路径，否则 null。别人的作品只能本机用，不能上架。
+  const [editingImportedFrom, setEditingImportedFrom] = useState<string | null>(null);
   const [studioDrafts, setStudioDrafts] = useState<BlackMarketStudioDraft[]>(() => loadBlackMarketStudioDrafts());
   const studioDraftFileInputRef = useRef<HTMLInputElement | null>(null);
   const [draft, setDraft] = useState<TheaterDraft>(() => createDefaultDraft());
@@ -1653,6 +1661,7 @@ export function BlackMarketApp({ onClose, autoOpenLocalId }: BlackMarketAppProps
   function resetDraft(): void {
     setEditingTemplateId(null);
     setEditingDraftId(null);
+    setEditingImportedFrom(null);
     setDraft(createDefaultDraft());
     setPreviewNonce(value => value + 1);
   }
@@ -1667,6 +1676,7 @@ export function BlackMarketApp({ onClose, autoOpenLocalId }: BlackMarketAppProps
     }
     setEditingTemplateId(fullTemplate.id);
     setEditingDraftId(null);
+    setEditingImportedFrom(null);
     setDraft(createDraftFromTemplate(fullTemplate));
     setStudioMode("create");
     setPreviewNonce(value => value + 1);
@@ -1675,6 +1685,7 @@ export function BlackMarketApp({ onClose, autoOpenLocalId }: BlackMarketAppProps
   function beginEditStudioDraft(item: BlackMarketStudioDraft): void {
     setEditingTemplateId(null);
     setEditingDraftId(item.id);
+    setEditingImportedFrom(item.importedFrom || null);
     setDraft(item.draft);
     setStudioMode("create");
     setPreviewNonce(value => value + 1);
@@ -1698,6 +1709,8 @@ export function BlackMarketApp({ onClose, autoOpenLocalId }: BlackMarketAppProps
           sourceTemplateTitle,
           // 关联草稿存了新内容但还没提交更新：卡片在「已发布」旁提示有未发布改动
           hasUnpublishedChanges: sourceTemplateId ? true : undefined,
+          // 来源标记跟着草稿走：改了内容再存也洗不掉，否则禁上架形同虚设
+          importedFrom: editingImportedFrom || existing?.importedFrom,
           createdAt: existing?.createdAt || now,
           updatedAt: now,
         },
@@ -1722,7 +1735,8 @@ export function BlackMarketApp({ onClose, autoOpenLocalId }: BlackMarketAppProps
   // 导出剧场草稿为 JSON 文件（blob 下载，不触发页面刷新），可发给别人「从文件导入」
   async function exportStudioDraftFile(item: BlackMarketStudioDraft): Promise<void> {
     try {
-      const payload = { type: "ai-phone-theater-draft", version: 1, title: item.title, draft: item.draft };
+      // 带上来源标记：集市来的作品导出再导入依然禁上架，不能靠转一手洗掉出处
+      const payload = { type: "ai-phone-theater-draft", version: 1, title: item.title, draft: item.draft, importedFrom: item.importedFrom };
       const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
       await downloadFile(blob, `${item.title.trim() || "剧场草稿"}.json`);
       showNotice("success", "草稿已导出为文件");
@@ -1752,16 +1766,22 @@ export function BlackMarketApp({ onClose, autoOpenLocalId }: BlackMarketAppProps
   // 导入草稿 JSON：整张创建表单自动填好（入口在「创建发布」表单顶部）
   async function importStudioDraftFile(file: File): Promise<void> {
     try {
-      const payload = JSON.parse(await file.text()) as { type?: string; draft?: unknown; title?: string };
+      const payload = JSON.parse(await file.text()) as { type?: string; draft?: unknown; title?: string; importedFrom?: unknown };
       if (payload?.type !== "ai-phone-theater-draft" || !payload.draft || typeof payload.draft !== "object") {
         throw new Error("不是有效的剧场草稿文件（需要从草稿箱「EXPORT」生成）");
       }
+      const importedFrom = typeof payload.importedFrom === "string" && payload.importedFrom.trim()
+        ? payload.importedFrom.trim().slice(0, 400)
+        : null;
       const importedDraft = normalizeStudioDraftPayload(payload.draft);
       setEditingDraftId(null);
+      setEditingImportedFrom(importedFrom);
       setEditingTemplateId(null);
       setDraft(importedDraft);
       const title = (typeof payload.title === "string" && payload.title.trim()) || importedDraft.title.trim() || "导入的剧场";
-      showNotice("success", `已导入草稿「${title}」，检查后可存草稿或发布`);
+      showNotice("success", importedFrom
+        ? `已导入草稿「${title}」，这是集市来的作品，可本机使用但不能上架`
+        : `已导入草稿「${title}」，检查后可存草稿或发布`);
     } catch (err) {
       showNotice("error", err instanceof Error ? err.message : "导入失败");
     }
@@ -1834,6 +1854,11 @@ export function BlackMarketApp({ onClose, autoOpenLocalId }: BlackMarketAppProps
   }
 
   async function handlePublishDraft(): Promise<void> {
+    // 集市导入的是别人的作品：本机随便用，但不能借道这里上架到黑市
+    if (editingImportedFrom) {
+      showNotice("error", "这是从资源集市导入的作品，只能本机使用，不能上架");
+      return;
+    }
     setPublishing(true);
     try {
       // 关联发布：修改已发布模式用该档案；否则草稿带关联时解析出原档案 → 同步更新同一条目
@@ -2268,7 +2293,9 @@ export function BlackMarketApp({ onClose, autoOpenLocalId }: BlackMarketAppProps
                     {studioDrafts.map(item => (
                       <article key={item.id} className="cp-black-market-published-card">
                         <div>
-                          <span data-pub={item.sourceTemplateId ? "yes" : "no"}>{item.sourceTemplateId ? "已发布" : "未发布"}</span>
+                          {item.importedFrom
+                            ? <span data-pub="no">集市作品·不可上架</span>
+                            : <span data-pub={item.sourceTemplateId ? "yes" : "no"}>{item.sourceTemplateId ? "已发布" : "未发布"}</span>}
                           {item.sourceTemplateId && item.hasUnpublishedChanges ? <i className="cp-bm-dirty-hint">有未发布改动</i> : null}
                           <strong>{item.title}</strong>
                           <p>{item.sourceTemplateId ? `关联：${item.sourceTemplateTitle || "已发布档案"}` : item.draft.subtitle || item.draft.synopsis || item.draft.storyText}</p>
@@ -2496,11 +2523,16 @@ export function BlackMarketApp({ onClose, autoOpenLocalId }: BlackMarketAppProps
                       <Play size={14} />
                       本机测试
                     </button>
-                    <button type="button" className="is-primary" disabled={publishing} onClick={() => void handlePublishDraft()}>
+                    <button type="button" className="is-primary" disabled={publishing || Boolean(editingImportedFrom)}
+                      title={editingImportedFrom ? "集市导入的作品只能本机使用" : undefined}
+                      onClick={() => void handlePublishDraft()}>
                       <Send size={14} />
-                      {publishing ? "同步中" : editingTemplate ? "保存修改" : editingStudioDraft?.sourceTemplateId ? "更新发布" : "发布共享"}
+                      {editingImportedFrom ? "集市作品·不可上架" : publishing ? "同步中" : editingTemplate ? "保存修改" : editingStudioDraft?.sourceTemplateId ? "更新发布" : "发布共享"}
                     </button>
                   </div>
+                  {editingImportedFrom ? (
+                    <p className="cp-black-market-studio-hint">这是从资源集市导入的作品，可以本机使用、改着自己玩，但不能上架到黑市。</p>
+                  ) : null}
                 </div>
               </>
             ) : null}

--- a/lib/custom-app-ownership.ts
+++ b/lib/custom-app-ownership.ts
@@ -5,7 +5,10 @@ import type { InstalledCustomApp } from "./custom-app-types";
 // 版权护栏共用，保证两边永不漂移。
 //
 // 归属是"应用 × 当前账号"的关系而非应用属性（换账号登录、条目易主都会改变），
-// 所以不落任何本地标记，每次拿服务端数据现场归类：
+// 所以除资源集市外不落本地标记，每次拿服务端数据现场归类。
+// 例外：从资源集市（GitHub 仓库）导入的应用在市场里没有任何对应条目，无从现场
+// 判定，只能在安装时落一个 resourceHubPath 标记，直接归为 others。
+// 归类结果：
 //   mine       —— 自己的工作副本：纯本地创作，或与自己市场发布关联（含从市场装回自己的 APP）
 //   local-only —— 纯本地创作，市场里没有对应条目
 //   others     —— 别人发布、从市场安装的副本：不进本地测试，小坊拒绝读取/导出/修改
@@ -44,6 +47,8 @@ export function linkedOwnMarketItem(app: InstalledCustomApp, myItems: CustomAppM
 }
 
 export function classifyInstalledApp(app: InstalledCustomApp, market: MarketOwnershipData): InstalledAppOwnership {
+  // 资源集市导入的是别人的作品：本机能玩，但不进本地测试、不能再发布到应用广场
+  if (app.resourceHubPath) return "others";
   const linked = linkedOwnMarketItem(app, market.myItems);
   if (app.marketItemId) {
     // 显式标记：指向自己的条目 → 工作副本；指向他人条目（或已失联）→ others

--- a/lib/custom-app-storage.ts
+++ b/lib/custom-app-storage.ts
@@ -755,6 +755,7 @@ function normalizeInstalledApp(raw: unknown): InstalledCustomApp | null {
       installedAt: cleanText(record.installedAt, 80) || new Date().toISOString(),
       updatedAt: cleanText(record.updatedAt, 80) || new Date().toISOString(),
       marketItemId: cleanText(record.marketItemId, 160) || undefined,
+      resourceHubPath: cleanText(record.resourceHubPath, 400) || undefined,
       hasUnpublishedChanges: record.hasUnpublishedChanges === true ? true : undefined,
     };
   } catch {

--- a/lib/custom-app-types.ts
+++ b/lib/custom-app-types.ts
@@ -273,6 +273,11 @@ export type InstalledCustomApp = {
   updatedAt: string;
   /** 来源标记:从应用广场安装/更新时记录市场条目 id;本地导入的没有此字段 */
   marketItemId?: string;
+  /**
+   * 来源标记:从资源集市导入时记录集市里的文件路径。别人的作品,只能本机玩,
+   * 不能再发布到应用广场——归属判定见 custom-app-ownership.ts。
+   */
+  resourceHubPath?: string;
   /** 关联市场版后,本机编辑/换包过但还没提交更新时为 true;发布成功或重新拉取市场版后清除 */
   hasUnpublishedChanges?: boolean;
 };

--- a/lib/data-management/modules.ts
+++ b/lib/data-management/modules.ts
@@ -250,6 +250,7 @@ export const DATA_MODULES: DataModuleDefinition[] = [
           "ai_phone_resource_hub_upload_cfg_v1",
           "ai_phone_resource_hub_source_v1",
           "ai_phone_resource_hub_flowers_sent_v1",
+          "ai_phone_resource_hub_notice_v1",
         ],
       },
     ],

--- a/lib/game-storage.ts
+++ b/lib/game-storage.ts
@@ -562,6 +562,7 @@ export function loadGameDrafts(): GameHallDraft[] {
         draft,
         publishedTemplateId: cleanText(record.publishedTemplateId, 160) || undefined,
         hasUnpublishedChanges: record.hasUnpublishedChanges === true ? true : undefined,
+        importedFrom: cleanText(record.importedFrom, 400) || undefined,
         createdAt: cleanText(record.createdAt, 80) || new Date().toISOString(),
         updatedAt: cleanText(record.updatedAt, 80) || new Date().toISOString(),
       } satisfies GameHallDraft;

--- a/lib/game-types.ts
+++ b/lib/game-types.ts
@@ -127,6 +127,11 @@ export type GameHallDraft = {
   publishedTemplateId?: string;
   /** 关联发布条目后,本机又存过草稿但还没提交更新时为 true;更新发布成功后清除 */
   hasUnpublishedChanges?: boolean;
+  /**
+   * 来源标记:从资源集市导入时记录集市里的文件路径。别人的作品,本机可试玩,
+   * 但不能发布到共享大厅。存草稿、导出再导入都会带着它,防止洗掉来源。
+   */
+  importedFrom?: string;
   createdAt: string;
   updatedAt: string;
 };

--- a/lib/qa-content-tools.ts
+++ b/lib/qa-content-tools.ts
@@ -714,6 +714,8 @@ type BmStudioDraftRecord = {
     sourceTemplateId?: string;
     sourceTemplateTitle?: string;
     hasUnpublishedChanges?: boolean;
+    /** 资源集市来源标记：别人的作品，不能上架（与 black-market-app 同字段） */
+    importedFrom?: string;
     createdAt: string;
     updatedAt: string;
 };
@@ -765,6 +767,10 @@ async function fetchMarketOwnershipData(): Promise<MarketOwnershipData> {
 }
 
 async function denyIfOthersMarketApp(app: InstalledCustomApp, action: string): Promise<string | null> {
+    // 资源集市导入的应用不依赖服务端判定，离线也照样拒绝
+    if (app.resourceHubPath) {
+        return `「${app.name}」是从资源集市导入的他人作品，只能在本机使用，${action}仅限作者本人。`;
+    }
     let data: MarketOwnershipData;
     try {
         data = await fetchMarketOwnershipData();
@@ -772,7 +778,7 @@ async function denyIfOthersMarketApp(app: InstalledCustomApp, action: string): P
         // 失败策略与市场 UI 相反（UI 宽容防创作区被离线锁死，这里严格防泄露）：
         // 带市场标记的一律拒绝，宁可等联网确认；仅无标记应用放行——
         // 刚在本机写出的新应用不能因断网而无法继续迭代。
-        if (!app.marketItemId) return null;
+        if (!app.marketItemId) return null;  // 集市导入的已在函数开头拦下，这里只剩纯本地创作
         return `「${app.name}」关联了应用市场条目，当前无法确认你是否为其作者（未登录或网络异常），为保护创作者版权，暂不能${action}。请联网并登录后重试；如果这是你自己发布的应用，届时即可正常操作。`;
     }
     if (classifyInstalledApp(app, data) === "others") {
@@ -963,6 +969,8 @@ const saveGameDraftTool: QaContentTool = {
             publishedTemplateId: existing?.publishedTemplateId,
             // 关联已发布条目的草稿被改动：与 UI 存草稿一致，标记有未发布改动
             hasUnpublishedChanges: existing?.publishedTemplateId ? true : undefined,
+            // 集市来源标记必须原样保留，否则让小坊改一次就把出处洗掉了
+            importedFrom: existing?.importedFrom,
             createdAt: existing?.createdAt ?? now,
             updatedAt: now,
         };
@@ -1046,6 +1054,8 @@ const saveTheaterDraftTool: QaContentTool = {
             sourceTemplateTitle: existing?.sourceTemplateTitle,
             // 关联已发布档案的草稿被改动：与 UI 存草稿一致，标记有未发布改动
             hasUnpublishedChanges: existing?.sourceTemplateId ? true : undefined,
+            // 集市来源标记必须原样保留，否则让小坊改一次就把出处洗掉了
+            importedFrom: existing?.importedFrom,
             createdAt: existing?.createdAt ?? now,
             updatedAt: now,
         };

--- a/lib/resource-hub-client.ts
+++ b/lib/resource-hub-client.ts
@@ -385,9 +385,10 @@ export async function importResourceHubFile(
             const { loadCustomAppPackage, loadSingleHtmlCustomApp, installCustomAppAsync } = await import("./custom-app-storage");
             const { applyCustomAppRegistrationsAsync } = await import("./custom-app-registration");
             const app = lower.endsWith(".zip") ? await loadCustomAppPackage(file) : await loadSingleHtmlCustomApp(file);
-            const installed = await installCustomAppAsync(app);
+            // 打来源标记：别人的作品，本机能玩，但不进本地测试、不能再发布到应用广场
+            const installed = await installCustomAppAsync({ ...app, resourceHubPath: path });
             await applyCustomAppRegistrationsAsync(installed);
-            return `应用「${installed.name}」已安装，桌面可找到图标`;
+            return `应用「${installed.name}」已安装，桌面可找到图标（集市来的作品仅供本机使用，不能再发布）`;
         }
         case "game": {
             const payload = JSON.parse(await fetchResourceHubText(source, path)) as { type?: string; title?: string; draft?: unknown };
@@ -401,12 +402,14 @@ export async function importResourceHubFile(
                     id: `draft_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
                     title,
                     draft: payload.draft as GameTemplateDraft,
+                    // 别人的作品：本机可试玩，不能发布到共享大厅
+                    importedFrom: path,
                     createdAt: now,
                     updatedAt: now,
                 },
                 ...loadGameDrafts(),
             ]);
-            return `游戏草稿「${title}」已导入草稿箱，可在游戏工作室查看发布`;
+            return `游戏草稿「${title}」已导入草稿箱，可在游戏工作室试玩（集市来的作品不能发布到大厅）`;
         }
         case "theater": {
             const payload = JSON.parse(await fetchResourceHubText(source, path)) as { type?: string; title?: string; draft?: unknown };
@@ -424,11 +427,13 @@ export async function importResourceHubFile(
                 id: `bmdraft_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
                 title,
                 draft: payload.draft,
+                // 别人的作品：本机可用，不能上架到黑市
+                importedFrom: path,
                 createdAt: now,
                 updatedAt: now,
             });
             kvSet(key, JSON.stringify(drafts.slice(0, 80)));
-            return `剧场草稿「${title}」已导入草稿箱，可在黑市工作室查看上架`;
+            return `剧场草稿「${title}」已导入草稿箱，可在黑市工作室查看（集市来的作品不能上架）`;
         }
         case "plugin": {
             const code = await fetchResourceHubText(source, path);


### PR DESCRIPTION
从资源集市导入的游戏 / 剧场 / 应用，此前在草稿箱里跟自己写的没有任何区别，点「发布」会把本机账号盖成作者，发到共享大厅 / 黑市 / 应用广场。导入路径也不记录任何来源信息。

改为在导入时落一个来源标记，并在所有发布入口拦下：

| | 标记字段 | 拦截点 |
|---|---|---|
| 游戏 | `GameHallDraft.importedFrom` | `publishDraft()` 提前返回；发布按钮置灰成「集市作品·不可发布」；草稿卡片带同名标签 |
| 剧场 | `BlackMarketStudioDraft.importedFrom` | `handlePublishDraft()` 同上 |
| 应用 | `InstalledCustomApp.resourceHubPath` | `classifyInstalledApp` 直接判 `others` |

应用这条复用了 `lib/custom-app-ownership.ts` 里既有的权属闸门——从应用广场装的他人作品早就判成 `others`（不进本地测试、无编辑/换包/发布入口），只是集市导入的应用因为拿的是随机运行时 id、没有 `marketItemId`，一直被判成 `local-only` 漏了过去。

**来源标记做成洗不掉的**，否则禁发布形同虚设：

- 改了内容再存草稿 → 从旧记录继承标记
- 导出文件再导入 → 导出的 JSON 带上标记，本地导入时读回来
- 让小坊改写草稿 → `qa-content-tools.ts` 的两处草稿写入原样保留标记（原本会丢）
- 断网时用小坊读源码 / 导出安装包 → 版权护栏原来只认 `marketItemId`，无标记的一律放行，集市应用正好落在这个口子里；现在集市标记在函数开头就拦，不依赖联网判定

另外三处导入成功提示原本是「可在游戏工作室查看**发布**」这类怂恿发布的话术，一并改掉。

**开屏提示**：进入资源集市先弹一次创作者权益说明，「确认」只关本次，「永不显示」写进 kv 后不再弹。该判断要等 kv 从 IndexedDB 加载完再做，否则冷启动读不到记忆、每次都会弹。新键一并纳入 `resource_hub` 备份模块。

`npx tsc --noEmit` 通过。用 Playwright 在 iPhone 13 视口下跑了真实导入链路与弹窗行为验证：三种类型的标记都正确落盘、存草稿往返后仍在、应用归属判定为 `others`；弹窗文案与加粗正确，「确认」后重进仍弹、「永不显示」后重进不弹。

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_