### PR TITLE
feat(chat): 聊天输入框新增表情包搜索联想组件

### DIFF
--- a/components/chat/chat-room.tsx
+++ b/components/chat/chat-room.tsx
@@ -10,6 +10,7 @@ import { translateReasoningText } from "@/lib/reasoning-translate";
 import { MessageBubble, MediaDetailModal, prewarmStickerCache, BilingualTextBlock, isStandaloneHtmlPreviewContent, normalizeTextBubbleContent } from "./message-bubble";
 import { PhotoInputModal, TextPhotoModal, VoiceRecordModal, RedPacketModal, LocationInputModal, SystemInstructionModal } from "./rich-input-modals";
 import { EmojiPanel, StickerPanel } from "./emoji-panel";
+import { StickerSearchSuggest } from "./sticker-search-suggest";
 import { StateValuesPanel } from "./state-values-panel";
 import { generateChatCompletion, generateOfflineChatCompletion, flattenCompletionResult, ChatEngineError } from "@/lib/chat-engine";
 import { sendBrowserNotification } from "@/lib/browser-notification";
@@ -652,6 +653,8 @@ const ChatTextInputBar = memo(forwardRef<ChatTextInputHandle, {
 }, ref) {
     const [inputText, setInputText] = useState("");
     const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+    // 表情包搜索联想：ESC/失焦置 true 隐藏，输入变化重新开启
+    const [suggestClosed, setSuggestClosed] = useState(false);
     // 围观群/被禁言：输入与富媒体入口全部锁定，只留线下切换和生成按钮
     const [muteNowTick, setMuteNowTick] = useState(() => Date.now());
     useEffect(() => {
@@ -700,6 +703,11 @@ const ChatTextInputBar = memo(forwardRef<ChatTextInputHandle, {
     };
 
     const panelOpen = showEmojiPanel || showStickerPanel || showPlusMenu;
+    const suggestCharacterIds = useMemo(
+        () => (isGroup ? (stickerCharacterIds || []) : characterId ? [characterId] : []),
+        [isGroup, stickerCharacterIds, characterId],
+    );
+    const suggestEnabled = !inputLocked && !panelOpen && !suggestClosed && inputText.trim().length > 0;
     const plusMenuItems = [
         { icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--c-text)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2" /><circle cx="8.5" cy="8.5" r="1.5" /><polyline points="21 15 16 10 5 21" /></svg>, label: "照片墙", onClick: () => onOpenRichModal("photo") },
         { icon: <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--c-text)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2" /><line x1="7" y1="8" x2="17" y2="8" /><line x1="7" y1="12" x2="14" y2="12" /><line x1="7" y1="16" x2="11" y2="16" /></svg>, label: "文字图片", onClick: () => onOpenRichModal("text_photo") },
@@ -749,12 +757,21 @@ const ChatTextInputBar = memo(forwardRef<ChatTextInputHandle, {
                 </div>
             )}
 
+            {suggestEnabled && (
+                <StickerSearchSuggest
+                    query={inputText}
+                    characterIds={suggestCharacterIds}
+                    onSend={(name, url) => onSendSticker(name, url)}
+                    onClose={() => setSuggestClosed(true)}
+                />
+            )}
             <textarea
                 ref={textareaRef}
                 rows={1}
                 value={inputText}
                 onChange={e => {
                     setInputText(e.target.value);
+                    setSuggestClosed(false);
                     e.target.style.height = "auto";
                     e.target.style.height = Math.min(e.target.scrollHeight, 120) + "px";
                 }}
@@ -765,8 +782,14 @@ const ChatTextInputBar = memo(forwardRef<ChatTextInputHandle, {
                         const target = e.target as HTMLTextAreaElement;
                         requestAnimationFrame(() => requestAnimationFrame(() => target.focus()));
                     }
+                    setSuggestClosed(false);
                 }}
+                onBlur={() => setSuggestClosed(true)}
                 onKeyDown={e => {
+                    if (e.key === "Escape") {
+                        setSuggestClosed(true);
+                        return;
+                    }
                     if (shouldSendChatInputOnEnter(e, enterToSendEnabled)) {
                         e.preventDefault();
                         handleSubmit();

--- a/components/chat/sticker-search-suggest.tsx
+++ b/components/chat/sticker-search-suggest.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+// 表情包搜索联想：输入时按名称模糊匹配本地表情包，横向列表浮在输入框正上方，
+// 点击直接发送（复用 onSendSticker 的 sticker 消息通道）。
+// 数据源 = 内置表情包（sticker-data，emoji 兜底）+ 当前会话角色绑定的自定义贴纸包（IndexedDB 解析出 url）。
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { STICKER_PACKS } from "@/lib/sticker-data";
+import { loadStickerPacksForCharacters, resolvePackStickerMap } from "@/lib/custom-sticker-storage";
+
+export type StickerSearchItem = {
+  key: string;
+  name: string;
+  /** 自定义贴纸解析出的图片地址（dataUrl / externalUrl） */
+  url?: string;
+  /** 内置表情的 emoji 兜底显示 */
+  emoji?: string;
+};
+
+type StickerSearchSuggestProps = {
+  /** 当前输入框的原始文本 */
+  query: string;
+  /** 会话相关的角色 id（单聊=[contactId]，群聊=participantIds） */
+  characterIds: string[];
+  /** 发送：与 ChatTextInputBar 的 onSendSticker 一致（name, url?） */
+  onSend: (name: string, url?: string) => void;
+  /** 关闭联想（发送后 / ESC / 失焦由父组件控制，这里只负责发送后收起） */
+  onClose: () => void;
+};
+
+const DEBOUNCE_MS = 300;
+const MAX_RESULTS = 12;
+
+export function StickerSearchSuggest({ query, characterIds, onSend, onClose }: StickerSearchSuggestProps) {
+  // ── 防抖：输入停止 300ms 后再匹配 ──
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDebouncedQuery(query.trim()), DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [query]);
+
+  // ── 加载自定义贴纸（按会话角色绑定的包），解析出 name → url ──
+  const [customItems, setCustomItems] = useState<StickerSearchItem[]>([]);
+  const loadSeqRef = useRef(0);
+  useEffect(() => {
+    const seq = ++loadSeqRef.current;
+    let cancelled = false;
+    (async () => {
+      const packs = loadStickerPacksForCharacters(characterIds).filter((pack) => pack.stickers.length > 0);
+      const urlByName: Record<string, string> = {};
+      for (const pack of packs) {
+        const map = await resolvePackStickerMap(pack);
+        for (const [name, url] of Object.entries(map)) {
+          if (url) urlByName[name] = url;
+        }
+      }
+      if (cancelled) return;
+      const items: StickerSearchItem[] = [];
+      for (const pack of packs) {
+        for (const sticker of pack.stickers) {
+          items.push({ key: `custom:${pack.id}:${sticker.id}`, name: sticker.name, url: urlByName[sticker.name] });
+        }
+      }
+      setCustomItems(items);
+    })();
+    return () => {
+      cancelled = true;
+      // 只清理最后一次加载，避免竞态时旧结果覆盖新结果
+      if (loadSeqRef.current === seq) setCustomItems([]);
+    };
+  }, [characterIds]);
+
+  // ── 内置表情包（emoji 兜底） ──
+  const builtinItems = useMemo<StickerSearchItem[]>(
+    () =>
+      STICKER_PACKS.flatMap((pack) =>
+        pack.stickers.map((sticker) => ({ key: `builtin:${sticker.name}`, name: sticker.name, emoji: sticker.emoji })),
+      ),
+    [],
+  );
+
+  // ── 模糊匹配 + 排序（前缀优先，再包含；同名去重，自定义优先） ──
+  const results = useMemo(() => {
+    const q = debouncedQuery.toLowerCase();
+    if (!q) return [];
+    const rank = (name: string): number => {
+      const n = name.toLowerCase();
+      if (n === q) return 0;
+      if (n.startsWith(q)) return 1;
+      if (n.includes(q)) return 2;
+      return -1;
+    };
+    const scored = [...customItems, ...builtinItems]
+      .map((item) => ({ item, rank: rank(item.name) }))
+      .filter((entry) => entry.rank >= 0)
+      .sort((a, b) => a.rank - b.rank || a.item.name.length - b.item.name.length);
+    const seen = new Set<string>();
+    const out: StickerSearchItem[] = [];
+    for (const { item } of scored) {
+      if (seen.has(item.name)) continue;
+      seen.add(item.name);
+      out.push(item);
+      if (out.length >= MAX_RESULTS) break;
+    }
+    return out;
+  }, [debouncedQuery, builtinItems, customItems]);
+
+  if (!debouncedQuery || results.length === 0) return null;
+
+  return (
+    <div
+      className="sticker-search-suggest"
+      style={{ position: "absolute", left: 0, right: 0, bottom: "100%", zIndex: 60, marginBottom: 6 }}
+      // 阻止 mousedown 默认行为：点击列表项时不触发 textarea 失焦，避免列表在 click 前被 blur 关掉
+      onMouseDown={(event) => event.preventDefault()}
+    >
+      <div
+        className="flex items-stretch gap-1.5 overflow-x-auto px-2.5 py-2 rounded-2xl hide-scrollbar"
+        style={{
+          background: "color-mix(in srgb, var(--c-card) 96%, transparent)",
+          border: "1px solid var(--c-card-border)",
+          boxShadow: "0 8px 28px rgba(0,0,0,0.12)",
+          backdropFilter: "blur(16px)",
+          WebkitBackdropFilter: "blur(16px)",
+          maxWidth: "100%",
+        }}
+      >
+        {results.map((item) => (
+          <button
+            key={item.key}
+            type="button"
+            onClick={() => {
+              onSend(item.name, item.url);
+              onClose();
+            }}
+            className="shrink-0 flex flex-col items-center gap-1 px-2 py-1.5 rounded-xl bg-transparent border-none cursor-pointer transition-transform active:scale-95"
+            style={{ minWidth: 52 }}
+            title={item.name}
+          >
+            <span className="w-10 h-10 flex items-center justify-center overflow-hidden">
+              {item.url ? (
+                <img src={item.url} alt={item.name} className="w-10 h-10 object-contain" draggable={false} />
+              ) : item.emoji ? (
+                <span className="text-[26px] leading-none">{item.emoji}</span>
+              ) : (
+                <span className="ts-10 text-[var(--c-text)] w-full text-center truncate">{item.name}</span>
+              )}
+            </span>
+            <span className="ts-10 text-[var(--c-text)] opacity-75 max-w-[56px] truncate leading-tight">{item.name}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
贡献者：温铎（@yechen1844）

聊天输入框新增表情包搜索联想组件：

1. 新增 components/chat/sticker-search-suggest.tsx：监听主输入框文本，防抖 300ms 后按名称做模糊匹配（前缀优先、其次包含，同名去重、自定义优先，最多 12 个），结果以横向滚动列表绝对定位浮在输入框正上方（bottom:100%）。数据源 = 内置表情包（sticker-data，emoji 兜底显示）+ 当前会话角色绑定的自定义贴纸包（IndexedDB 解析 url）。点击列表项复用 onSendSticker 发送 sticker 消息，输入框内容保留不清空。
2. 接入 ChatTextInputBar：输入变化重新开启联想；ESC / 输入框失焦自动隐藏（列表项用 onMouseDown preventDefault 避免点击前先失焦）；输入锁定（禁言/围观）或 emoji/表情/+ 面板打开时不触发；单聊用会话角色、群聊用全部群成员角色的表情包。

验证：本地 dev 运行，输入"笑""猫"等关键词可联想并发送内置/自定义表情；ESC 与失焦正确收起。无输入时不渲染，不影响现有聊天流程。

---
_经小手机「共同建设」通道提交_