### PR TITLE
资源集市支持导入单条预设条目

### DIFF
--- a/components/resource-hub/pixel-icons.tsx
+++ b/components/resource-hub/pixel-icons.tsx
@@ -253,6 +253,25 @@ const DEST_ICONS: Record<ImportDestination, PixelGrid> = {
         "................",
         "................",
     ],
+    // 列表卡片 + 加号徽标（单条预设条目）
+    preset_entry: [
+        "................",
+        "................",
+        "..kkkkkkkkkkkk..",
+        "..kwwwwwwwwwwk..",
+        "..kwddddddddwk..",
+        "..kwddddddddwk..",
+        "..kwwwwwwwwwwk..",
+        "..kwbbbbbbbbwk..",
+        "..kwbbbbbbbbwk..",
+        "..kwwwwwwkkkkk..",
+        "..kwdddddkkykk..",
+        "..kwdddddkyyyk..",
+        "..kkkkkkkkkykk..",
+        ".........kkkkk..",
+        "................",
+        "................",
+    ],
 };
 
 function renderGrid(grid: PixelGrid, size: number, className?: string) {

--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -13,6 +13,8 @@ import {
     downloadResourceHubFile,
     fetchShareIndex,
     importResourceHubFile,
+    fetchPresetEntry,
+    applyPresetEntry,
     loadResourceHubSource,
     purgeShareIndexCache,
     resolveResourceHubAssetUrl,
@@ -47,6 +49,9 @@ import {
 import { mergeMyUploads } from "@/lib/resource-hub-upload";
 import { DefaultPixelAvatar } from "@/components/resource-hub/pixel-avatar";
 import { DestPixelIcon, FileTypePixelIcon, fileExtension } from "@/components/resource-hub/pixel-icons";
+import { loadPresets } from "@/lib/settings-storage";
+import { displayOrderPrompts } from "@/lib/preset-entry-import";
+import type { Prompt, PresetConfig } from "@/lib/settings-types";
 // 标题栏图标用 lucide 矢量图：⚙/⟳ 这些字符在 iOS 上会被当彩色 emoji 画、
 // 或者字形本身偏小，各设备长相不一；矢量图标则处处一致且小尺寸清晰。
 import { RotateCw, Settings, X } from "lucide-react";
@@ -158,6 +163,13 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
     const [confirmPlugin, setConfirmPlugin] = useState<string | null>(null);
     // 应用主题包前的覆盖确认：待导入的主题包文件路径
     const [confirmTheme, setConfirmTheme] = useState<string | null>(null);
+    // 「预设条目」四步流程：取到的条目 → 选新增/覆盖 → 选预设 → 选位置
+    const [entryImport, setEntryImport] = useState<{
+        prompt: Prompt;
+        mode: "insert" | "replace" | null;
+        preset: PresetConfig | null;
+    } | null>(null);
+    const [entryBusy, setEntryBusy] = useState(false);
     const [uploadCfg, setUploadCfg] = useState<ResourceHubUploadConfig>(() => loadUploadConfig());
     // 所见即所得编辑器：贴纸选择器（标题/正文两处）、颜色面板
     const [stickerPickerFor, setStickerPickerFor] = useState<"title" | "desc" | null>(null);
@@ -346,6 +358,21 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
         }
     }, [onNotice, source]);
 
+    /** 第三步点下去：落盘并收尾。 */
+    const runEntryImport = useCallback(async (anchorIdentifier: string | null) => {
+        if (!entryImport?.mode || !entryImport.preset) return;
+        setEntryBusy(true);
+        try {
+            const message = await applyPresetEntry(entryImport.prompt, entryImport.preset.id, entryImport.mode, anchorIdentifier);
+            onNotice?.(message);
+            setEntryImport(null);
+        } catch (err) {
+            onNotice?.(`导入失败：${err instanceof Error ? err.message : String(err)}`);
+        } finally {
+            setEntryBusy(false);
+        }
+    }, [entryImport, onNotice]);
+
     const handlePickDestination = useCallback((destination: ImportDestination) => {
         if (!importFile) return;
         const typeError = checkImportFileForDestination(destination, importFile);
@@ -368,6 +395,19 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
         if (destination === "theme") {
             setConfirmTheme(importFile);
             setImportFile(null);
+            return;
+        }
+        // 预设条目：先把条目取下来（顺便校验是不是单条），再走选预设/选位置
+        if (destination === "preset_entry") {
+            const target = importFile;
+            setImportingTo(destination);
+            void fetchPresetEntry(source, target)
+                .then(prompt => {
+                    setEntryImport({ prompt, mode: null, preset: null });
+                    setImportFile(null);
+                })
+                .catch(err => onNotice?.(`导入失败：${err instanceof Error ? err.message : String(err)}`))
+                .finally(() => setImportingTo(null));
             return;
         }
         void runImport(importFile, destination);
@@ -1186,6 +1226,72 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                                 setShowUpload(true);
                             }}>确认</button>
                         </div>
+                    </div>
+                </div>
+            )}
+
+            {/* 预设条目：新增 or 覆盖 → 选预设 → 选位置 */}
+            {entryImport && (
+                <div className="rh-dialog-overlay" onClick={entryBusy ? undefined : () => setEntryImport(null)}>
+                    <div className="rh-dialog" onClick={e => e.stopPropagation()}>
+                        <div className="rh-titlebar">
+                            <span className="rh-titlebar-text">
+                                {!entryImport.mode ? "导入预设条目"
+                                    : !entryImport.preset ? "导入到哪个预设？"
+                                        : entryImport.mode === "insert" ? "插到哪一条后面？" : "覆盖哪一条？"}
+                            </span>
+                            <span className="rh-titlebar-controls">
+                                <button className="rh-tb-btn" disabled={entryBusy} onClick={() => setEntryImport(null)}>✕</button>
+                            </span>
+                        </div>
+                        <div className="rh-import-filename">条目：{entryImport.prompt.name || entryImport.prompt.identifier}</div>
+
+                        {/* 第一步：新增还是覆盖 */}
+                        {!entryImport.mode && (
+                            <div className="rh-dialog-body rh-dest-list">
+                                <button className="rh-dest" onClick={() => setEntryImport(v => v && { ...v, mode: "insert" })}>
+                                    <span className="rh-dest-label">新增 —— 插入到某一条之后</span>
+                                </button>
+                                <button className="rh-dest" onClick={() => setEntryImport(v => v && { ...v, mode: "replace" })}>
+                                    <span className="rh-dest-label">覆盖 —— 替换掉某一条</span>
+                                </button>
+                            </div>
+                        )}
+
+                        {/* 第二步：选预设 */}
+                        {entryImport.mode && !entryImport.preset && (
+                            <div className="rh-dialog-body rh-dest-list">
+                                {loadPresets().length > 0 ? loadPresets().map(preset => (
+                                    <button key={preset.id} className="rh-dest"
+                                        onClick={() => setEntryImport(v => v && { ...v, preset })}>
+                                        <span className="rh-dest-label">{preset.name}</span>
+                                        <span className="rh-dest-hint">{preset.prompts.length} 条</span>
+                                    </button>
+                                )) : <div className="rh-center-hint">还没有任何预设，先去设置里建一个吧</div>}
+                            </div>
+                        )}
+
+                        {/* 第三步：选位置。用显示顺序，与预设管理页看到的一致 */}
+                        {entryImport.mode && entryImport.preset && (
+                            <div className="rh-dialog-body rh-dest-list">
+                                {entryImport.mode === "insert" && (
+                                    <button className="rh-dest" disabled={entryBusy}
+                                        onClick={() => void runEntryImport(null)}>
+                                        <span className="rh-dest-label">▲ 放到最前面</span>
+                                    </button>
+                                )}
+                                {displayOrderPrompts(entryImport.preset).map(p => (
+                                    <button key={p.identifier} className="rh-dest" disabled={entryBusy}
+                                        onClick={() => void runEntryImport(p.identifier)}>
+                                        <span className="rh-dest-label">
+                                            {entryBusy && <><PixelHourglass size={13} /> </>}
+                                            {p.name || p.identifier}
+                                        </span>
+                                        <span className="rh-dest-hint">{p.marker ? "占位条目" : p.role}</span>
+                                    </button>
+                                ))}
+                            </div>
+                        )}
                     </div>
                 </div>
             )}

--- a/lib/preset-entry-import.ts
+++ b/lib/preset-entry-import.ts
@@ -1,0 +1,139 @@
+import type { Prompt, PresetConfig } from "./settings-types";
+
+/**
+ * 预设「单条目」的解析与落位。
+ *
+ * 顺序这件事在这个应用里有两份真相：`prompts` 数组和 `prompt_order`。
+ * 界面显示、以及组装 prompt 时的先后，都以 `prompt_order` 为准、把不在其中的
+ * 条目（孤儿）接在后面（见 preset-manager 的渲染与 llm-prompt-assembler 的
+ * buildProcessingOrder）。所以插入/覆盖必须在"显示顺序"这份列表上做，
+ * 再由它重建两份数据，否则用户看到的位置和实际生效的位置会对不上。
+ */
+
+/** 还原成与界面一致的显示顺序：prompt_order 的次序 + 不在其中的孤儿条目。 */
+export function displayOrderPrompts(preset: PresetConfig): Prompt[] {
+    const ordered = preset.prompt_order && preset.prompt_order.length > 0
+        ? preset.prompt_order
+            .map(entry => preset.prompts.find(p => p.identifier === entry.identifier))
+            .filter((p): p is Prompt => !!p)
+        : [...(preset.prompts || [])];
+    const seen = new Set(ordered.map(p => p.identifier));
+    return [...ordered, ...(preset.prompts || []).filter(p => !seen.has(p.identifier))];
+}
+
+/** 按显示顺序重建两份数据，逐条沿用原有的启用状态。 */
+function rebuild(preset: PresetConfig, displayed: Prompt[]): PresetConfig {
+    return {
+        ...preset,
+        prompts: displayed,
+        prompt_order: displayed.map(p => ({
+            identifier: p.identifier,
+            enabled: preset.prompt_order?.find(o => o.identifier === p.identifier)?.enabled ?? p.enabled,
+        })),
+    };
+}
+
+/** 单条 prompt 的消毒（与预设管理页的条目导入同一套规则）。 */
+export function sanitizePromptEntry(raw: unknown, fallbackIdentifier: string): Prompt | null {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+    const obj = raw as Record<string, unknown>;
+    if (typeof obj.name !== "string" && typeof obj.content !== "string" && typeof obj.identifier !== "string") return null;
+    const role = obj.role === "user" || obj.role === "assistant" || obj.role === "system" ? obj.role : "system";
+    const prompt: Prompt = {
+        identifier: typeof obj.identifier === "string" && obj.identifier ? obj.identifier : fallbackIdentifier,
+        name: typeof obj.name === "string" ? obj.name : "",
+        role,
+        content: typeof obj.content === "string" ? obj.content : "",
+        injection_depth: typeof obj.injection_depth === "number" ? obj.injection_depth : 0,
+        injection_position: typeof obj.injection_position === "number" ? obj.injection_position : 0,
+        enabled: obj.enabled !== false,
+        marker: !!obj.marker,
+        system_prompt: !!obj.system_prompt,
+        forbid_overrides: !!obj.forbid_overrides,
+    };
+    if (Array.isArray(obj.tags)) prompt.tags = obj.tags.filter((t): t is string => typeof t === "string");
+    if (typeof obj.featureTag === "string") prompt.featureTag = obj.featureTag;
+    if (typeof obj.followUpOnly === "boolean") prompt.followUpOnly = obj.followUpOnly;
+    return prompt;
+}
+
+export type ParsedEntryFile =
+    | { ok: true; prompt: Prompt }
+    /** 整份预设或多条条目：这条路只处理单条，让调用方去引导用户改用「预设」目的地 */
+    | { ok: false; reason: "multiple"; count: number }
+    | { ok: false; reason: "invalid" };
+
+/**
+ * 把文件解析成"一条"预设条目。
+ * 接受：单条 prompt 对象、只含一条的数组。
+ * 拒绝：整份预设、多条数组——那是「预设」目的地该干的事。
+ */
+export function parseSinglePromptEntry(text: string): ParsedEntryFile {
+    let raw: unknown;
+    try {
+        raw = JSON.parse(text);
+    } catch {
+        return { ok: false, reason: "invalid" };
+    }
+    if (Array.isArray(raw)) {
+        if (raw.length !== 1) return { ok: false, reason: "multiple", count: raw.length };
+        const prompt = sanitizePromptEntry(raw[0], `prompt-${Date.now()}`);
+        return prompt ? { ok: true, prompt } : { ok: false, reason: "invalid" };
+    }
+    if (raw && typeof raw === "object") {
+        const obj = raw as Record<string, unknown>;
+        // 整份预设有 prompts 数组：它有 name 字段，直接当条目消毒会得到一条空垃圾
+        if (Array.isArray(obj.prompts)) {
+            return obj.prompts.length === 1
+                ? (() => {
+                    const prompt = sanitizePromptEntry(obj.prompts[0], `prompt-${Date.now()}`);
+                    return prompt ? { ok: true as const, prompt } : { ok: false as const, reason: "invalid" as const };
+                })()
+                : { ok: false, reason: "multiple", count: obj.prompts.length };
+        }
+        const prompt = sanitizePromptEntry(raw, `prompt-${Date.now()}`);
+        return prompt ? { ok: true, prompt } : { ok: false, reason: "invalid" };
+    }
+    return { ok: false, reason: "invalid" };
+}
+
+/** identifier 撞车时加后缀，避免顶掉预设里已有的条目。 */
+function uniqueIdentifier(preset: PresetConfig, wanted: string): string {
+    const used = new Set((preset.prompts || []).map(p => p.identifier));
+    if (!used.has(wanted)) return wanted;
+    let n = 1;
+    let id = `${wanted}_${n}`;
+    while (used.has(id)) id = `${wanted}_${++n}`;
+    return id;
+}
+
+/**
+ * 插到 afterIdentifier 那一条之后；afterIdentifier 为 null 表示放到最前面。
+ * 返回新的预设对象（不落盘，由调用方保存）。
+ */
+export function insertPromptAfter(preset: PresetConfig, afterIdentifier: string | null, prompt: Prompt): PresetConfig {
+    const entry = { ...prompt, identifier: uniqueIdentifier(preset, prompt.identifier) };
+    const displayed = displayOrderPrompts(preset);
+    if (afterIdentifier === null) {
+        displayed.unshift(entry);
+    } else {
+        const idx = displayed.findIndex(p => p.identifier === afterIdentifier);
+        if (idx >= 0) displayed.splice(idx + 1, 0, entry);
+        else displayed.push(entry);
+    }
+    return rebuild(preset, displayed);
+}
+
+/**
+ * 覆盖 targetIdentifier 那一条，位置不变。
+ * 新条目的 identifier 若与预设里"别的"条目撞车，保留被覆盖条目的 identifier，
+ * 否则会连带顶掉另一条。
+ */
+export function replacePromptEntry(preset: PresetConfig, targetIdentifier: string, prompt: Prompt): PresetConfig {
+    const clashesElsewhere = prompt.identifier !== targetIdentifier
+        && (preset.prompts || []).some(p => p.identifier === prompt.identifier);
+    const finalId = clashesElsewhere ? targetIdentifier : prompt.identifier;
+    const entry = { ...prompt, identifier: finalId };
+    const displayed = displayOrderPrompts(preset).map(p => p.identifier === targetIdentifier ? entry : p);
+    return rebuild(preset, displayed);
+}

--- a/lib/resource-hub-client.ts
+++ b/lib/resource-hub-client.ts
@@ -22,6 +22,7 @@ import { createOrGetSession, loadChatSessions, saveChatSessions } from "./chat-s
 import { readThemeProfile, writeThemeProfile } from "./theme-storage";
 import { loadGameDrafts, saveGameDrafts } from "./game-storage";
 import type { GameTemplateDraft } from "./game-types";
+import type { Prompt } from "./settings-types";
 
 const SOURCE_KEY = "ai_phone_resource_hub_source_v1";
 registerKvMigration(SOURCE_KEY);
@@ -310,10 +311,52 @@ export function checkImportFileForDestination(destination: ImportDestination, pa
             return lower.endsWith(".zip") || lower.endsWith(".html") || lower.endsWith(".htm") ? null : "应用需要 zip 安装包或单 HTML 文件";
         case "plugin":
             return lower.endsWith(".js") || lower.endsWith(".mjs") || lower.endsWith(".txt") ? null : "插件需要 JS 源码文件";
+        case "preset_entry":
+            return isJson ? null : "预设条目需要 JSON 文件";
         case "theme":
             // .ai-theme 就是个 zip，有人改名成 .zip 上传也照收
             return lower.endsWith(".ai-theme") || lower.endsWith(".zip") ? null : "主题包需要 .ai-theme 文件";
     }
+}
+
+/**
+ * 取一条预设条目（供集市的「预设条目」流程用）。
+ * 单独暴露是因为这条路要先让用户选预设和位置，不能一步到底。
+ */
+export async function fetchPresetEntry(source: ResourceHubSource, path: string): Promise<Prompt> {
+    const { ensureSettingsStorageHydrated } = await import("./settings-storage");
+    await ensureSettingsStorageHydrated();
+    const { parseSinglePromptEntry } = await import("./preset-entry-import");
+    const parsed = parseSinglePromptEntry(await fetchResourceHubText(source, path));
+    if (parsed.ok) return parsed.prompt;
+    if (parsed.reason === "multiple") {
+        throw new Error(`这个文件里有 ${parsed.count} 条条目，不是单条。整份预设请改用「预设」目的地导入。`);
+    }
+    throw new Error("解析失败，请确认这是预设条目左滑「导出」生成的 JSON");
+}
+
+/** 把取到的条目插入/覆盖进指定预设，落盘并返回给用户看的说明。 */
+export async function applyPresetEntry(
+    prompt: Prompt,
+    presetId: string,
+    mode: "insert" | "replace",
+    anchorIdentifier: string | null,
+): Promise<string> {
+    const { ensureSettingsStorageHydrated } = await import("./settings-storage");
+    await ensureSettingsStorageHydrated();
+    const { insertPromptAfter, replacePromptEntry } = await import("./preset-entry-import");
+    const presets = loadPresets();
+    const target = presets.find(p => p.id === presetId);
+    if (!target) throw new Error("目标预设不存在，可能已被删除");
+    const next = mode === "replace" && anchorIdentifier
+        ? replacePromptEntry(target, anchorIdentifier, prompt)
+        : insertPromptAfter(target, anchorIdentifier, prompt);
+    savePresets(presets.map(p => p.id === presetId ? next : p));
+    dispatch("settings-presets-updated");
+    const label = prompt.name || prompt.identifier;
+    return mode === "replace"
+        ? `已覆盖预设「${target.name}」里的一条条目为「${label}」`
+        : `条目「${label}」已插入预设「${target.name}」`;
 }
 
 function dispatch(eventName: string): void {
@@ -533,6 +576,10 @@ export async function importResourceHubFile(
             dispatchWith(THEME_PACKAGE_INSTALLED_EVENT, result);
             return `主题包已应用：${result.summary.assetCount} 个资源，${result.summary.widgetCount} 个桌面组件`;
         }
+        case "preset_entry":
+            // 这条目的地要先选预设和位置，走 fetchPresetEntry + applyPresetEntry 两步，
+            // 不经过这里。留个明确的兜底，免得以后有人直接调进来静默什么都不做。
+            throw new Error("预设条目需要先选择目标预设与位置");
         case "plugin": {
             const code = await fetchResourceHubText(source, path);
             const { installChatPluginFromCode } = await import("./chat-plugin-loader");

--- a/lib/resource-hub-types.ts
+++ b/lib/resource-hub-types.ts
@@ -66,7 +66,8 @@ export type ImportDestination =
     | "game"
     | "theater"
     | "plugin"
-    | "theme";
+    | "theme"
+    | "preset_entry";
 
 export const IMPORT_DESTINATIONS: Array<{ key: ImportDestination; label: string; hint: string }> = [
     { key: "preset", label: "预设", hint: "预设管理页导出的 JSON" },
@@ -81,4 +82,5 @@ export const IMPORT_DESTINATIONS: Array<{ key: ImportDestination; label: string;
     { key: "theater", label: "黑市剧场", hint: "剧场草稿箱导出的 JSON" },
     { key: "plugin", label: "插件", hint: "聊天插件 JS 源码文件" },
     { key: "theme", label: "主题包", hint: "外观页导出的 .ai-theme 主题包" },
+    { key: "preset_entry", label: "预设条目", hint: "单条预设条目，插入或覆盖到已有预设" },
 ];


### PR DESCRIPTION
集市原本只能整份导入预设，单条条目没法导。新增「预设条目」导入目的地，四步走完：

1. 选**新增**还是**覆盖**
2. 选导入到哪个预设
3. 选插到哪一条之后（新增）／覆盖哪一条
4. 完成

**顺序必须在"显示顺序"上做。** `prompts` 和 `prompt_order` 是两份数据，界面显示与 `llm-prompt-assembler` 组装 prompt 的先后都以 `prompt_order` 为准、把不在其中的孤儿条目接在后面。新增 `lib/preset-entry-import.ts` 收口这套还原与重建逻辑：插入/覆盖都在还原出的显示顺序上做，再由它重建两份数据并逐条沿用原有的启用状态，避免用户看到的位置和实际生效的位置对不上。

其他几个必须处理的细节：

- `identifier` 撞车自动加后缀
- 覆盖时若新条目的 `identifier` 与预设里**别的**条目撞车，保留被覆盖那条的 `identifier`，否则会连带顶掉另一条
- 新增模式多给一个「▲ 放到最前面」，否则第一条之前的位置根本选不到
- 喂进来的是整份预设或多条条目时直接挡下并提示改用「预设」目的地——按单条消毒会得到一条以预设名命名的空垃圾条目

新增像素图标（16×16 网格由脚本生成并校验行列数）。

`npx tsc --noEmit` 通过。端到端验证，逐步核对落盘结果：

```
导入前: {"order":["a","hist","b"],"names":["甲条目","◇ [短期记忆]","乙条目"]}
③ 第三步（选位置）: ['▲ 放到最前面', '甲条目', '◇ [短期记忆]', '乙条目']
④ 插入后: {"order":["a","newbie","hist","b"],"names":["甲条目","新来的条目","◇ [短期记忆]","乙条目"]}
⑤ 覆盖模式的位置列表: ['甲条目','新来的条目','◇ [短期记忆]','乙条目']（无「放到最前面」）
⑥ 覆盖后: 条目数不变，乙条目已被替换
⑦ 喂整份预设: 导入失败：这个文件里有 2 条条目，不是单条。整份预设请改用「预设」目的地导入。
ALL CHECKS PASSED
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_