### PR TITLE
主题包的文件类型提示改以 zip 为主

### DIFF
--- a/lib/resource-hub-client.ts
+++ b/lib/resource-hub-client.ts
@@ -314,8 +314,10 @@ export function checkImportFileForDestination(destination: ImportDestination, pa
         case "preset_entry":
             return isJson ? null : "预设条目需要 JSON 文件";
         case "theme":
-            // .ai-theme 就是个 zip，有人改名成 .zip 上传也照收
-            return lower.endsWith(".ai-theme") || lower.endsWith(".zip") ? null : "主题包需要 .ai-theme 文件";
+            // 现在导出的就是 .zip；.ai-theme 是旧版后缀，留作兼容。
+            // 真正的校验在 installThemePackageFile 里按包内 manifest.json 做，
+            // 这里只是个便宜的前置过滤。
+            return lower.endsWith(".zip") || lower.endsWith(".ai-theme") ? null : "主题包需要 zip 文件（旧版 .ai-theme 也可以）";
     }
 }
 
@@ -568,7 +570,7 @@ export async function importResourceHubFile(
         }
         case "theme": {
             const buffer = await fetchResourceHubBinary(source, path);
-            const filename = path.split("/").pop() || "theme.ai-theme";
+            const filename = path.split("/").pop() || "theme.zip";
             const { installThemePackageFile, THEME_PACKAGE_INSTALLED_EVENT } = await import("./theme-package");
             // installThemePackageFile 自己就把资源/主题档案/组件/布局都落盘了，
             // 但桌面上那些 React 状态还是旧的，得派事件让 shell 重新落地一次。

--- a/lib/resource-hub-types.ts
+++ b/lib/resource-hub-types.ts
@@ -81,6 +81,6 @@ export const IMPORT_DESTINATIONS: Array<{ key: ImportDestination; label: string;
     { key: "game", label: "游戏", hint: "游戏草稿箱导出的 JSON" },
     { key: "theater", label: "黑市剧场", hint: "剧场草稿箱导出的 JSON" },
     { key: "plugin", label: "插件", hint: "聊天插件 JS 源码文件" },
-    { key: "theme", label: "主题包", hint: "外观页导出的 .ai-theme 主题包" },
+    { key: "theme", label: "主题包", hint: "外观页导出的主题包 zip" },
     { key: "preset_entry", label: "预设条目", hint: "单条预设条目，插入或覆盖到已有预设" },
 ];


### PR DESCRIPTION
导出早就产出 `.zip` 了——`packageFileName`（`lib/theme-package.ts:360-366`）明确写着用标准后缀，避免 iOS 选择器把未注册 UTI 的类型置灰；`.ai-theme` 只是旧版兼容后缀。而集市的报错和目的地提示反过来把兼容项说成了要求（「主题包需要 .ai-theme 文件」），会让人以为必须改名才能导入。

三处一并改：

- 报错文案 → 「主题包需要 zip 文件（旧版 .ai-theme 也可以）」
- 目的地格子提示 → 「外观页导出的主题包 zip」
- 取不到文件名时的兜底名 → `theme.zip`

**接受的后缀不变**（两种都收）。真正的校验本来就在 `installThemePackageFile` 里按包内 `manifest.json` 做，扩展名只是个便宜的前置过滤。

验证：

```
目的地提示：外观页导出的主题包 zip
我的主题.zip → 通过
旧版主题.ai-theme → 通过
THEME.ZIP → 通过
说明.txt → 主题包需要 zip 文件（旧版 .ai-theme 也可以）
预设.json → 主题包需要 zip 文件（旧版 .ai-theme 也可以）
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_