### PR TITLE
fix(qa-github): 读取 GitHub 文件兼容 raw 响应形态，修复已贡献文件无法读取/编辑的 bug

### DIFF
--- a/lib/qa-github.ts
+++ b/lib/qa-github.ts
@@ -110,7 +110,9 @@ export async function getQaGithubTree(config: QaGithubConfig, signal?: AbortSign
 
 export type QaGithubFile = { path: string; text: string; size: number; truncated: boolean };
 
-/** 读取单个文件内容（base64 解码）。 */
+/** 读取单个文件内容（base64 解码）。
+ *  兼容两种响应形态：标准 contents API（JSON，content 为 base64）与 raw 媒体类型（直接返回源码）。
+ *  一律先按文本收下再尝试解包 JSON，绝不直接 response.json()——否则 raw 源码会被当成 JSON 解析而崩溃。 */
 export async function readQaGithubFile(config: QaGithubConfig, path: string, signal?: AbortSignal): Promise<QaGithubFile> {
     const branch = await resolveBranch(config, signal);
     const cleanPath = path.replace(/^\/+/, "");
@@ -121,17 +123,26 @@ export async function readQaGithubFile(config: QaGithubConfig, path: string, sig
     );
     if (response.status === 404) throw new Error(`文件不存在：${cleanPath}`);
     if (!response.ok) throw new Error(`读取文件失败：HTTP ${response.status}`);
-    const data = (await response.json()) as { content?: string; encoding?: string; size?: number; type?: string };
-    if (data.type !== "file") throw new Error(`${cleanPath} 不是文件（可能是目录）`);
-    let text = "";
-    if (data.encoding === "base64" && typeof data.content === "string") {
-        try {
-            text = decodeURIComponent(escape(atob(data.content.replace(/\n/g, ""))));
-        } catch {
-            text = atob(data.content.replace(/\n/g, ""));
+    const text = await response.text();
+    try {
+        const data = JSON.parse(text) as { content?: string; encoding?: string; size?: number; type?: string };
+        if (data && typeof data === "object" && data.type === "file" && data.encoding === "base64" && typeof data.content === "string") {
+            const binary = atob(data.content.replace(/\n/g, ""));
+            let decoded: string;
+            try {
+                decoded = new TextDecoder("utf-8").decode(Uint8Array.from(binary, (c) => c.charCodeAt(0)));
+            } catch {
+                decoded = binary;
+            }
+            return { path: cleanPath, text: decoded, size: data.size ?? decoded.length, truncated: false };
         }
+        if (data && typeof data === "object" && data.type === "file" && typeof data.content === "string") {
+            return { path: cleanPath, text: data.content, size: data.size ?? data.content.length, truncated: false };
+        }
+    } catch {
+        // 响应不是 JSON（raw 源码 / 代理返回原文）→ 直接作为文件内容返回
     }
-    return { path: cleanPath, text, size: data.size ?? text.length, truncated: false };
+    return { path: cleanPath, text, size: text.length, truncated: false };
 }
 
 export type QaGithubCommitSummary = { sha: string; message: string; author: string; date: string };


### PR DESCRIPTION
贡献者：温铎（@yechen1844）

修复工坊读取 GitHub 文件时 JSON 解析崩溃的 bug——针对此前反馈的「已贡献过 PR 的文件无法读取/编辑」问题。

【关联反馈】此前用户反馈：通过贡献流程提交过 PR 的文件（如 components/chat/chat-room.tsx、lib/mascot-tools.ts、lib/mascot-prompts.ts、components/chat/sticker-search-suggest.tsx），工坊「读取」动作持续报 JSON 解析错误（Unexpected non-whitespace character after JSON / Unexpected token '/'），导致这些文件无法再被读取与编辑（「编辑」动作因依赖「读取」也连带不可用）。刷新会话、清空提交暂存区均无法解决。此 PR 即针对该问题的修复尝试。

【根因】lib/qa-github.ts 的 readQaGithubFile 原先直接 response.json() 解析 GitHub 响应，并假设响应恒为「JSON 且 content 为 base64」的标准 contents API 形态。当 GitHub 对某些请求返回 raw 媒体类型（直接返回源码文本，非 JSON）时，response.json() 把源码当 JSON 解析而抛错——正是反馈中见到的报错。

【修复】改为先 response.text() 统一收下文本，再尝试 JSON.parse：解析成功且为标准 contents API 形态时按 base64 解码（改用 TextDecoder 处理 UTF-8 中文）；解析失败则说明响应是 raw 源码，直接作为文件内容返回。两种形态都能正确读取。

【验证】修复前无法读取的「已贡献文件」现在均可正常读取与编辑（实测 chat-room.tsx 可正常 find/replace 修改并提交）；普通 JSON 形态文件读取行为不变。

---
_经小手机「共同建设」通道提交_