### PR TITLE
feat(小卷): 增加多会话管理功能

### DIFF
--- a/components/chat/mascot-chat-room.tsx
+++ b/components/chat/mascot-chat-room.tsx
@@ -13,15 +13,18 @@ import { SessionCustomCSS } from "@/components/ui/session-custom-css";
 import { CHAT_SESSION_CSS_EXAMPLE } from "@/lib/css-examples";
 import {
     clearMascotToolHistoryMessages,
+    createMascotSession,
     deleteMascotMessageWithLinkedTools,
+    deleteMascotSession,
     getMascotChatSnapshot,
     hasMascotToolHistoryMessages,
     hydrateMascotChat,
-    resetMascotConversation,
+    renameMascotSession,
     sendMascotMessage,
     setMascotMessages,
     stopMascotGeneration,
     subscribeMascotChat,
+    switchMascotSession,
 } from "@/lib/mascot-chat-store";
 import type { MascotMsg } from "@/lib/mascot-engine";
 import { getMascotContext, subscribeMascotContext } from "@/lib/mascot-context";
@@ -139,7 +142,6 @@ function MascotInfoPanel({
     const [personaDraft, setPersonaDraft] = useState(settings.personaPrompt);
     const [editingCSS, setEditingCSS] = useState(false);
     const [cssDraft, setCssDraft] = useState(settings.chatCustomCSS || "");
-    const [showConfirmNewSession, setShowConfirmNewSession] = useState(false);
     const [showConfirmClearTools, setShowConfirmClearTools] = useState(false);
     const [showConfirmDelete, setShowConfirmDelete] = useState(false);
     const chat = useSyncExternalStore(subscribeMascotChat, getMascotChatSnapshot, getMascotChatSnapshot);
@@ -280,13 +282,62 @@ function MascotInfoPanel({
                             </span>
                         </div>
                     </button>
-                    <button className="menu-item" onClick={() => setShowConfirmNewSession(true)}>
-                        <MascotInfoIcon color="var(--c-danger)"><RotateCcw size={22} strokeWidth={1.75} /></MascotInfoIcon>
+                    <button
+                        className="menu-item"
+                        disabled={!chat.hydrated || chat.isThinking}
+                        onClick={() => {
+                            const id = createMascotSession();
+                            if (id) onClose();
+                        }}
+                        style={!chat.hydrated || chat.isThinking ? { opacity: 0.55, cursor: "not-allowed" } : undefined}
+                    >
+                        <MascotInfoIcon color="var(--c-icon-active)"><RotateCcw size={22} strokeWidth={1.75} /></MascotInfoIcon>
                         <div className="menu-label-group">
-                            <span className="menu-label menu-label-danger">新会话</span>
-                            <span className="menu-desc">清空当前 AI助手聊天记录并重新开始</span>
+                            <span className="menu-label">开启新对话</span>
+                            <span className="menu-desc">保留当前记录，创建一段独立对话</span>
                         </div>
                     </button>
+                    {chat.sessions.map((session) => {
+                        const active = session.id === chat.activeSessionId;
+                        return (
+                            <div className="menu-item" key={session.id} style={{ gap: 8 }}>
+                                <MascotInfoIcon color={active ? "var(--c-icon-active)" : "var(--c-text-secondary)"}>
+                                    <MessageSquare size={21} strokeWidth={1.75} />
+                                </MascotInfoIcon>
+                                <button
+                                    type="button"
+                                    className="menu-label-group min-w-0 flex-1 text-left"
+                                    disabled={chat.isThinking || active}
+                                    onClick={() => {
+                                        if (switchMascotSession(session.id)) onClose();
+                                    }}
+                                    style={{ opacity: chat.isThinking ? 0.55 : 1 }}
+                                >
+                                    <span className="menu-label truncate">{session.title}{active ? "（当前）" : ""}</span>
+                                    <span className="menu-desc">{new Date(session.updatedAt).toLocaleString()}</span>
+                                </button>
+                                <button
+                                    type="button"
+                                    className="menu-desc shrink-0"
+                                    disabled={chat.isThinking}
+                                    onClick={() => {
+                                        const title = window.prompt("重命名对话", session.title);
+                                        if (title !== null) renameMascotSession(session.id, title);
+                                    }}
+                                >改名</button>
+                                <button
+                                    type="button"
+                                    className="menu-desc shrink-0 text-[var(--c-danger)]"
+                                    disabled={chat.isThinking}
+                                    onClick={() => {
+                                        if (window.confirm(`确定删除对话“${session.title}”吗？此操作不会删除角色卡，但无法恢复这段聊天记录。`)) {
+                                            deleteMascotSession(session.id);
+                                        }
+                                    }}
+                                >删除</button>
+                            </div>
+                        );
+                    })}
                     <button className="menu-item" onClick={() => setShowConfirmDelete(true)}>
                         <MascotInfoIcon color="var(--c-danger)"><Trash2 size={22} strokeWidth={1.75} /></MascotInfoIcon>
                         <div className="menu-label-group">
@@ -367,22 +418,6 @@ function MascotInfoPanel({
                     </PageShell>
                 </div>
                 </div>
-            )}
-
-            {showConfirmNewSession && (
-                <ConfirmDialog
-                    title="开始新会话？"
-                    message="当前 AI助手聊天记录会被清空，之后从新会话继续。"
-                    icon={AlertCircle}
-                    variant="danger"
-                    confirmLabel="新会话"
-                    cancelLabel="取消"
-                    onConfirm={() => {
-                        resetMascotConversation();
-                        setShowConfirmNewSession(false);
-                    }}
-                    onCancel={() => setShowConfirmNewSession(false)}
-                />
             )}
 
             {showConfirmClearTools && (

--- a/lib/mascot-chat-store.ts
+++ b/lib/mascot-chat-store.ts
@@ -21,23 +21,42 @@ import { isMascotPanelOpen } from "./mascot-state";
 const MASCOT_DB_NAME = "AiPhoneMascotDB";
 const MASCOT_DB_VERSION = 2;
 const MASCOT_CHAT_STORE = "chat";
-const MASCOT_MESSAGES_KEY = "messages";
+const MASCOT_MESSAGES_KEY = "messages"; // 旧版单会话键，仅用于迁移
+const MASCOT_STATE_KEY = "state";
 const MAX_STORED_MASCOT_MESSAGES = 50;
+const MAX_MASCOT_SESSIONS = 30;
 
-type MascotChatSnapshot = {
+export type MascotSession = {
+    id: string;
+    title: string;
+    createdAt: number;
+    updatedAt: number;
     messages: MascotMsg[];
+};
+
+type PersistedMascotState = {
+    sessions: MascotSession[];
+    activeSessionId: string | null;
+};
+
+export type MascotChatSnapshot = {
+    messages: MascotMsg[];
+    sessions: MascotSession[];
+    activeSessionId: string | null;
     hydrated: boolean;
     isThinking: boolean;
 };
 
 const listeners = new Set<() => void>();
 let messages: MascotMsg[] = [];
+let sessions: MascotSession[] = [];
+let activeSessionId: string | null = null;
 let hydrated = false;
 let hydratePromise: Promise<void> | null = null;
 let isThinking = false;
 let abortRequested = false;
 let abortController: AbortController | null = null;
-let snapshot: MascotChatSnapshot = { messages, hydrated, isThinking };
+let snapshot: MascotChatSnapshot = { messages, sessions, activeSessionId, hydrated, isThinking };
 
 function openMascotDb(): IDBOpenDBRequest {
     const request = indexedDB.open(MASCOT_DB_NAME, MASCOT_DB_VERSION);
@@ -50,14 +69,14 @@ function openMascotDb(): IDBOpenDBRequest {
 }
 
 function emit() {
-    snapshot = { messages, hydrated, isThinking };
+    snapshot = { messages, sessions, activeSessionId, hydrated, isThinking };
     for (const listener of listeners) listener();
     if (typeof window !== "undefined") {
         window.dispatchEvent(new CustomEvent("mascot-chat-updated", { detail: snapshot }));
     }
 }
 
-function persistMessages(nextMessages: MascotMsg[]) {
+function persistState() {
     if (typeof indexedDB === "undefined") return;
     try {
         const req = openMascotDb();
@@ -65,7 +84,10 @@ function persistMessages(nextMessages: MascotMsg[]) {
             try {
                 if (!req.result.objectStoreNames.contains(MASCOT_CHAT_STORE)) return;
                 const tx = req.result.transaction(MASCOT_CHAT_STORE, "readwrite");
-                tx.objectStore(MASCOT_CHAT_STORE).put(nextMessages, MASCOT_MESSAGES_KEY);
+                const state: PersistedMascotState = { sessions, activeSessionId };
+                tx.objectStore(MASCOT_CHAT_STORE).put(state, MASCOT_STATE_KEY);
+                tx.oncomplete = () => req.result.close();
+                tx.onerror = () => req.result.close();
             } catch {
                 // Keep in-memory chat usable even if persistence fails.
             }
@@ -242,9 +264,31 @@ export function deleteMascotMessageWithLinkedTools(
     return { messages: messagesAfterDelete, deletedMessages, cleanedMessages };
 }
 
+function makeMascotSessionId(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function autoMascotSessionTitle(text: string): string {
+    const compact = text.replace(/\s+/g, " ").trim();
+    return compact.length > 18 ? `${compact.slice(0, 18)}…` : compact || "新对话";
+}
+
+function getActiveMascotSession(): MascotSession | null {
+    return sessions.find((session) => session.id === activeSessionId) ?? null;
+}
+
 function publishMessages(nextMessages: MascotMsg[], options: { persist?: boolean } = {}) {
     messages = normalizeMessages(nextMessages);
-    if (options.persist !== false) persistMessages(messages);
+    const active = getActiveMascotSession();
+    if (active) {
+        const now = Date.now();
+        sessions = sessions
+            .map((session) => session.id === active.id
+                ? { ...session, messages, updatedAt: now }
+                : session)
+            .sort((a, b) => b.updatedAt - a.updatedAt);
+    }
+    if (options.persist !== false) persistState();
     emit();
 }
 
@@ -267,6 +311,72 @@ export function setMascotMessages(updater: MascotMsg[] | ((prev: MascotMsg[]) =>
     publishMessages(next);
 }
 
+export function createMascotSession(): string | null {
+    if (!hydrated || isThinking) return null;
+    clearExpandedPackages();
+    const now = Date.now();
+    const greeting = defaultGreetingMessage();
+    const session: MascotSession = {
+        id: makeMascotSessionId(),
+        title: "新对话",
+        createdAt: now,
+        updatedAt: now,
+        messages: greeting ? [greeting] : [],
+    };
+    sessions = [session, ...sessions].slice(0, MAX_MASCOT_SESSIONS);
+    activeSessionId = session.id;
+    messages = session.messages;
+    persistState();
+    emit();
+    return session.id;
+}
+
+export function switchMascotSession(sessionId: string): boolean {
+    if (!hydrated || isThinking) return false;
+    const session = sessions.find((item) => item.id === sessionId);
+    if (!session) return false;
+    activeSessionId = session.id;
+    messages = normalizeMessages(session.messages);
+    persistState();
+    emit();
+    return true;
+}
+
+export function renameMascotSession(sessionId: string, title: string): boolean {
+    const nextTitle = title.replace(/\s+/g, " ").trim();
+    if (!nextTitle || !hydrated || isThinking || !sessions.some((session) => session.id === sessionId)) return false;
+    sessions = sessions.map((session) => session.id === sessionId ? { ...session, title: nextTitle } : session);
+    persistState();
+    emit();
+    return true;
+}
+
+export function deleteMascotSession(sessionId: string): boolean {
+    if (!hydrated || isThinking || !sessions.some((session) => session.id === sessionId)) return false;
+    sessions = sessions.filter((session) => session.id !== sessionId);
+    if (activeSessionId === sessionId) {
+        activeSessionId = sessions[0]?.id ?? null;
+        messages = sessions[0]?.messages ?? [];
+    }
+    if (sessions.length === 0) {
+        const now = Date.now();
+        const greeting = defaultGreetingMessage();
+        const replacement: MascotSession = {
+            id: makeMascotSessionId(),
+            title: "新对话",
+            createdAt: now,
+            updatedAt: now,
+            messages: greeting ? [greeting] : [],
+        };
+        sessions = [replacement];
+        activeSessionId = replacement.id;
+        messages = replacement.messages;
+    }
+    persistState();
+    emit();
+    return true;
+}
+
 function defaultGreetingMessage(): MascotMsg | null {
     const greeting = PAGE_GREETINGS["desktop"];
     return greeting ? { role: "mascot", text: greeting, createdAt: new Date().toISOString() } : null;
@@ -280,54 +390,84 @@ export function resetMascotConversation(options: { withGreeting?: boolean } = {}
 }
 
 export async function hydrateMascotChat(): Promise<void> {
+    if (hydrated) return;
     if (hydratePromise) return hydratePromise;
     hydratePromise = new Promise<void>((resolve) => {
-        if (typeof indexedDB === "undefined") {
+        const finishWithMessages = (loaded: MascotMsg[], migrated: boolean) => {
+            const greeting = loaded.length > 0 ? null : defaultGreetingMessage();
+            messages = greeting ? [greeting] : loaded;
+            const now = Date.now();
+            const session: MascotSession = {
+                id: makeMascotSessionId(),
+                title: migrated && loaded.length > 0 ? "之前的对话" : "新对话",
+                createdAt: now,
+                updatedAt: now,
+                messages,
+            };
+            sessions = [session];
+            activeSessionId = session.id;
             hydrated = true;
-            const greeting = defaultGreetingMessage();
-            messages = greeting ? [greeting] : [];
+            persistState();
             emit();
             resolve();
+        };
+
+        if (typeof indexedDB === "undefined") {
+            finishWithMessages([], false);
             return;
         }
         const req = openMascotDb();
         req.onsuccess = () => {
             try {
                 if (!req.result.objectStoreNames.contains(MASCOT_CHAT_STORE)) {
-                    hydrated = true;
-                    const greeting = defaultGreetingMessage();
-                    messages = greeting ? [greeting] : [];
-                    emit();
-                    resolve();
+                    req.result.close();
+                    finishWithMessages([], false);
                     return;
                 }
                 const tx = req.result.transaction(MASCOT_CHAT_STORE, "readonly");
-                const get = tx.objectStore(MASCOT_CHAT_STORE).get(MASCOT_MESSAGES_KEY);
-                get.onsuccess = () => {
-                    const loaded = Array.isArray(get.result) ? normalizeMessages(get.result) : [];
-                    const greeting = loaded.length > 0 ? null : defaultGreetingMessage();
-                    messages = greeting ? [greeting] : loaded;
-                    hydrated = true;
-                    if (greeting) persistMessages(messages);
-                    emit();
-                    resolve();
+                const store = tx.objectStore(MASCOT_CHAT_STORE);
+                const stateGet = store.get(MASCOT_STATE_KEY);
+                stateGet.onsuccess = () => {
+                    const state = stateGet.result as PersistedMascotState | undefined;
+                    if (state && Array.isArray(state.sessions) && state.sessions.length > 0) {
+                        sessions = state.sessions
+                            .filter((session) => session && typeof session.id === "string" && Array.isArray(session.messages))
+                            .map((session) => ({ ...session, messages: normalizeMessages(session.messages) }))
+                            .sort((a, b) => b.updatedAt - a.updatedAt)
+                            .slice(0, MAX_MASCOT_SESSIONS);
+                        activeSessionId = state.activeSessionId && sessions.some((session) => session.id === state.activeSessionId)
+                            ? state.activeSessionId
+                            : sessions[0]?.id ?? null;
+                        messages = sessions.find((session) => session.id === activeSessionId)?.messages ?? [];
+                        hydrated = true;
+                        emit();
+                        req.result.close();
+                        resolve();
+                        return;
+                    }
+
+                    // 首次升级：保留旧键，并将旧版单会话记录复制进多会话 state。
+                    const legacyGet = store.get(MASCOT_MESSAGES_KEY);
+                    legacyGet.onsuccess = () => {
+                        const loaded = Array.isArray(legacyGet.result) ? normalizeMessages(legacyGet.result) : [];
+                        req.result.close();
+                        finishWithMessages(loaded, loaded.length > 0);
+                    };
+                    legacyGet.onerror = () => {
+                        req.result.close();
+                        finishWithMessages([], false);
+                    };
                 };
-                get.onerror = () => {
-                    hydrated = true;
-                    emit();
-                    resolve();
+                stateGet.onerror = () => {
+                    req.result.close();
+                    finishWithMessages([], false);
                 };
             } catch {
-                hydrated = true;
-                emit();
-                resolve();
+                try { req.result.close(); } catch {}
+                finishWithMessages([], false);
             }
         };
-        req.onerror = () => {
-            hydrated = true;
-            emit();
-            resolve();
-        };
+        req.onerror = () => finishWithMessages([], false);
     });
     return hydratePromise;
 }
@@ -353,7 +493,13 @@ export async function sendMascotMessage({
     const userMsg: MascotMsg = images.length > 0
         ? { role: "user", text: trimmed, images, createdAt: new Date().toISOString() }
         : { role: "user", text: trimmed, createdAt: new Date().toISOString() };
+    const shouldAutoTitle = !messages.some((msg) => msg.role === "user");
     let workingMessages = normalizeMessages([...messages, userMsg]);
+    if (shouldAutoTitle && activeSessionId) {
+        sessions = sessions.map((session) => session.id === activeSessionId
+            ? { ...session, title: autoMascotSessionTitle(trimmed || "（图片）") }
+            : session);
+    }
     publishMessages(workingMessages);
     setThinking(true);
 


### PR DESCRIPTION
贡献者：什锦杂货铺（小红书）（@huaxingdictionar-art）

为桌面 AI 助手小卷增加安全的多会话管理：开启新对话时保留当前聊天记录，各会话相互独立；支持查看会话列表、切换、重命名和删除会话；首条用户消息可自动生成会话标题；最多保留 30 个会话，并继续限制单个会话的本地消息数量。兼容旧版单会话数据，首次加载时自动迁移，无需用户手动处理。生成回复期间禁用会话切换及管理操作，避免状态错乱。本功能已进行实际使用测试；本次未在工坊环境运行 npm run lint 或 npm run build。贡献者：什锦杂货铺（小红书）

---
_经小手机「共同建设」通道提交_