### PR TITLE
集市开屏须知改为两条，并强制对老用户再弹一次

### DIFF
--- a/components/resource-hub/resource-hub-app.tsx
+++ b/components/resource-hub/resource-hub-app.tsx
@@ -93,8 +93,12 @@ function formatEntryDate(iso: string | null): string {
     return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
-/** 开屏版权提示的「永不显示」记忆键（值为 "1" 即不再弹）。 */
-const NOTICE_DISMISSED_KEY = "ai_phone_resource_hub_notice_v1";
+/**
+ * 开屏须知的「永不显示」记忆键（值为 "1" 即不再弹）。
+ * 须知内容有实质改动时要升版本号：旧键的「永不显示」不该压住新内容，
+ * 否则老用户永远看不到新增的隐私告知。
+ */
+const NOTICE_DISMISSED_KEY = "ai_phone_resource_hub_notice_v2";
 registerKvMigration(NOTICE_DISMISSED_KEY);
 
 export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onNotice?: (msg: string) => void }) {
@@ -1348,12 +1352,18 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
             {showNotice && (
                 <div className="rh-dialog-overlay">
                     <div className="rh-dialog" onClick={e => e.stopPropagation()}>
-                        <div className="rh-titlebar"><span className="rh-titlebar-text">创作者权益提示</span></div>
-                        <div className="rh-dialog-body">
-                            <span className="rh-dialog-icon">📢</span>
-                            <span>
-                                为了保护创作者权益，从资源市场导入的他人作品，仅限于本地运行，<b>不能将他人的作品发布市场</b>。
-                            </span>
+                        <div className="rh-titlebar"><span className="rh-titlebar-text">资源市场 APP 须知</span></div>
+                        <div className="rh-dialog-body rh-notice-body">
+                            <p>
+                                <span className="rh-notice-no">1.</span>
+                                上传内容将会发布于公开仓库，你设置的头像、昵称、正文内容、资源文件<b>所有人可见</b>，
+                                请确保你知晓以上内容，<b>保护个人隐私</b>，并发布<b>网络允许的安全内容</b>。
+                            </p>
+                            <p>
+                                <span className="rh-notice-no">2.</span>
+                                为了保护创作者权益，从资源市场导入的他人作品，仅限于本地运行，
+                                <b>不能将他人的作品发布市场</b>。
+                            </p>
                         </div>
                         <div className="rh-dialog-footer">
                             <button className="rh-btn" onClick={() => {
@@ -1995,6 +2005,9 @@ export function ResourceHubApp({ onClose, onNotice }: { onClose: () => void; onN
                     gap: 10px;
                 }
                 .rh-dialog-icon { font-size: 30px; }
+                .rh-notice-body { flex-direction: column; align-items: stretch; gap: 10px; line-height: 1.6; }
+                .rh-notice-body p { margin: 0; }
+                .rh-notice-no { font-weight: 700; margin-right: 2px; }
                 .rh-dialog-footer {
                     display: flex;
                     justify-content: center;

--- a/lib/data-management/modules.ts
+++ b/lib/data-management/modules.ts
@@ -250,7 +250,7 @@ export const DATA_MODULES: DataModuleDefinition[] = [
           "ai_phone_resource_hub_upload_cfg_v1",
           "ai_phone_resource_hub_source_v1",
           "ai_phone_resource_hub_flowers_sent_v1",
-          "ai_phone_resource_hub_notice_v1",
+          "ai_phone_resource_hub_notice_v2",
         ],
       },
     ],


### PR DESCRIPTION
标题改为「资源市场 APP 须知」，正文拆成两条：

1. 上传内容将会发布于公开仓库，你设置的头像、昵称、正文内容、资源文件**所有人可见**，请确保你知晓以上内容，**保护个人隐私**，并发布**网络允许的安全内容**。
2. 为了保护创作者权益，从资源市场导入的他人作品，仅限于本地运行，**不能将他人的作品发布市场**。

第 1 条是新增的。此前只在上传确认弹窗里笼统说了「上传文件……所有人可见」，没有点名**头像和昵称**也会写进公开仓库（`.avatar.png` / `.author`），投稿人未必意识到自己那张照片也会进去。

记忆键升到 `..._notice_v2`：内容有实质改动时旧键的「永不显示」不该继续压住新须知，否则老用户永远看不到新增的隐私告知。备份模块里的键名一并跟上。

`npx tsc --noEmit` 通过。验证时**预先写入了 v1 的「永不显示」**来模拟老用户：

```
① 老用户（已点过旧版永不显示）仍然弹: true
② 标题: 资源市场 APP 须知
③ 正文: 1.上传内容将会发布于公开仓库…… 2.为了保护创作者权益……
④ 加粗: ['所有人可见', '保护个人隐私', '网络允许的安全内容', '不能将他人的作品发布市场']
⑤ 按钮: ['永不显示', '确认']
⑥ 点过新版「永不显示」后重进，还弹吗: false
ALL CHECKS PASSED
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVqPuCM8qTHwLejnfUYb9u)_