### PR TITLE
记忆库融合 Ombre Brain 机制：7维评分检索 + BM25 + 衰减归档 + 写入门卫

### DIFF
--- a/lib/memory-bm25.ts
+++ b/lib/memory-bm25.ts
@@ -1,0 +1,109 @@
+// lib/memory-bm25.ts
+// Okapi BM25 keyword ranking for memory retrieval (Ombre Brain port).
+// Full BM25 formula — no simplification. Only the tokenizer differs from the
+// Python original (jieba → hybrid CJK tokenizer below).
+
+// ── Tokenizer ──
+// Hybrid strategy for Chinese without jieba:
+//   1. Latin/digit runs → whole words (lowercased)
+//   2. CJK runs → unigrams + bigrams (bigrams approximate jieba words;
+//      unigrams guarantee recall for single-char terms like 猫/家)
+// Both query and documents use the same tokenizer, so matching is consistent.
+// This is the standard client-side approach; ranking quality is close to
+// jieba-based BM25 for retrieval purposes because IDF automatically down-weights
+// meaningless bigrams (they appear everywhere → low IDF).
+
+export function tokenizeForBm25(text: string): string[] {
+    const lower = text.toLowerCase();
+    const tokens: string[] = [];
+    // Latin words & numbers
+    const words = lower.match(/[a-z0-9]+/g);
+    if (words) tokens.push(...words);
+    // CJK runs → unigrams + bigrams
+    const cjkRuns = lower.match(/[\u2E80-\u9FFF\uF900-\uFAFF\uAC00-\uD7AF]+/g);
+    if (cjkRuns) {
+        for (const run of cjkRuns) {
+            for (let i = 0; i < run.length; i++) {
+                tokens.push(run[i]);
+                if (i < run.length - 1) tokens.push(run.slice(i, i + 2));
+            }
+        }
+    }
+    return tokens;
+}
+
+// ── Okapi BM25 ──
+
+const K1 = 1.5;
+const B = 0.75;
+
+export type Bm25Index = {
+    /** term → document frequency */
+    df: Map<string, number>;
+    /** per-document term frequency maps */
+    docTf: Map<string, number>[];
+    /** per-document token counts */
+    docLen: number[];
+    avgDocLen: number;
+    docCount: number;
+};
+
+/** Build a BM25 index over document bodies (one string per document). */
+export function buildBm25Index(docs: string[]): Bm25Index {
+    const df = new Map<string, number>();
+    const docTf: Map<string, number>[] = [];
+    const docLen: number[] = [];
+    let totalLen = 0;
+
+    for (const doc of docs) {
+        const tokens = tokenizeForBm25(doc);
+        const tf = new Map<string, number>();
+        for (const t of tokens) tf.set(t, (tf.get(t) || 0) + 1);
+        for (const term of tf.keys()) df.set(term, (df.get(term) || 0) + 1);
+        docTf.push(tf);
+        docLen.push(tokens.length);
+        totalLen += tokens.length;
+    }
+
+    return {
+        df,
+        docTf,
+        docLen,
+        avgDocLen: docs.length > 0 ? totalLen / docs.length : 0,
+        docCount: docs.length,
+    };
+}
+
+/**
+ * Score every document in the index against the query.
+ * Returns raw BM25 scores (unbounded, >= 0), aligned with the doc order
+ * used to build the index. Standard Okapi BM25:
+ *   score = Σ IDF(q) · tf·(k1+1) / (tf + k1·(1-b+b·len/avgLen))
+ *   IDF   = ln( (N - df + 0.5) / (df + 0.5) + 1 )
+ */
+export function scoreBm25(index: Bm25Index, query: string): number[] {
+    const scores = new Array<number>(index.docCount).fill(0);
+    if (index.docCount === 0 || index.avgDocLen === 0) return scores;
+
+    const queryTerms = new Set(tokenizeForBm25(query));
+    for (const term of queryTerms) {
+        const df = index.df.get(term);
+        if (!df) continue;
+        const idf = Math.log((index.docCount - df + 0.5) / (df + 0.5) + 1);
+        for (let i = 0; i < index.docCount; i++) {
+            const tf = index.docTf[i].get(term);
+            if (!tf) continue;
+            const denom = tf + K1 * (1 - B + (B * index.docLen[i]) / index.avgDocLen);
+            scores[i] += idf * ((tf * (K1 + 1)) / denom);
+        }
+    }
+    return scores;
+}
+
+/** Normalize raw BM25 scores to 0-1 by dividing by the batch max (0 if all zero). */
+export function normalizeBm25Scores(raw: number[]): number[] {
+    let max = 0;
+    for (const s of raw) if (s > max) max = s;
+    if (max <= 0) return raw.map(() => 0);
+    return raw.map(s => s / max);
+}

--- a/lib/memory-lifecycle.ts
+++ b/lib/memory-lifecycle.ts
@@ -1,0 +1,171 @@
+// lib/memory-lifecycle.ts
+// Ombre Brain lifecycle mechanics: lazy decay engine, touch + time ripple,
+// and the write-admission gate.
+// The Python original runs decay as a standalone process; in the browser we
+// run it lazily (on retrieval / app usage) which is equivalent for our scale.
+
+import type { MemoryEntry, MemoryConfig } from "./memory-types";
+import {
+    RIPPLE_WINDOW_HOURS,
+    RIPPLE_INCREMENT,
+    RIPPLE_MAX_NEIGHBORS,
+    TIME_DECAY_RATE,
+    TOUCH_NORMALIZE_CAP,
+} from "./memory-types";
+import { loadMemoryEntriesByType, saveMemoryEntry, loadMemoryConfig } from "./memory-storage";
+import { keywordOverlapRatio } from "./memory-embedding";
+import { kvGet, kvSet, registerDynamicPrefix } from "./kv-db";
+
+// ── Decay engine ──
+
+const DECAY_LAST_RUN_PREFIX = "ai_phone_mem_decay_last_";
+registerDynamicPrefix(DECAY_LAST_RUN_PREFIX);
+
+/** Minimum interval between decay sweeps per character (ms). */
+const DECAY_MIN_INTERVAL_MS = 6 * 3600 * 1000; // 6h
+
+/**
+ * Decay retention score for a single entry, 0-1.
+ * Time-exponential on last_active, slowed by activation_count:
+ * effective rate = base rate / (1 + activation_count / cap).
+ * pinned / protected entries never decay.
+ */
+export function decayScore(entry: MemoryEntry, now: Date): number {
+    if (entry.pinned || entry.protected) return 1;
+    const ref = entry.lastActive || entry.updatedAt || entry.createdAt;
+    const days = Math.max(0, (now.getTime() - new Date(ref).getTime()) / 86400000);
+    const activation = entry.activationCount ?? 0;
+    let rate = TIME_DECAY_RATE / (1 + activation / TOUCH_NORMALIZE_CAP);
+    if (entry.digested) rate *= 2; // digested → fades faster
+    let score = Math.exp(-rate * days);
+    // importance keeps memories alive longer (floor scaled by importance)
+    score = score + (1 - score) * Math.min(1, Math.max(0, entry.importance)) * 0.3;
+    return score;
+}
+
+/**
+ * Lazy decay sweep for one character: entries whose retention score falls
+ * below the threshold are soft-archived (archived=true + deletedAt), never
+ * physically deleted. Runs at most once per DECAY_MIN_INTERVAL_MS.
+ * Returns number of entries archived.
+ */
+export async function maybeRunDecay(characterId: string): Promise<number> {
+    const config = loadMemoryConfig();
+    if (!config.decayEnabled) return 0;
+
+    if (typeof window === "undefined") return 0;
+    const lastRunKey = DECAY_LAST_RUN_PREFIX + characterId;
+    const lastRun = kvGet(lastRunKey);
+    const now = new Date();
+    if (lastRun && now.getTime() - new Date(lastRun).getTime() < DECAY_MIN_INTERVAL_MS) return 0;
+    kvSet(lastRunKey, now.toISOString());
+
+    const entries = await loadMemoryEntriesByType(characterId, "long_term");
+    let archivedCount = 0;
+    for (const entry of entries) {
+        if (entry.archived || entry.pinned || entry.protected) continue;
+        if (decayScore(entry, now) < config.decayArchiveThreshold) {
+            entry.archived = true;
+            entry.deletedAt = now.toISOString();
+            entry.updatedAt = now.toISOString();
+            await saveMemoryEntry(entry);
+            archivedCount++;
+        }
+    }
+    if (archivedCount > 0) {
+        console.log(`[MemoryDecay] Archived ${archivedCount} low-score memories for ${characterId}`);
+    }
+    return archivedCount;
+}
+
+/** Restore a soft-archived entry back to active pool. */
+export async function restoreMemory(entry: MemoryEntry): Promise<void> {
+    entry.archived = false;
+    entry.deletedAt = undefined;
+    entry.updatedAt = new Date().toISOString();
+    await saveMemoryEntry(entry);
+}
+
+// ── Touch + time ripple ──
+
+/**
+ * Mark entries as recalled: bump activation_count + last_active, then apply
+ * the OB time ripple — neighbors created within ±48h of a touched entry get
+ * activation_count +0.3 (up to 5 neighbors per touched entry).
+ * `pool` must contain the full candidate pool the touched entries came from
+ * (used to locate neighbors without re-reading the DB).
+ */
+export async function touchMemories(touched: MemoryEntry[], pool: MemoryEntry[]): Promise<void> {
+    if (touched.length === 0) return;
+    const now = new Date().toISOString();
+    const dirty = new Map<string, MemoryEntry>();
+
+    for (const entry of touched) {
+        entry.activationCount = (entry.activationCount ?? 0) + 1;
+        entry.lastActive = now;
+        dirty.set(entry.id, entry);
+    }
+
+    const touchedIds = new Set(touched.map(e => e.id));
+    for (const entry of touched) {
+        const center = new Date(entry.createdAt).getTime();
+        const windowMs = RIPPLE_WINDOW_HOURS * 3600 * 1000;
+        const neighbors = pool
+            .filter(p =>
+                !touchedIds.has(p.id) &&
+                !p.archived &&
+                Math.abs(new Date(p.createdAt).getTime() - center) <= windowMs)
+            .sort((a, b) =>
+                Math.abs(new Date(a.createdAt).getTime() - center) -
+                Math.abs(new Date(b.createdAt).getTime() - center))
+            .slice(0, RIPPLE_MAX_NEIGHBORS);
+        for (const n of neighbors) {
+            n.activationCount = (n.activationCount ?? 0) + RIPPLE_INCREMENT;
+            dirty.set(n.id, n);
+        }
+    }
+
+    for (const entry of dirty.values()) {
+        await saveMemoryEntry(entry);
+    }
+}
+
+// ── Write admission gate ──
+
+export type AdmissionVerdict = {
+    admitted: boolean;
+    reason?: string;
+    /** highest duplicate ratio found (0-1) */
+    dupRatio?: number;
+};
+
+/**
+ * OB write_admission port: auto (background) writes are checked for
+ * duplication against existing memories; manual/forced writes pass through.
+ * "Wait for recurrence" state from OB is simplified to plain rejection —
+ * the summarization pipeline will naturally re-produce recurring content.
+ */
+export function checkWriteAdmission(
+    candidate: string,
+    existing: MemoryEntry[],
+    config: MemoryConfig,
+    auto: boolean,
+): AdmissionVerdict {
+    if (!auto || !config.writeAdmissionEnabled) return { admitted: true };
+    if (!candidate.trim()) return { admitted: false, reason: "空内容" };
+
+    let maxRatio = 0;
+    for (const entry of existing) {
+        if (entry.archived) continue;
+        const ratio = keywordOverlapRatio(candidate, entry.content);
+        if (ratio > maxRatio) maxRatio = ratio;
+        if (maxRatio >= config.writeAdmissionDupThreshold) {
+            return {
+                admitted: false,
+                reason: `与已有记忆重复率 ${(maxRatio * 100).toFixed(0)}% 超过阈值`,
+                dupRatio: maxRatio,
+            };
+        }
+    }
+    return { admitted: true, dupRatio: maxRatio };
+}

--- a/lib/memory-scoring.ts
+++ b/lib/memory-scoring.ts
@@ -1,0 +1,156 @@
+// lib/memory-scoring.ts
+// 7-dimension weighted memory scoring engine (Ombre Brain "breath" port).
+// Dimensions: topic / emotion / time / importance / touch / semantic / bm25.
+// Each dimension is normalized to 0-1, weighted, summed, then normalized to 0-100.
+
+import type { MemoryEntry, MemoryScoringWeights } from "./memory-types";
+import {
+    DEFAULT_SCORING_WEIGHTS,
+    LITERAL_HIT_BONUS,
+    RESOLVED_DEMOTE_FACTOR,
+    SEMANTIC_THRESHOLD,
+    TIME_DECAY_RATE,
+    TOUCH_NORMALIZE_CAP,
+} from "./memory-types";
+import { buildBm25Index, scoreBm25, normalizeBm25Scores, tokenizeForBm25 } from "./memory-bm25";
+import { cosineSimilarity } from "./memory-embedding";
+
+export type ScoredMemory = {
+    entry: MemoryEntry;
+    /** final score 0-100 (after resolved demotion & literal bonus) */
+    score: number;
+    /** literal query hit → force recall regardless of budget cutoff position */
+    literalHit: boolean;
+};
+
+export type ScoringContext = {
+    query: string;
+    queryEmbedding?: number[] | null;
+    queryValence?: number;
+    queryArousal?: number;
+    weights?: Partial<MemoryScoringWeights>;
+    now?: Date;
+};
+
+// ── topic: fuzzy match over name-ish fields + body ──
+// rapidfuzz.partial_ratio approximation: token-overlap ratio between query
+// tokens and entry tokens, with substring containment counted as full match.
+
+function topicScore(queryTokens: string[], queryRaw: string, entry: MemoryEntry): number {
+    const haystack = [
+        entry.content,
+        ...(entry.tags ?? []),
+        ...(entry.domain ?? []),
+        ...(entry.meaning ?? []),
+    ].join(" ").toLowerCase();
+    if (!haystack) return 0;
+    // full substring containment → strong signal
+    if (queryRaw.length >= 2 && haystack.includes(queryRaw)) return 1;
+    if (queryTokens.length === 0) return 0;
+    const entryTokens = new Set(tokenizeForBm25(haystack));
+    let matched = 0;
+    for (const qt of queryTokens) {
+        if (entryTokens.has(qt)) matched++;
+    }
+    return matched / queryTokens.length;
+}
+
+// ── emotion: 1 - euclidean distance in (valence, arousal) space ──
+// Max possible distance in unit square is √2; normalize by it.
+
+function emotionScore(qv: number, qa: number, entry: MemoryEntry): number {
+    const ev = typeof entry.valence === "number" ? entry.valence : 0.5;
+    const ea = typeof entry.arousal === "number" ? entry.arousal : 0.5;
+    const dist = Math.sqrt((qv - ev) ** 2 + (qa - ea) ** 2);
+    return Math.max(0, 1 - dist / Math.SQRT2);
+}
+
+// ── time: e^(-0.02 × days since last_active) ──
+
+function timeScore(entry: MemoryEntry, now: Date): number {
+    const ref = entry.lastActive || entry.updatedAt || entry.createdAt;
+    const days = Math.max(0, (now.getTime() - new Date(ref).getTime()) / 86400000);
+    return Math.exp(-TIME_DECAY_RATE * days);
+}
+
+// ── importance: stored 0-1 in this project (OB uses 1-10; we keep 0-1) ──
+
+function importanceScore(entry: MemoryEntry): number {
+    if (entry.pinned || entry.protected) return 1;
+    return Math.min(1, Math.max(0, entry.importance));
+}
+
+// ── touch: activation_count normalized, capped ──
+
+function touchScore(entry: MemoryEntry): number {
+    const count = entry.activationCount ?? 0;
+    return Math.min(1, count / TOUCH_NORMALIZE_CAP);
+}
+
+// ── semantic: cosine similarity, gated by threshold ──
+
+function semanticScore(queryEmbedding: number[] | null | undefined, entry: MemoryEntry): number {
+    if (!queryEmbedding || !entry.embedding || entry.embedding.length === 0) return 0;
+    const sim = cosineSimilarity(queryEmbedding, entry.embedding);
+    return sim >= SEMANTIC_THRESHOLD ? sim : 0;
+}
+
+// ── literal hit: raw query string appears verbatim in searchable fields ──
+
+function isLiteralHit(queryRaw: string, entry: MemoryEntry): boolean {
+    if (queryRaw.length < 2) return false;
+    const fields = [
+        entry.content,
+        ...(entry.tags ?? []),
+        ...(entry.domain ?? []),
+    ];
+    return fields.some(f => f.toLowerCase().includes(queryRaw));
+}
+
+/**
+ * Score a batch of memories against a query context.
+ * Returns entries sorted by final score (desc). Does not mutate entries.
+ * Weight dimensions with missing data (no embedding, no emotion on query)
+ * contribute 0 and their weight still counts in the normalizer — same as OB,
+ * which keeps scores comparable across queries.
+ */
+export function scoreMemories(entries: MemoryEntry[], ctx: ScoringContext): ScoredMemory[] {
+    if (entries.length === 0) return [];
+    const now = ctx.now ?? new Date();
+    const w: MemoryScoringWeights = { ...DEFAULT_SCORING_WEIGHTS, ...ctx.weights };
+    const queryRaw = ctx.query.trim().toLowerCase();
+    const queryTokens = [...new Set(tokenizeForBm25(queryRaw))];
+    const qv = ctx.queryValence ?? 0.5;
+    const qa = ctx.queryArousal ?? 0.5;
+    const hasQueryEmotion = ctx.queryValence !== undefined || ctx.queryArousal !== undefined;
+
+    // BM25 over the whole batch (index built per call; batches are ≤ a few
+    // hundred entries so this stays well under a millisecond budget)
+    const bm25Raw = scoreBm25(buildBm25Index(entries.map(e => e.content)), queryRaw);
+    const bm25Norm = normalizeBm25Scores(bm25Raw);
+
+    const totalWeight =
+        w.topic + w.emotion + w.time + w.importance + w.touch + w.semantic + w.bm25;
+
+    const results: ScoredMemory[] = entries.map((entry, i) => {
+        const weighted =
+            w.topic * topicScore(queryTokens, queryRaw, entry) +
+            w.emotion * (hasQueryEmotion ? emotionScore(qv, qa, entry) : 0) +
+            w.time * timeScore(entry, now) +
+            w.importance * importanceScore(entry) +
+            w.touch * touchScore(entry) +
+            w.semantic * semanticScore(ctx.queryEmbedding, entry) +
+            w.bm25 * bm25Norm[i];
+
+        let score = (weighted / totalWeight) * 100;
+
+        const literalHit = isLiteralHit(queryRaw, entry);
+        if (literalHit) score += LITERAL_HIT_BONUS;
+        if (entry.resolved) score *= RESOLVED_DEMOTE_FACTOR;
+
+        return { entry, score, literalHit };
+    });
+
+    results.sort((a, b) => b.score - a.score);
+    return results;
+}

--- a/lib/memory-service.ts
+++ b/lib/memory-service.ts
@@ -1,63 +1,68 @@
 // lib/memory-service.ts
 // High-level memory orchestration: retrieve long-term memories for prompt injection.
+// Retrieval core is the Ombre Brain 7-dimension scoring engine (memory-scoring.ts)
+// with lazy decay + touch/ripple lifecycle (memory-lifecycle.ts).
+// Public function signatures are unchanged from v1 — callers need no changes.
 
 import type { MemoryConfig, MemoryEntry } from "./memory-types";
 import { loadMemoryEntriesByType } from "./memory-storage";
 import { resolveAuxiliaryApiConfig } from "./settings-storage";
-import { generateEmbedding, resolveEmbeddingModel, cosineSimilarity } from "./memory-embedding";
+import { generateEmbedding, resolveEmbeddingModel } from "./memory-embedding";
 import { estimateTokens } from "./token-counter";
+import { scoreMemories, type ScoredMemory } from "./memory-scoring";
+import { maybeRunDecay, touchMemories } from "./memory-lifecycle";
 
 /**
  * Retrieve relevant long-term memories for prompt injection.
  * Strategy:
- *   1. Total tokens <= longTermTokenBudget → return all
- *   2. Over budget + embedding API configured → vector-rank, fill until budget
- *   3. Over budget + no embedding → time-sorted (newest first), fill until budget
+ *   1. Lazy decay sweep (throttled, archives low-retention entries)
+ *   2. Active pool fits budget → return all (still touch them)
+ *   3. Over budget → 7-dim OB scoring (topic/emotion/time/importance/touch/
+ *      semantic/bm25), literal hits force-recalled, fill until token budget
  * Embedding API is resolved from auxiliary binding (global, not per-character).
+ * Missing embedding config degrades gracefully: semantic dim scores 0,
+ * the other 6 dims still rank meaningfully.
  */
 export async function retrieveMemoriesForPrompt(
     characterId: string,
     currentContext: string,
     config: MemoryConfig
 ): Promise<MemoryEntry[]> {
-    const longTermEntries = await loadMemoryEntriesByType(characterId, "long_term");
-    if (longTermEntries.length === 0 || !currentContext.trim()) return [];
+    await maybeRunDecay(characterId);
+
+    const allEntries = await loadMemoryEntriesByType(characterId, "long_term");
+    const pool = allEntries.filter(e => !e.archived && !e.dontSurface);
+    if (pool.length === 0 || !currentContext.trim()) return [];
 
     const budget = config.longTermTokenBudget;
 
-    // Calculate total tokens for all entries
+    // All fit within budget → return all
     let totalTokens = 0;
-    for (const entry of longTermEntries) {
+    for (const entry of pool) {
         totalTokens += estimateTokens(entry.content) + 4;
     }
-
-    // Strategy 1: all fit within budget → return all
     if (totalTokens <= budget) {
-        return longTermEntries;
+        void touchMemories(pool, allEntries);
+        return sortByCreated(pool);
     }
 
-    // Strategy 2: vector recall enabled + embedding API configured → vector search, fill by relevance
+    // Over budget → OB 7-dimension scoring
+    let queryEmbedding: number[] | null = null;
     const embeddingApiConfig = config.vectorRecallEnabled ? resolveAuxiliaryApiConfig("embeddingApiConfigId") : null;
     if (embeddingApiConfig && resolveEmbeddingModel(embeddingApiConfig)) {
-        const queryEmbedding = await generateEmbedding(currentContext, embeddingApiConfig);
-        if (queryEmbedding) {
-            const withEmbeddings = longTermEntries.filter(m => m.embedding && m.embedding.length > 0);
-            if (withEmbeddings.length > 0) {
-                const scored = withEmbeddings.map(entry => ({
-                    entry,
-                    score: cosineSimilarity(queryEmbedding, entry.embedding!),
-                }));
-                scored.sort((a, b) => b.score - a.score);
-                return fillByBudget(scored.map(s => s.entry), budget);
-            }
-        }
+        try {
+            queryEmbedding = await generateEmbedding(currentContext, embeddingApiConfig);
+        } catch { /* semantic dim degrades to 0 */ }
     }
 
-    // Strategy 3: no embedding support → newest first, fill by budget
-    const sorted = [...longTermEntries].sort(
-        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    );
-    return fillByBudget(sorted, budget);
+    const scored = scoreMemories(pool, {
+        query: currentContext,
+        queryEmbedding,
+    });
+
+    const selected = fillByBudgetScored(scored, budget);
+    void touchMemories(selected, allEntries);
+    return sortByCreated(selected);
 }
 
 export async function retrieveCoreMemoriesForPrompt(
@@ -65,9 +70,14 @@ export async function retrieveCoreMemoriesForPrompt(
     config: MemoryConfig,
 ): Promise<MemoryEntry[]> {
     const coreEntries = await loadMemoryEntriesByType(characterId, "core");
-    if (coreEntries.length === 0) return [];
+    const pool = coreEntries.filter(e => !e.archived);
+    if (pool.length === 0) return [];
 
-    const sorted = [...coreEntries].sort((a, b) => {
+    const sorted = [...pool].sort((a, b) => {
+        // pinned first, then active flag, then event date
+        const aPin = a.pinned || a.protected ? 1 : 0;
+        const bPin = b.pinned || b.protected ? 1 : 0;
+        if (aPin !== bPin) return bPin - aPin;
         const aActive = a.metadata?.active ? 1 : 0;
         const bActive = b.metadata?.active ? 1 : 0;
         if (aActive !== bActive) return bActive - aActive;
@@ -77,6 +87,24 @@ export async function retrieveCoreMemoriesForPrompt(
     });
 
     return fillByBudget(sorted, config.coreMemoryTokenBudget);
+}
+
+/** Chronological order for prompt injection (scoring picks WHAT, time orders HOW). */
+function sortByCreated(entries: MemoryEntry[]): MemoryEntry[] {
+    return [...entries].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+}
+
+/**
+ * Fill scored entries until token budget is exhausted.
+ * OB rule: literal hits are force-recalled — they are placed first so budget
+ * cutoff cannot drop them.
+ */
+function fillByBudgetScored(scored: ScoredMemory[], budget: number): MemoryEntry[] {
+    const literalFirst = [
+        ...scored.filter(s => s.literalHit),
+        ...scored.filter(s => !s.literalHit),
+    ];
+    return fillByBudget(literalFirst.map(s => s.entry), budget);
 }
 
 /** Pick entries in order until token budget is exhausted. */

--- a/lib/memory-summarizer.ts
+++ b/lib/memory-summarizer.ts
@@ -8,7 +8,6 @@ import {
     loadMemoryConfig,
     loadMemoryEntries,
     saveMemoryEntry,
-    deleteMemoryEntries,
     getEventCounter,
     resetEventCounter,
     getLastSummarizedTimestamp,
@@ -20,6 +19,46 @@ import { loadNativeTimeline, formatTimelineForSummarization } from "./short-term
 import { generateEmbedding, resolveEmbeddingModel } from "./memory-embedding";
 import { simpleLLMCall } from "./api-helpers";
 import { maybeRunCoreMemoryPipeline } from "./core-memory-builder";
+import { checkWriteAdmission } from "./memory-lifecycle";
+
+/**
+ * Parse the optional trailing [META] line produced by the summarization
+ * prompt: valence / arousal / importance / tags. Returns cleaned summary
+ * (META line stripped) + parsed fields; malformed values fall back to
+ * defaults so old prompts and non-compliant models keep working.
+ */
+function parseSummaryMeta(text: string): {
+    summary: string;
+    valence: number;
+    arousal: number;
+    importance: number;
+    tags: string[];
+} {
+    const fallback = { valence: 0.5, arousal: 0.5, importance: 0.8, tags: [] as string[] };
+    const metaMatch = text.match(/^\s*\[META\][^\n]*$/im);
+    if (!metaMatch) return { summary: text.trim(), ...fallback };
+
+    const metaLine = metaMatch[0];
+    const summary = text.replace(metaLine, "").trim();
+    const num = (key: string, def: number): number => {
+        const m = metaLine.match(new RegExp(`${key}\\s*=\\s*([0-9.]+)`, "i"));
+        if (!m) return def;
+        const v = parseFloat(m[1]);
+        return Number.isFinite(v) ? Math.min(1, Math.max(0, v)) : def;
+    };
+    const tagsMatch = metaLine.match(/tags\s*=\s*([^\s].*?)\s*$/i);
+    const tags = tagsMatch
+        ? tagsMatch[1].split(/[,，、]/).map(t => t.trim()).filter(Boolean).slice(0, 64)
+        : [];
+
+    return {
+        summary: summary || text.trim(),
+        valence: num("valence", fallback.valence),
+        arousal: num("arousal", fallback.arousal),
+        importance: num("importance", fallback.importance),
+        tags,
+    };
+}
 
 /** Per-character lock to prevent concurrent summarization. */
 const summarizingSet = new Set<string>();
@@ -111,7 +150,19 @@ export async function runSummarizationPipeline(
         return { success: false, error: "记忆总结结果疑似被截断，已取消入库，请稍后重试或提高模型输出上限" };
     }
 
-    const summary = result.content;
+    const meta = parseSummaryMeta(result.content);
+    const summary = meta.summary;
+
+    // OB write admission gate: reject near-duplicate auto writes
+    const existingLongTerm = (await loadMemoryEntries(characterId)).filter(e => e.type === "long_term");
+    const verdict = checkWriteAdmission(summary, existingLongTerm, config, !options?.force);
+    if (!verdict.admitted) {
+        // Advance watermark & counter anyway so the same span isn't retried forever
+        setLastSummarizedTimestamp(characterId, latest);
+        resetEventCounter(characterId);
+        console.log(`[MemorySummarizer] Write rejected by admission gate: ${verdict.reason}`);
+        return { success: false, error: `写入门卫拒绝：${verdict.reason}` };
+    }
 
     // Generate embedding for the summary (only if vector recall is enabled)
     let embedding: number[] | undefined;
@@ -148,7 +199,12 @@ export async function runSummarizationPipeline(
         type: "long_term",
         content: summary,
         embedding,
-        importance: 0.8,
+        importance: meta.importance,
+        valence: meta.valence,
+        arousal: meta.arousal,
+        tags: meta.tags,
+        lastActive: now,
+        activationCount: 0,
         createdAt: now,
         updatedAt: now,
         metadata: {
@@ -163,11 +219,20 @@ export async function runSummarizationPipeline(
     setLastSummarizedTimestamp(characterId, latest);
     resetEventCounter(characterId);
 
-    // Enforce long-term limit
-    const allLongTerm = await loadMemoryEntries(characterId);
+    // Enforce long-term limit: soft-archive oldest (OB-style), never touch pinned
+    const allLongTerm = (await loadMemoryEntries(characterId))
+        .filter(e => e.type === "long_term" && !e.archived);
     if (allLongTerm.length > config.maxLongTermEntries) {
-        const excess = allLongTerm.slice(0, allLongTerm.length - config.maxLongTermEntries);
-        await deleteMemoryEntries(excess.map(e => e.id));
+        const excess = allLongTerm
+            .filter(e => !e.pinned && !e.protected)
+            .slice(0, allLongTerm.length - config.maxLongTermEntries);
+        const archiveTs = new Date().toISOString();
+        for (const e of excess) {
+            e.archived = true;
+            e.deletedAt = archiveTs;
+            e.updatedAt = archiveTs;
+            await saveMemoryEntry(e);
+        }
     }
 
     incrementCoreMemoryCounter(characterId);

--- a/lib/memory-types.ts
+++ b/lib/memory-types.ts
@@ -14,7 +14,60 @@ export type MemoryEntry = {
     updatedAt: string;
     sourceMessageIds?: string[];
     metadata?: Record<string, unknown>;
+
+    // ── Ombre Brain 扩展元数据（全部可选，旧数据缺省时按默认值处理）──
+    tags?: string[];             // 标签（≤64 个，每个 ≤128 字符）
+    domain?: string[];           // 主题域（≤16 个）
+    valence?: number;            // 情感效价 0-1（消极→积极），默认 0.5
+    arousal?: number;            // 情感唤醒 0-1（平静→激动），默认 0.5
+    lastActive?: string;         // 最后激活时间（ISO），缺省取 updatedAt
+    activationCount?: number;    // 被召回次数（影响衰减与 touch 评分）
+    pinned?: boolean;            // 钉选：不参与衰减归档
+    protected?: boolean;         // 保护：同 pinned，importance 视为满值
+    resolved?: boolean;          // 已放下：排序降权 ×0.3，关键词命中仍可召回
+    digested?: boolean;          // 已消化：加速淡化
+    dontSurface?: boolean;       // 不再主动浮现（可被显式搜索）
+    archived?: boolean;          // 已归档（软删除，不参与常规检索）
+    deletedAt?: string;          // 软删除时间（ISO）
+    whyRemembered?: string;      // 为什么记得（自由文本，≤500 字符）
+    meaning?: string[];          // 意义列表（≤50 条）
 };
+
+/** Ombre Brain 评分维度权重（breath 检索核心） */
+export type MemoryScoringWeights = {
+    topic: number;       // 主题相关（模糊匹配）
+    emotion: number;     // 情感共振（valence/arousal 欧氏距离）
+    time: number;        // 时间近度（指数衰减）
+    importance: number;  // 重要度
+    touch: number;       // 召回频率
+    semantic: number;    // 语义相似（embedding 余弦）
+    bm25: number;        // 关键词匹配（BM25）
+};
+
+export const DEFAULT_SCORING_WEIGHTS: MemoryScoringWeights = {
+    topic: 4.0,
+    emotion: 2.0,
+    time: 1.5,
+    importance: 1.0,
+    touch: 1.0,
+    semantic: 2.5,
+    bm25: 1.5,
+};
+
+/** 字面命中（查询串原样出现）→ 排序加分并强制召回 */
+export const LITERAL_HIT_BONUS = 25;
+/** resolved 桶排序降权系数 */
+export const RESOLVED_DEMOTE_FACTOR = 0.3;
+/** semantic 维度生效的余弦相似度阈值 */
+export const SEMANTIC_THRESHOLD = 0.65;
+/** 时间近度衰减系数：e^(-0.02 × days) */
+export const TIME_DECAY_RATE = 0.02;
+/** 时间涟漪：touch 后 ±48h 邻居 activation_count 增量与上限 */
+export const RIPPLE_WINDOW_HOURS = 48;
+export const RIPPLE_INCREMENT = 0.3;
+export const RIPPLE_MAX_NEIGHBORS = 5;
+/** touch 评分归一化上限（召回次数） */
+export const TOUCH_NORMALIZE_CAP = 10;
 
 export type MemoryConfig = {
     autoSummarizeEnabled: boolean;          // whether auto-summarization runs after N events
@@ -29,6 +82,10 @@ export type MemoryConfig = {
     summarizationPrompt: string;            // user-editable prompt template for memory summarization
     coreMemoryPrompt: string;               // user-editable prompt template for core-memory extraction
     vnSummaryPrompt: string;                // user-editable prompt for VN chapter summarization
+    decayEnabled: boolean;                  // OB 衰减引擎：低分记忆自动归档（软删除）
+    decayArchiveThreshold: number;          // 衰减得分低于该值移入归档（0-1）
+    writeAdmissionEnabled: boolean;         // OB 写入门卫：自动写入前做重复率检测
+    writeAdmissionDupThreshold: number;     // 重复率超过该值拒绝写入（0-1）
 };
 
 export type MemorySearchResult = {
@@ -55,6 +112,8 @@ export const DEFAULT_SUMMARIZATION_PROMPT = `你是一个记忆整理助手。�
 - 保留朋友圈等非聊天事件中的关键信息
 - 100-200字
 - 不要包含格式标记
+- 在总结正文之后，另起一行输出一行元数据（仅此一行允许格式）：
+[META] valence=0到1的情感效价 arousal=0到1的情感唤醒 importance=0到1的重要度 tags=逗号分隔的3-6个中文标签
 
 总结：`;
 
@@ -101,4 +160,8 @@ export const DEFAULT_MEMORY_CONFIG: MemoryConfig = {
     summarizationPrompt: DEFAULT_SUMMARIZATION_PROMPT,
     coreMemoryPrompt: DEFAULT_CORE_MEMORY_PROMPT,
     vnSummaryPrompt: "",
+    decayEnabled: true,
+    decayArchiveThreshold: 0.15,
+    writeAdmissionEnabled: true,
+    writeAdmissionDupThreshold: 0.85,
 };


### PR DESCRIPTION
- memory-types: MemoryEntry 扩展 OB 元数据（valence/arousal/tags/pinned/resolved/activationCount/archived 等，全部可选向后兼容）；新增评分权重与常量；总结提示词要求输出 [META] 行
- memory-bm25 (新): 完整 Okapi BM25 + 中文 unigram+bigram 分词
- memory-scoring (新): 7 维加权评分（topic/emotion/time/importance/touch/semantic/bm25），字面命中 +25 强制召回，resolved ×0.3 降权
- memory-lifecycle (新): 惰性衰减引擎（低分软归档，pinned 豁免，6h 节流）、touch + ±48h 时间涟漪、写入门卫（重复率检测）
- memory-service: 检索核心替换为 OB 评分，函数签名不变，无 embedding 时优雅降级
- memory-summarizer: 解析 META 元数据入库，接入写入门卫，超量改软归档且豁免 pinned