### PR TITLE
资源集市导入链路排查：修 7 个问题

### DIFF
--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -154,6 +154,8 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     const [confirmUpload, setConfirmUpload] = useState(false);
     // 开屏版权提示（勾了「永不显示」就不再弹）
     const [showNotice, setShowNotice] = useState(false);
+    // 安装插件前的风险告知：待安装的插件文件路径
+    const [confirmPlugin, setConfirmPlugin] = useState<string | null>(null);
     const [uploadCfg, setUploadCfg] = useState<ResourceHubUploadConfig>(() => loadUploadConfig());
     // 所见即所得编辑器：贴纸选择器（标题/正文两处）、颜色面板
     const [stickerPickerFor, setStickerPickerFor] = useState<"title" | "desc" | null>(null);
@@ -290,8 +292,11 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     const chatContacts = useMemo(() => {
         if (pickCharacterFor === null) return [];
         const characters = loadCharacters();
+        // ChatSession.contactId 存的是「角色 id」（全仓 createOrGetSession 都传角色 id，
+        // chat-storage 也用它反查角色名）。这里必须给 characterId，给 contact.id 会建出
+        // 一个谁都匹配不上的游离会话，CSS 写进去等于扔了。
         return loadChatContacts().map(contact => ({
-            contactId: contact.id,
+            contactId: contact.characterId,
             name: contact.nickname || characters.find(c => c.id === contact.characterId)?.name || "未知角色",
         }));
     }, [pickCharacterFor]);
@@ -348,6 +353,12 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
         }
         if (destination === "chat_session_css") {
             setPickCharacterFor(importFile);
+            setImportFile(null);
+            return;
+        }
+        // 插件与本应用同权限，装上即执行；集市来源必然是陌生人写的代码，先问一句
+        if (destination === "plugin") {
+            setConfirmPlugin(importFile);
             setImportFile(null);
             return;
         }
@@ -1166,6 +1177,30 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                 setUploadAuthor(profile.nickname);
                                 setShowUpload(true);
                             }}>确认</button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* 插件安装告知：插件与本应用同权限，装上即执行，必须先问一句 */}
+            {confirmPlugin && (
+                <div className="rh-dialog-overlay" onClick={importingTo ? undefined : () => setConfirmPlugin(null)}>
+                    <div className="rh-dialog" onClick={e => e.stopPropagation()}>
+                        <div className="rh-titlebar"><span className="rh-titlebar-text">安装插件</span></div>
+                        <div className="rh-dialog-body">
+                            <span className="rh-dialog-icon">⚠️</span>
+                            <span>
+                                插件将与应用本身拥有<b>相同的能力</b>（包括访问你的 API 配置与全部聊天数据），
+                                且安装后立即启用。这是其他用户上传的代码，请只安装你信任的来源。确认安装吗？
+                            </span>
+                        </div>
+                        <div className="rh-dialog-footer">
+                            <button className="rh-btn" disabled={!!importingTo} onClick={() => setConfirmPlugin(null)}>取消</button>
+                            <button className="rh-btn rh-btn-primary" disabled={!!importingTo} onClick={() => {
+                                const target = confirmPlugin;
+                                setConfirmPlugin(null);
+                                void runImport(target, "plugin");
+                            }}>确认安装</button>
                         </div>
                     </div>
                 </div>

--- a/lib/resource-hub-client.ts
+++ b/lib/resource-hub-client.ts
@@ -313,6 +313,34 @@ export function checkImportFileForDestination(destination: ImportDestination, pa
     }
 }
 
+function dispatch(eventName: string): void {
+    if (typeof window !== "undefined") window.dispatchEvent(new CustomEvent(eventName));
+}
+
+/** PNG 字节 → data URL（角色卡的画像就是这张图本身）。 */
+function bytesToPngDataUrl(buffer: ArrayBuffer): string {
+    const bytes = new Uint8Array(buffer);
+    let binary = "";
+    for (let i = 0; i < bytes.length; i += 1) binary += String.fromCharCode(bytes[i]);
+    return `data:image/png;base64,${btoa(binary)}`;
+}
+
+/**
+ * 解析器抛的是内部哨兵串（UNSUPPORTED_IMPORT_FORMAT / CHAR_BLOCKED_FIELDS），
+ * 各管理页都会翻译成人话，集市原本直接甩给用户看，会显示成
+ * 「导入失败：UNSUPPORTED_IMPORT_FORMAT」。
+ */
+function translateParseError<T>(run: () => T): T {
+    try {
+        return run();
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message === "UNSUPPORTED_IMPORT_FORMAT") throw new Error("不支持该文件的格式，请确认它是本应用导出的");
+        if (message === "CHAR_BLOCKED_FIELDS") throw new Error("不支持包含开场白、场景或示例对话的角色卡");
+        throw err;
+    }
+}
+
 /**
  * 把资源文件导入到指定目的地。chat_session_css 必须传 contactId（选中的角色会话）。
  * 返回给用户看的结果说明。
@@ -323,34 +351,58 @@ export async function importResourceHubFile(
     destination: ImportDestination,
     options?: { contactId?: string },
 ): Promise<string> {
+    // 下面全是"读出来 → 加一条 → 整份写回"。kv 的 kvSet 是无条件覆盖、kvGet 在
+    // 水合前一律返回 null，抢在加载完成前写会把整份旧数据（角色库/主题/草稿/插件）
+    // 抹掉。settings 与 chat 两层自带增量兜底，kv 没有，所以这里统一先等齐。
+    const { hydrateKvDb } = await import("./kv-db");
+    const { hydrateChatStorage } = await import("./chat-storage");
+    const { ensureSettingsStorageHydrated } = await import("./settings-storage");
+    await Promise.all([hydrateKvDb(), hydrateChatStorage(), ensureSettingsStorageHydrated()]);
+
     const lower = path.toLowerCase();
     const displayName = fileBaseName(path);
     switch (destination) {
         case "preset": {
-            const preset = parsePresetFromJson(await fetchResourceHubText(source, path), displayName);
+            const presetText = await fetchResourceHubText(source, path);
+            const preset = translateParseError(() => parsePresetFromJson(presetText, displayName));
             if (!preset) throw new Error("预设解析失败，请确认文件是预设管理页导出的 JSON");
-            savePresets([...loadPresets(), preset]);
+            // 与各管理页一致：新导入的排在最前，别沉到长列表底部
+            savePresets([preset, ...loadPresets()]);
+            dispatch("settings-presets-updated");
             return `预设「${preset.name}」已导入`;
         }
         case "regex": {
-            const regex = parseRegexFromJson(await fetchResourceHubText(source, path), displayName);
+            const regexText = await fetchResourceHubText(source, path);
+            const regex = translateParseError(() => parseRegexFromJson(regexText, displayName));
             if (!regex) throw new Error("正则解析失败，请确认文件是正则管理页导出的 JSON");
-            saveRegexes([...loadRegexes(), regex]);
+            saveRegexes([regex, ...loadRegexes()]);  // saveRegexes 自带事件派发
             return `正则组「${regex.name}」已导入`;
         }
         case "worldbook": {
-            const book = parseWorldBookFromJson(await fetchResourceHubText(source, path));
+            const bookText = await fetchResourceHubText(source, path);
+            const book = translateParseError(() => parseWorldBookFromJson(bookText));
             if (!book) throw new Error("世界书解析失败，请确认文件是世界书管理页导出的 JSON");
-            saveWorldBooks([...loadWorldBooks(), book]);
+            saveWorldBooks([book, ...loadWorldBooks()]);
+            dispatch("settings-worldbooks-updated");
             return `世界书「${book.name}」已导入`;
         }
         case "character": {
-            const data = lower.endsWith(".png")
-                ? parseCharacterFromPng(await fetchResourceHubBinary(source, path))
-                : parseCharacterFromJson(await fetchResourceHubText(source, path));
+            let avatar = "";
+            let data;
+            if (lower.endsWith(".png")) {
+                const buffer = await fetchResourceHubBinary(source, path);
+                data = translateParseError(() => parseCharacterFromPng(buffer));
+                // PNG 角色卡的画就是这张图本身，导出时 avatar 被有意写成 "none"，
+                // 不把图片补回去，导进来的角色就是个空白头像。
+                avatar = bytesToPngDataUrl(buffer);
+            } else {
+                const charText = await fetchResourceHubText(source, path);
+                data = translateParseError(() => parseCharacterFromJson(charText));
+            }
             if (!data) throw new Error("角色卡解析失败");
-            const character = createCharacter(data);
-            saveCharacters([...loadCharacters(), character]);
+            if (!avatar && typeof data.avatar === "string" && data.avatar.trim()) avatar = data.avatar;
+            const character = createCharacter(avatar ? { ...data, avatar } : data);
+            saveCharacters([character, ...loadCharacters()]);
             return `角色「${character.name}」已加入角色库`;
         }
         case "chat_session_css": {
@@ -386,14 +438,38 @@ export async function importResourceHubFile(
             const { applyCustomAppRegistrationsAsync } = await import("./custom-app-registration");
             const app = lower.endsWith(".zip") ? await loadCustomAppPackage(file) : await loadSingleHtmlCustomApp(file);
             // 打来源标记：别人的作品，本机能玩，但不进本地测试、不能再发布到应用广场
-            const installed = await installCustomAppAsync({ ...app, resourceHubPath: path });
-            await applyCustomAppRegistrationsAsync(installed);
+            const tagged = { ...app, resourceHubPath: path };
+            // 重复导入（作者更新了资源）：包每次都会拿到新的随机运行时 id，直接装必然
+            // 撞名报错，而报错文案指向的「换包」入口对集市应用是关着的。这里比照小坊
+            // 的做法原地更新，保住 id 与安装时间，应用数据不丢。
+            const { loadInstalledCustomApps, saveInstalledCustomAppsAsync } = await import("./custom-app-storage");
+            const apps = loadInstalledCustomApps();
+            const existing = apps.find(a =>
+                a.resourceHubPath === path
+                || (a.resourceHubPath && a.name.trim().toLowerCase() === tagged.name.trim().toLowerCase()));
+            let installed;
+            if (existing) {
+                installed = { ...tagged, id: existing.id, installedAt: existing.installedAt };
+                await saveInstalledCustomAppsAsync([installed, ...apps.filter(a => a.id !== existing.id)]);
+            } else {
+                installed = await installCustomAppAsync(tagged);
+            }
+            // 注册（预设/正则等附带声明）失败不阻塞安装：应用已经装上了，
+            // 抛出去会显示成「导入失败」，还会顺带跳过下面的摆图标。
+            let registerWarning = "";
+            try {
+                await applyCustomAppRegistrationsAsync(installed);
+            } catch (err) {
+                registerWarning = `（附带内容注册失败：${err instanceof Error ? err.message : String(err)}）`;
+            }
             // 请桌面摆图标：应用广场走 onInstallToDesktop 回调，我们够不着它，
             // 改派同一套事件（小坊装应用也是这么做的）。漏了这步图标不会出现在桌面。
             if (typeof window !== "undefined") {
                 window.dispatchEvent(new CustomEvent(CUSTOM_APP_PLACE_DESKTOP_EVENT, { detail: { appId: installed.id } }));
             }
-            return `应用「${installed.name}」已安装，桌面可找到图标（集市来的作品仅供本机使用，不能再发布）`;
+            return existing
+                ? `应用「${installed.name}」已更新（原有数据保留）${registerWarning}`
+                : `应用「${installed.name}」已安装，桌面可找到图标（集市来的作品仅供本机使用，不能再发布）${registerWarning}`;
         }
         case "game": {
             const payload = JSON.parse(await fetchResourceHubText(source, path)) as { type?: string; title?: string; draft?: unknown };
@@ -443,11 +519,13 @@ export async function importResourceHubFile(
         case "plugin": {
             const code = await fetchResourceHubText(source, path);
             const { installChatPluginFromCode } = await import("./chat-plugin-loader");
+            // 装插件即执行代码（模块顶层在校验阶段就会跑），与插件管理页同样的告知不能省
             const result = await installChatPluginFromCode(code);
             if (!result.ok) throw new Error(result.error || "插件安装失败");
+            // persistChatPlugin 对新插件直接 enabled: true，装完就已经在跑了
             return result.upgraded
                 ? `插件「${result.name}」已升级（${result.fromVersion} → ${result.toVersion}）`
-                : `插件「${result.name}」已安装，可在聊天设置的插件管理里启用`;
+                : `插件「${result.name}」已安装并启用，可在聊天设置的插件管理里关闭`;
         }
     }
 }

--- a/lib/resource-hub-client.ts
+++ b/lib/resource-hub-client.ts
@@ -382,12 +382,17 @@ export async function importResourceHubFile(
             const buffer = await fetchResourceHubBinary(source, path);
             const filename = path.split("/").pop() || "app.zip";
             const file = new File([buffer], filename);
-            const { loadCustomAppPackage, loadSingleHtmlCustomApp, installCustomAppAsync } = await import("./custom-app-storage");
+            const { loadCustomAppPackage, loadSingleHtmlCustomApp, installCustomAppAsync, CUSTOM_APP_PLACE_DESKTOP_EVENT } = await import("./custom-app-storage");
             const { applyCustomAppRegistrationsAsync } = await import("./custom-app-registration");
             const app = lower.endsWith(".zip") ? await loadCustomAppPackage(file) : await loadSingleHtmlCustomApp(file);
             // 打来源标记：别人的作品，本机能玩，但不进本地测试、不能再发布到应用广场
             const installed = await installCustomAppAsync({ ...app, resourceHubPath: path });
             await applyCustomAppRegistrationsAsync(installed);
+            // 请桌面摆图标：应用广场走 onInstallToDesktop 回调，我们够不着它，
+            // 改派同一套事件（小坊装应用也是这么做的）。漏了这步图标不会出现在桌面。
+            if (typeof window !== "undefined") {
+                window.dispatchEvent(new CustomEvent(CUSTOM_APP_PLACE_DESKTOP_EVENT, { detail: { appId: installed.id } }));
+            }
             return `应用「${installed.name}」已安装，桌面可找到图标（集市来的作品仅供本机使用，不能再发布）`;
         }
         case "game": {


### PR DESCRIPTION
把 `importResourceHubFile` 的 11 个导入目的地逐个与各自的原生导入流程对照，修掉发现的问题。

**1. 集市导入的应用不出现在桌面。** 应用广场装完会调 `onInstallToDesktop` 摆图标，小坊装完会派发 `CUSTOM_APP_PLACE_DESKTOP_EVENT`，只有集市两样都没做——而提示还写着「桌面可找到图标」。改派同一套事件。

**2. 聊天室 CSS 从来就没生效过。** 选角色的列表传的是 `ChatContact.id`，而 `ChatSession.contactId` 存的是**角色 id**（全仓另外 18 处 `createOrGetSession` 都传角色 id，`chat-storage.ts:326` 也用它反查角色名）。于是每次导入都新建一个谁都匹配不上的游离会话、把 CSS 写进去，聊天室永远看不到，还每导一次多攒一个死会话。改传 `characterId`。

**3. PNG 角色卡导入后头像是空的。** PNG 卡的画像就是图片本身，导出时 `avatar` 被有意写成 `"none"`；原生导入会把图片本体补成头像，集市这条路没补。

**4. 导入前不等存储加载完。** 整个函数都是「读出来 → 加一条 → 整份写回」，而 `kvSet` 是无条件覆盖、`kvGet` 在水合前返回 `null`，抢跑会把角色库 / 主题档案 / 游戏草稿 / 剧场草稿 / 插件整份抹掉。settings 与 chat 两层自带增量兜底，kv 没有。统一在入口 `await` 齐三套存储。

**5. 装插件没有任何告知。** 插件与本应用同权限且装上即执行（模块顶层在校验阶段就会跑），插件管理页装本地文件都要先确认，集市这条来源必然是陌生人的代码却直接装。补一个确认弹窗；顺带修正文案——新装插件默认就是启用的。

**6. 内部哨兵串直接甩给用户**，显示成「导入失败：UNSUPPORTED_IMPORT_FORMAT」。按各管理页的做法翻译成人话。

**7. 同一个应用重复导入直接报错**，而报错文案指向的「换包」入口对集市应用是关着的，等于死路。改为原地更新，保住 id 与安装时间。

另外：新导入的预设 / 正则 / 世界书改为排在列表最前（与各管理页一致），补发 presets / worldbooks 刷新事件，应用的附带内容注册失败不再报成「导入失败」。

`npx tsc --noEmit` 通过。用 Playwright 在真实 app 里验证：桌面图标从 24 → 25；聊天室 CSS 落到聊天室真正在用的那个会话上且不新增会话（并用反证确认旧写法确实会多建一个游离会话）；PNG 头像非空；预设新导入的排最前；错误文案已翻译；应用二次导入变成原地更新且 id 不变。

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_