### PR TITLE
集市开屏提示文案改为点明「他人作品」

### DIFF
--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -1246,7 +1246,7 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                         <div className="rh-dialog-body">
                             <span className="rh-dialog-icon">📢</span>
                             <span>
-                                为了保护创作者权益，从资源市场导入的作品，仅限于本地运行，<b>不能发布市场</b>。
+                                为了保护创作者权益，从资源市场导入的他人作品，仅限于本地运行，<b>不能将他人的作品发布市场</b>。
                             </span>
                         </div>
                         <div className="rh-dialog-footer">


### PR DESCRIPTION
资源集市开屏的创作者权益提示文案调整，把「他人作品」这层意思写明白，避免被误读成自己的作品也不能发布。

- 旧：为了保护创作者权益，从资源市场导入的作品，仅限于本地运行，**不能发布市场**。
- 新：为了保护创作者权益，从资源市场导入的他人作品，仅限于本地运行，**不能将他人的作品发布市场**。

加粗范围跟着调到新的禁止语句上。按钮与「永不显示」的记忆行为不变。

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_