### PR TITLE
资源集市支持直接导入主题包

### DIFF
--- a/components/desktop-shell.tsx
+++ b/components/desktop-shell.tsx
@@ -87,6 +87,7 @@ import {
   readThemeProfile,
   writeThemeProfile
 } from "@/lib/theme-storage";
+import { THEME_PACKAGE_INSTALLED_EVENT } from "@/lib/theme-package";
 import {
   DEFAULT_THEME_PROFILE,
   DEFAULT_FONT_FAMILY,
@@ -1407,6 +1408,8 @@ export function DesktopShell({ initialThemeProfile, initialThemeAssets }: Deskto
 
   // 其他模块（如工坊 agent 装应用）请求把已安装应用的图标摆上桌面
   const handleInstallCustomAppToDesktopRef = useRef<((app: InstalledCustomApp) => void) | null>(null);
+  const handleThemeDesktopChangeRef = useRef<((next: { widgets: WidgetInstance[]; iconLayout: DesktopLayout; dock?: DesktopIconId[] }) => void) | null>(null);
+  const applyThemeRef = useRef<((next: ThemeProfile) => Promise<void>) | null>(null);
   useEffect(() => {
     const placeHandler = (e: Event) => {
       const appId = (e as CustomEvent).detail?.appId;
@@ -1416,6 +1419,21 @@ export function DesktopShell({ initialThemeProfile, initialThemeAssets }: Deskto
     };
     window.addEventListener(CUSTOM_APP_PLACE_DESKTOP_EVENT, placeHandler);
     return () => window.removeEventListener(CUSTOM_APP_PLACE_DESKTOP_EVENT, placeHandler);
+  }, []);
+
+  // 资源集市在 lib 里装完主题包后请桌面刷新。走的落地路径与外观页导入完全一致
+  // （handleThemeDesktopChange + applyTheme），只是入口从 React 回调换成了事件。
+  useEffect(() => {
+    const onThemePackage = (e: Event) => {
+      const detail = (e as CustomEvent).detail as
+        | { themeProfile?: ThemeProfile; iconLayout?: DesktopLayout; widgets?: WidgetInstance[]; dock?: DesktopIconId[] }
+        | undefined;
+      if (!detail?.themeProfile || !detail.iconLayout || !detail.widgets) return;
+      handleThemeDesktopChangeRef.current?.({ widgets: detail.widgets, iconLayout: detail.iconLayout, dock: detail.dock });
+      void applyThemeRef.current?.(detail.themeProfile);
+    };
+    window.addEventListener(THEME_PACKAGE_INSTALLED_EVENT, onThemePackage);
+    return () => window.removeEventListener(THEME_PACKAGE_INSTALLED_EVENT, onThemePackage);
   }, []);
 
   useEffect(() => {
@@ -2884,6 +2902,9 @@ html,body{margin:0;padding:0;width:100%;height:100%;background:#121110;color:rgb
     saveWidgets(normalizedWidgets);
     kvSet(ICON_LAYOUT_STORAGE_KEY, JSON.stringify(normalizedLayout));
   }
+
+  handleThemeDesktopChangeRef.current = handleThemeDesktopChange;
+  applyThemeRef.current = applyTheme;
 
   function handleWidgetConfigChange(widgetId: string, config: Record<string, unknown>): void {
     setWidgets((prev) => {

--- a/components/resource-hub/pixel-icons.tsx
+++ b/components/resource-hub/pixel-icons.tsx
@@ -234,6 +234,25 @@ const DEST_ICONS: Record<ImportDestination, PixelGrid> = {
         "................",
         "................",
     ],
+    // 调色板（主题包）
+    theme: [
+        "................",
+        "................",
+        "................",
+        "......kkkk......",
+        "....kkwwwwkk....",
+        "...kwrrwwyywk...",
+        "..kwwrrwwyywwk..",
+        "..kwbbwwwwwcck..",
+        "..kwbbwwwwwcck..",
+        "..kwwwwwwwwwwk..",
+        "..kwwwwwwkkwwk..",
+        "...kwwwwwkkwk...",
+        "....kkwwwwkk....",
+        "......kkkk......",
+        "................",
+        "................",
+    ],
 };
 
 function renderGrid(grid: PixelGrid, size: number, className?: string) {

--- a/lib/resource-hub-client.ts
+++ b/lib/resource-hub-client.ts
@@ -310,11 +310,18 @@ export function checkImportFileForDestination(destination: ImportDestination, pa
             return lower.endsWith(".zip") || lower.endsWith(".html") || lower.endsWith(".htm") ? null : "应用需要 zip 安装包或单 HTML 文件";
         case "plugin":
             return lower.endsWith(".js") || lower.endsWith(".mjs") || lower.endsWith(".txt") ? null : "插件需要 JS 源码文件";
+        case "theme":
+            // .ai-theme 就是个 zip，有人改名成 .zip 上传也照收
+            return lower.endsWith(".ai-theme") || lower.endsWith(".zip") ? null : "主题包需要 .ai-theme 文件";
     }
 }
 
 function dispatch(eventName: string): void {
     if (typeof window !== "undefined") window.dispatchEvent(new CustomEvent(eventName));
+}
+
+function dispatchWith(eventName: string, detail: unknown): void {
+    if (typeof window !== "undefined") window.dispatchEvent(new CustomEvent(eventName, { detail }));
 }
 
 /** PNG 字节 → data URL（角色卡的画像就是这张图本身）。 */
@@ -515,6 +522,16 @@ export async function importResourceHubFile(
             });
             kvSet(key, JSON.stringify(drafts.slice(0, 80)));
             return `剧场草稿「${title}」已导入草稿箱，可在黑市工作室查看（集市来的作品不能上架）`;
+        }
+        case "theme": {
+            const buffer = await fetchResourceHubBinary(source, path);
+            const filename = path.split("/").pop() || "theme.ai-theme";
+            const { installThemePackageFile, THEME_PACKAGE_INSTALLED_EVENT } = await import("./theme-package");
+            // installThemePackageFile 自己就把资源/主题档案/组件/布局都落盘了，
+            // 但桌面上那些 React 状态还是旧的，得派事件让 shell 重新落地一次。
+            const result = await installThemePackageFile(new File([buffer], filename));
+            dispatchWith(THEME_PACKAGE_INSTALLED_EVENT, result);
+            return `主题包已应用：${result.summary.assetCount} 个资源，${result.summary.widgetCount} 个桌面组件`;
         }
         case "plugin": {
             const code = await fetchResourceHubText(source, path);

--- a/lib/resource-hub-types.ts
+++ b/lib/resource-hub-types.ts
@@ -65,7 +65,8 @@ export type ImportDestination =
     | "custom_app"
     | "game"
     | "theater"
-    | "plugin";
+    | "plugin"
+    | "theme";
 
 export const IMPORT_DESTINATIONS: Array<{ key: ImportDestination; label: string; hint: string }> = [
     { key: "preset", label: "预设", hint: "预设管理页导出的 JSON" },
@@ -79,4 +80,5 @@ export const IMPORT_DESTINATIONS: Array<{ key: ImportDestination; label: string;
     { key: "game", label: "游戏", hint: "游戏草稿箱导出的 JSON" },
     { key: "theater", label: "黑市剧场", hint: "剧场草稿箱导出的 JSON" },
     { key: "plugin", label: "插件", hint: "聊天插件 JS 源码文件" },
+    { key: "theme", label: "主题包", hint: "外观页导出的 .ai-theme 主题包" },
 ];

--- a/lib/theme-package.ts
+++ b/lib/theme-package.ts
@@ -427,6 +427,13 @@ export async function inspectThemePackageFile(file: File): Promise<ThemePackageS
   return makeSummary(manifest);
 }
 
+/**
+ * 主题包已装好、请桌面刷新（detail 带 installThemePackageFile 的返回值）。
+ * 资源集市在 lib 里够不着外观页那两个 React 回调，改派这个事件，
+ * 桌面 shell 走与外观页导入完全相同的落地路径。
+ */
+export const THEME_PACKAGE_INSTALLED_EVENT = "ai-phone-theme-package-installed";
+
 export async function installThemePackageFile(file: File): Promise<InstalledThemePackage> {
   const { zip, manifest } = await loadZip(file);
   const records: ThemeAssetRecord[] = [];


### PR DESCRIPTION
集市的导入目的地里没有主题包这一项，`.ai-theme` 文件只能下载下来、再去外观页手动导入。补上「主题包」目的地。

`installThemePackageFile` 本身就把资源、主题档案、桌面组件、图标布局全都落盘了，缺的只是让桌面刷新——外观页靠 `onDesktopThemeChange` + `onApply` 两个 React 回调完成，lib 里够不着它们。于是照搬「摆应用图标」那套做法派一个事件（`THEME_PACKAGE_INSTALLED_EVENT`），桌面 shell 收到后走**完全相同**的落地路径（`handleThemeDesktopChange` + `applyTheme`），不必重开 app。

改动：

- `ImportDestination` 新增 `theme`，目的地列表加「主题包」
- `checkImportFileForDestination` 接受 `.ai-theme` 与 `.zip`（同一种格式，有人改名上传也照收）
- 新增调色板像素图标（16×16 网格由脚本生成并校验行列数，不手数格子）
- `lib/theme-package.ts` 导出事件常量；`desktop-shell.tsx` 加监听

`npx tsc --noEmit` 通过。端到端验证：让 app 自己 `createThemePackageBlob` 生成一个真主题包（内含把图标文字染成 `#ff0066` 的全局 CSS），拿它当集市资源走完整导入流程，**不刷新页面**关掉集市后读取图标文字的计算样式：

```
② 导入前图标文字颜色: rgb(74, 74, 74)
③ 导入目的地: … · 插件 · 主题包
④ 导入后图标文字颜色: rgb(255, 0, 102)
ALL CHECKS PASSED
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_