### PR TITLE
feat: 适配沉浸/非沉浸显示模式并完善聊天 Enter 发送

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { ChatPluginBootstrap } from "@/components/chat-plugin-bootstrap";
 import { ChatReasoningVisibilityController } from "@/components/chat-reasoning-visibility-controller";
 import { CSSImportEnhancer } from "@/components/css-import-enhancer";
+import { PWAManifestInjector } from "@/components/pwa-manifest-injector";
 import { PWARegistrar } from "@/components/pwa-registrar";
 import "../styles/fonts.css";
 import "./globals.css";
@@ -29,7 +30,7 @@ export default function RootLayout({
   return (
     <html lang="zh-CN">
       <head>
-        <link rel="manifest" href="/manifest.webmanifest" />
+        <link rel="manifest" href="/manifest.webmanifest" crossOrigin="use-credentials" />
         <meta name="theme-color" content="#f8f7f2" />
         <link rel="apple-touch-icon" href="/icon-192.png" />
         <link rel="icon" href="/icon-192.png" type="image/png" />
@@ -39,6 +40,7 @@ export default function RootLayout({
         <meta name="mobile-web-app-capable" content="yes" />
       </head>
       <body>
+        <PWAManifestInjector />
         <PWARegistrar />
         <CSSImportEnhancer />
         <ChatPluginBootstrap />

--- a/app/manifest.webmanifest/route.ts
+++ b/app/manifest.webmanifest/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import baseManifest from "../../public/manifest.json";
+import { readPwaDisplayPreference } from "@/lib/pwa-display-mode";
 
 export const runtime = "nodejs";
 
@@ -10,25 +11,40 @@ export const runtime = "nodejs";
 // but ONLY for Edge, so Chrome/others keep the fully immersive `standalone` look.
 // The manifest is fetched per browser at install time, so UA sniffing here works.
 // Takes effect only on (re)install.
+//
+// An explicit cookie can override the install mode. With no cookie, keep the
+// upstream behavior so existing installs and users are not silently changed.
 export function GET(request: NextRequest) {
   const ua = request.headers.get("user-agent") || "";
   const isEdge = /Edg/i.test(ua);
+  const preference = readPwaDisplayPreference(request.headers.get("cookie") || "");
 
-  const manifest = isEdge
+  const manifest = preference === "fullscreen"
     ? {
         ...baseManifest,
-        display: "minimal-ui",
-        display_override: ["minimal-ui", "standalone"],
-        theme_color: "#f8f7f2",
+        display: "fullscreen",
+        display_override: ["fullscreen", "standalone"],
       }
-    : baseManifest;
+    : preference === "standalone"
+      ? {
+          ...baseManifest,
+          display: isEdge ? "minimal-ui" : "standalone",
+          display_override: isEdge ? ["minimal-ui", "standalone"] : ["standalone", "minimal-ui"],
+          ...(isEdge ? { theme_color: "#f8f7f2" } : {}),
+        }
+      : isEdge
+        ? {
+            ...baseManifest,
+            display: "minimal-ui",
+            display_override: ["minimal-ui", "standalone"],
+            theme_color: "#f8f7f2",
+          }
+        : baseManifest;
 
   return new NextResponse(JSON.stringify(manifest), {
     headers: {
       "content-type": "application/manifest+json; charset=utf-8",
-      // Must vary by UA and not be CDN-cached, or one browser's manifest would be
-      // served to another.
-      "vary": "user-agent",
+      "vary": "user-agent, cookie",
       "cache-control": "no-store",
     },
   });

--- a/components/android-fullscreen.tsx
+++ b/components/android-fullscreen.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from "react";
 
+import { shouldRequestPwaFullscreen } from "@/lib/pwa-display-mode";
+
 /**
  * 安卓全屏兜底：点击屏幕进入全屏模式（iOS 不支持此 API，会自动忽略）。
  *
@@ -17,6 +19,7 @@ export function AndroidFullscreen() {
     if (!isMobile) return;
 
     function tryFullscreen() {
+      if (!shouldRequestPwaFullscreen()) return;
       const doc = document.documentElement;
       if (document.fullscreenElement) return;
       doc.requestFullscreen?.().catch(() => { });

--- a/components/app-market/custom-app-runner.tsx
+++ b/components/app-market/custom-app-runner.tsx
@@ -18,6 +18,7 @@ import { OnlineRoomConnection, onlineCloudApi } from "@/lib/online-room-client";
 import { submitContentReport } from "@/lib/moderation-client";
 import { hydrateKvDb } from "@/lib/kv-db";
 import { ensureSettingsStorageHydrated } from "@/lib/settings-storage";
+import { getPwaHostedSafeArea, PWA_DISPLAY_MODE_CHANGED_EVENT } from "@/lib/pwa-display-mode";
 import {
   addChatContact,
   CHAT_MESSAGE_PUSHED_EVENT,
@@ -169,6 +170,16 @@ html, body { min-height: 100%; }
   window.addEventListener('message', function(event){
     var data = event.data || {};
     if (data.source !== 'ai-phone-custom-app-host' || data.frameId !== frameId) return;
+    if (data.type === 'layout.safe-area' && data.safeArea) {
+      var safeArea = data.safeArea;
+      var root = document.documentElement;
+      root.style.setProperty('--ai-phone-app-safe-top', String(safeArea.top || '0px'));
+      root.style.setProperty('--ai-phone-app-safe-right', String(safeArea.right || '0px'));
+      root.style.setProperty('--ai-phone-app-safe-bottom', String(safeArea.bottom || '0px'));
+      root.style.setProperty('--ai-phone-app-safe-left', String(safeArea.left || '0px'));
+      window.dispatchEvent(new CustomEvent('aiphone:safe-area-change', { detail: safeArea }));
+      return;
+    }
     if (data.type === 'tool.invoke' && data.toolRequestId) {
       var handlerKey = String(data.handler || data.toolId || data.toolName || '').trim();
       var handler = toolHandlers[handlerKey] || toolHandlers[String(data.toolId || '')] || toolHandlers[String(data.toolName || '')];
@@ -734,6 +745,14 @@ export function CustomAppRunner({
   const isBackgroundRunner = Boolean(backgroundEvent || backgroundTool);
   const effectiveEmbedded = embedded || isBackgroundRunner;
   const srcDoc = useMemo(() => createCustomAppSrcDoc(app, frameId, launchContext, effectiveEmbedded), [app, frameId, launchContext, effectiveEmbedded]);
+  const syncHostedSafeArea = useCallback(() => {
+    iframeRef.current?.contentWindow?.postMessage({
+      source: "ai-phone-custom-app-host",
+      type: "layout.safe-area",
+      frameId,
+      safeArea: getPwaHostedSafeArea("custom-app", effectiveEmbedded),
+    }, "*");
+  }, [effectiveEmbedded, frameId]);
   const declaredEvents = useMemo(() => getCustomAppDeclaredEventNames(app), [app]);
   const declaredToolKeys = useMemo(() => getCustomAppDeclaredToolKeys(app), [app]);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -744,6 +763,17 @@ export function CustomAppRunner({
   const closeLabel = launchSource === "chat_plus_action" || launchSource === "chat_card" || launchSource === "chat_directive"
     ? "返回聊天室"
     : "返回桌面";
+
+  useEffect(() => {
+    window.addEventListener(PWA_DISPLAY_MODE_CHANGED_EVENT, syncHostedSafeArea);
+    document.addEventListener("fullscreenchange", syncHostedSafeArea);
+    window.addEventListener("pageshow", syncHostedSafeArea);
+    return () => {
+      window.removeEventListener(PWA_DISPLAY_MODE_CHANGED_EVENT, syncHostedSafeArea);
+      document.removeEventListener("fullscreenchange", syncHostedSafeArea);
+      window.removeEventListener("pageshow", syncHostedSafeArea);
+    };
+  }, [syncHostedSafeArea]);
 
   const getFrameAudioChannel = useCallback((name: string): FrameAudioChannel => {
     let entry = frameAudioChannelsRef.current.get(name);
@@ -1819,6 +1849,7 @@ export function CustomAppRunner({
         className="custom-app-runner-frame"
         sandbox="allow-scripts allow-downloads"
         allow="autoplay"
+        onLoad={syncHostedSafeArea}
         srcDoc={bridgeReady ? srcDoc : EMPTY_CUSTOM_APP_SRC_DOC}
       />
 

--- a/components/desktop-shell.tsx
+++ b/components/desktop-shell.tsx
@@ -823,11 +823,6 @@ function sameWidgetOrder(a: WidgetInstance[], b: WidgetInstance[]): boolean {
   return true;
 }
 
-type KeyboardTargetRect = {
-  top: number;
-  bottom: number;
-};
-
 function isKeyboardEditableElement(element: EventTarget | null): element is HTMLElement {
   if (!(element instanceof HTMLElement)) return false;
   if (element.isContentEditable) return true;
@@ -845,174 +840,38 @@ function shouldBypassDesktopItemPointerCapture(target: EventTarget | null): bool
   return isKeyboardEditableElement(target);
 }
 
-function parseCssPixels(value: string, fallback: number) {
-  const parsed = Number.parseFloat(value);
-  return Number.isFinite(parsed) ? parsed : fallback;
-}
-
-function measureTextareaCaretRect(textarea: HTMLTextAreaElement): KeyboardTargetRect {
-  const selectionStart = textarea.selectionStart ?? textarea.value.length;
-  const computed = window.getComputedStyle(textarea);
-  const rect = textarea.getBoundingClientRect();
-  const mirror = document.createElement("div");
-  const marker = document.createElement("span");
-  const fontSize = parseCssPixels(computed.fontSize, 14);
-  const lineHeight = computed.lineHeight === "normal" ? fontSize * 1.2 : parseCssPixels(computed.lineHeight, fontSize * 1.2);
-  const mirrorProperties = [
-    "font-family",
-    "font-size",
-    "font-style",
-    "font-variant",
-    "font-weight",
-    "letter-spacing",
-    "text-align",
-    "text-indent",
-    "text-transform",
-    "word-spacing",
-    "tab-size",
-    "direction",
-    "padding-top",
-    "padding-right",
-    "padding-bottom",
-    "padding-left",
-  ];
-
-  for (const property of mirrorProperties) {
-    mirror.style.setProperty(property, computed.getPropertyValue(property));
-  }
-
-  mirror.style.position = "fixed";
-  mirror.style.visibility = "hidden";
-  mirror.style.pointerEvents = "none";
-  mirror.style.left = "-10000px";
-  mirror.style.top = "0";
-  mirror.style.width = `${textarea.clientWidth}px`;
-  mirror.style.boxSizing = "border-box";
-  mirror.style.whiteSpace = "pre-wrap";
-  mirror.style.overflowWrap = "break-word";
-  mirror.style.wordBreak = computed.getPropertyValue("word-break");
-  mirror.style.lineHeight = `${lineHeight}px`;
-  mirror.textContent = textarea.value.slice(0, selectionStart);
-  marker.textContent = "\u200b";
-  mirror.appendChild(marker);
-  document.body.appendChild(mirror);
-
-  const mirrorRect = mirror.getBoundingClientRect();
-  const markerRect = marker.getBoundingClientRect();
-  document.body.removeChild(mirror);
-
-  const top = rect.top + markerRect.top - mirrorRect.top - textarea.scrollTop;
-  return {
-    top,
-    bottom: top + lineHeight,
-  };
-}
-
-function getKeyboardTargetRect(element: HTMLElement): KeyboardTargetRect {
-  if (element instanceof HTMLTextAreaElement) {
-    return measureTextareaCaretRect(element);
-  }
-
-  const rect = element.getBoundingClientRect();
-  return {
-    top: rect.top,
-    bottom: rect.bottom,
-  };
-}
-
-function useAndroidCaretKeyboardLift() {
+function useMobileVisualViewportHeight() {
   useEffect(() => {
     if (typeof window === "undefined" || typeof document === "undefined") return;
 
     const root = document.documentElement;
-    if (!/Android/i.test(navigator.userAgent)) {
-      root.style.removeProperty("--mobile-keyboard-lift");
-      return;
-    }
-
     const mobileMq = window.matchMedia("(max-width: 500px) and (hover: none) and (pointer: coarse)");
     const viewport = window.visualViewport;
-    let focusedElement: HTMLElement | null = null;
+    if (!viewport || !mobileMq.matches) return;
+
+    // 不再用 transform 整体上移 phone-shell：浏览器在键盘出现时已经会调整
+    // visual viewport，额外 transform 会造成“先上弹、再回落”的双重位移。
+    // 直接同步可视高度，让 absolute bottom:0 的输入栏自然贴在键盘上方。
     let raf = 0;
-    let currentLift = 0;
-
-    const applyLift = (nextLift: number) => {
-      const rounded = Math.max(0, Math.round(nextLift));
-      if (Math.abs(rounded - currentLift) < 2) return;
-      currentLift = rounded;
-      if (rounded > 0) {
-        root.style.setProperty("--mobile-keyboard-lift", `${rounded}px`);
-      } else {
-        root.style.removeProperty("--mobile-keyboard-lift");
-      }
-    };
-
     const update = () => {
       raf = 0;
-      const element = focusedElement;
-      if (!element || document.activeElement !== element || !mobileMq.matches || !viewport) {
-        applyLift(0);
-        return;
-      }
-
-      const keyboardTop = viewport.offsetTop + viewport.height;
-      const keyboardInset = Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop);
-      const targetRect = getKeyboardTargetRect(element);
-      const gap = 36;
-
-      if (keyboardInset < 80) {
-        applyLift(0);
-        return;
-      }
-
-      const naturalBottom = targetRect.bottom + currentLift;
-      const neededLift = Math.max(0, naturalBottom + gap - keyboardTop);
-      applyLift(Math.min(keyboardInset, neededLift));
+      if (!mobileMq.matches) return;
+      const height = Math.max(240, Math.round(viewport.height));
+      root.style.setProperty("--mobile-visible-height", `${height}px`);
     };
-
     const requestUpdate = () => {
       if (raf) window.cancelAnimationFrame(raf);
       raf = window.requestAnimationFrame(update);
     };
 
-    const handleFocusIn = (event: FocusEvent) => {
-      const target = event.target;
-      if (!isKeyboardEditableElement(target)) return;
-      focusedElement = target;
-      requestUpdate();
-    };
-
-    const handleFocusOut = () => {
-      focusedElement = null;
-      applyLift(0);
-    };
-
-    const handleCaretMove = () => {
-      if (focusedElement) requestUpdate();
-    };
-
-    const handleViewportChange = () => {
-      if (focusedElement) requestUpdate();
-    };
-
-    document.addEventListener("focusin", handleFocusIn);
-    document.addEventListener("focusout", handleFocusOut);
-    document.addEventListener("click", handleCaretMove, true);
-    document.addEventListener("keyup", handleCaretMove, true);
-    document.addEventListener("input", handleCaretMove, true);
-    viewport?.addEventListener("resize", handleViewportChange);
-    viewport?.addEventListener("scroll", handleViewportChange);
-
+    update();
+    viewport.addEventListener("resize", requestUpdate);
+    window.addEventListener("resize", requestUpdate);
     return () => {
       if (raf) window.cancelAnimationFrame(raf);
-      document.removeEventListener("focusin", handleFocusIn);
-      document.removeEventListener("focusout", handleFocusOut);
-      document.removeEventListener("click", handleCaretMove, true);
-      document.removeEventListener("keyup", handleCaretMove, true);
-      document.removeEventListener("input", handleCaretMove, true);
-      viewport?.removeEventListener("resize", handleViewportChange);
-      viewport?.removeEventListener("scroll", handleViewportChange);
-      root.style.removeProperty("--mobile-keyboard-lift");
+      viewport.removeEventListener("resize", requestUpdate);
+      window.removeEventListener("resize", requestUpdate);
+      root.style.removeProperty("--mobile-visible-height");
     };
   }, []);
 }
@@ -1047,7 +906,7 @@ export function DesktopShell({ initialThemeProfile, initialThemeAssets }: Deskto
   const handleMusicOverlayControllerChange = useCallback((controller: MusicOverlayController | null) => {
     musicOverlayControllerRef.current = controller;
   }, []);
-  useAndroidCaretKeyboardLift();
+  useMobileVisualViewportHeight();
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
   const [layout, setLayout] = useState<DesktopLayout>(DEFAULT_LAYOUT);
   // Dock is an ordered icon-id list (max DOCK_MAX), kept disjoint from `layout`.

--- a/components/game/game-hub-app.tsx
+++ b/components/game/game-hub-app.tsx
@@ -88,6 +88,7 @@ import type { LLMMessage } from "@/lib/llm-prompt-assembler";
 import { resolveUserIdentity } from "@/lib/settings-storage";
 import { incrementEventCounter } from "@/lib/memory-storage";
 import { maybeRunSummarization } from "@/lib/memory-summarizer";
+import { getPwaHostedSafeArea, PWA_DISPLAY_MODE_CHANGED_EVENT } from "@/lib/pwa-display-mode";
 import { IFRAME_ERROR_CAPTURE_SCRIPT } from "@/lib/qa-iframe-error-bridge";
 
 type GameMainView = "hall" | "library" | "studio";
@@ -437,6 +438,16 @@ ${body}
   window.addEventListener('message', function(event){
     var data = event.data || {};
     if (data.source !== 'ai-phone-game-host' || data.id !== frameId) return;
+    if (data.type === 'layout.safe-area' && data.safeArea) {
+      var safeArea = data.safeArea;
+      var root = document.documentElement;
+      root.style.setProperty('--ai-phone-game-safe-top', String(safeArea.top || '0px'));
+      root.style.setProperty('--ai-phone-game-safe-right', String(safeArea.right || '0px'));
+      root.style.setProperty('--ai-phone-game-safe-bottom', String(safeArea.bottom || '0px'));
+      root.style.setProperty('--ai-phone-game-safe-left', String(safeArea.left || '0px'));
+      window.dispatchEvent(new CustomEvent('aiphone:safe-area-change', { detail: safeArea }));
+      return;
+    }
     if (data.type === 'event' && data.event) {
       var handlers = (eventHandlers[data.event] || []).concat(eventHandlers['*'] || []);
       handlers.forEach(function(handler){
@@ -528,6 +539,25 @@ function GameIframe({
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [frameId] = useState(() => `game_frame_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`);
   const srcDoc = useMemo(() => createGameFrameSrcDoc(html, frameId), [frameId, html]);
+  const syncHostedSafeArea = useCallback(() => {
+    iframeRef.current?.contentWindow?.postMessage({
+      source: "ai-phone-game-host",
+      type: "layout.safe-area",
+      id: frameId,
+      safeArea: getPwaHostedSafeArea("game"),
+    }, "*");
+  }, [frameId]);
+
+  useEffect(() => {
+    window.addEventListener(PWA_DISPLAY_MODE_CHANGED_EVENT, syncHostedSafeArea);
+    document.addEventListener("fullscreenchange", syncHostedSafeArea);
+    window.addEventListener("pageshow", syncHostedSafeArea);
+    return () => {
+      window.removeEventListener(PWA_DISPLAY_MODE_CHANGED_EVENT, syncHostedSafeArea);
+      document.removeEventListener("fullscreenchange", syncHostedSafeArea);
+      window.removeEventListener("pageshow", syncHostedSafeArea);
+    };
+  }, [syncHostedSafeArea]);
 
   useEffect(() => {
     if (!registerEventSender) return;
@@ -587,6 +617,7 @@ function GameIframe({
       className="game-hub-frame"
       sandbox={allowExternalControl ? "allow-scripts allow-same-origin" : "allow-scripts"}
       allow="autoplay"
+      onLoad={syncHostedSafeArea}
       srcDoc={srcDoc}
     />
   );

--- a/components/main-app.tsx
+++ b/components/main-app.tsx
@@ -13,6 +13,7 @@ import { hydrateKvDb } from "@/lib/kv-db";
 import { getThemeAssetMap, readThemeProfile } from "@/lib/theme-storage";
 import { resolveActiveIconSkins, type ThemeProfile } from "@/lib/theme-types";
 import { hasPendingMcpOAuthCallback } from "@/lib/tool-executor";
+import { shouldRequestPwaFullscreen } from "@/lib/pwa-display-mode";
 
 const TEXT = {
   loading: "\u52A0\u8F7D\u4E2D...",
@@ -254,20 +255,18 @@ export function MainApp() {
       }
     })();
 
-    // 安卓全屏兜底：点击屏幕进入全屏模式（iOS 不支持此 API，会自动忽略）
+    // 安卓全屏兜底。是否请求全屏在每次点击时读取，设置切换后无需重载。
     const isMobile = window.matchMedia("(max-width: 500px) and (hover: none) and (pointer: coarse)").matches;
-    // Edge 改用 minimal-ui 保留原生状态栏，不能再被强制全屏顶掉（仅 Edge 跳过，其它浏览器照旧）
-    const isEdge = /Edg/i.test(navigator.userAgent);
-    if (!isMobile || isEdge) return () => {
+    if (!isMobile) return () => {
       cancelled = true;
     };
 
     function tryFullscreen() {
+      if (!shouldRequestPwaFullscreen()) return;
       const doc = document.documentElement;
       if (document.fullscreenElement) return;
       doc.requestFullscreen?.().catch(() => { });
     }
-    // 每次点击都尝试进入全屏（退出后可重新进入）
     document.addEventListener("click", tryFullscreen);
     return () => {
       cancelled = true;

--- a/components/mascot/mascot-float.tsx
+++ b/components/mascot/mascot-float.tsx
@@ -39,6 +39,8 @@ import {
   type NineSliceCalibrationEventDetail,
   type NineSliceValues,
 } from "@/lib/css-asset-tools";
+import { CHAT_APP_SETTINGS_UPDATED_EVENT, loadChatAppSettings } from "@/lib/chat-storage";
+import { shouldSendChatInputOnEnter } from "@/lib/chat-input-keyboard";
 
 
 /**
@@ -603,6 +605,7 @@ export function MascotFloat() {
 
   // Chat state
   const [chatInput, setChatInput] = useState("");
+  const [enterToSendEnabled, setEnterToSendEnabled] = useState(() => loadChatAppSettings().enterToSendEnabled === true);
   const mascotChat = useSyncExternalStore(subscribeMascotChat, getMascotChatSnapshot, getMascotChatSnapshot);
   const mascotSettings = useSyncExternalStore(subscribeMascotSettings, getMascotSettingsSnapshot, getMascotSettingsSnapshot);
   const mascotDisplayName = mascotSettings.nickname || "AI助手";
@@ -627,6 +630,14 @@ export function MascotFloat() {
 
   useEffect(() => {
     void hydrateMascotChat();
+  }, []);
+
+  useEffect(() => {
+    const syncEnterToSend = () => {
+      setEnterToSendEnabled(loadChatAppSettings().enterToSendEnabled === true);
+    };
+    window.addEventListener(CHAT_APP_SETTINGS_UPDATED_EVENT, syncEnterToSend);
+    return () => window.removeEventListener(CHAT_APP_SETTINGS_UPDATED_EVENT, syncEnterToSend);
   }, []);
 
   useEffect(() => {
@@ -2294,7 +2305,12 @@ export function MascotFloat() {
                         placeholder={`跟${mascotDisplayName}聊聊...`}
                         value={chatInput}
                         onChange={(e) => setChatInput(e.target.value)}
-                        onKeyDown={(e) => { if (e.key === "Enter") handleSend(); }}
+                        onKeyDown={(event) => {
+                          if (!shouldSendChatInputOnEnter(event, enterToSendEnabled)) return;
+                          event.preventDefault();
+                          void handleSend();
+                        }}
+                        enterKeyHint={enterToSendEnabled ? "send" : "enter"}
                         disabled={isThinking}
                       />
                       {isThinking
@@ -2396,7 +2412,12 @@ export function MascotFloat() {
                           placeholder={context.mode === "editing" ? `告诉${mascotDisplayName}你想改什么...` : `跟${mascotDisplayName}聊聊...`}
                           value={chatInput}
                           onChange={(e) => setChatInput(e.target.value)}
-                          onKeyDown={(e) => { if (e.key === "Enter") handleSend(); }}
+                          onKeyDown={(event) => {
+                            if (!shouldSendChatInputOnEnter(event, enterToSendEnabled)) return;
+                            event.preventDefault();
+                            void handleSend();
+                          }}
+                          enterKeyHint={enterToSendEnabled ? "send" : "enter"}
                           disabled={isThinking}
                         />
                         {isThinking

--- a/components/phone-settings-app.tsx
+++ b/components/phone-settings-app.tsx
@@ -27,6 +27,7 @@ import { Toggle } from "./ui/form";
 import { loadChatAppSettings, saveChatAppSettings } from "@/lib/chat-storage";
 import { loadKeepAlive, saveKeepAlive } from "@/lib/weixin-storage";
 import { BINDING_ACCENTS, CONTENT_APP_ACCENTS } from "@/lib/ui-accent-colors";
+import { PwaDisplaySetting } from "@/components/pwa-display-setting";
 
 export const SettingsContext = createContext<{
     setSubpageTitle: (title: string | null) => void;
@@ -417,6 +418,7 @@ export function PhoneSettingsApp({ onClose, onNotice }: SettingsPageProps) {
                                 </div>
                                 <Toggle checked={keepAlive} onChange={handleKeepAliveChange} className="settings-toggle-control" />
                             </div>
+                            <PwaDisplaySetting onNotice={onNotice} />
                         </div>
                         {isAdmin ? (
                             <div className="settings-moderation-section">

--- a/components/pwa-display-setting.tsx
+++ b/components/pwa-display-setting.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState, type CSSProperties } from "react";
+import { Layers } from "lucide-react";
+
+import { Toggle } from "@/components/ui/form";
+import {
+  DEFAULT_PWA_DISPLAY_PREFERENCE,
+  readPwaDisplayPreference,
+  writePwaDisplayPreference,
+  type PwaDisplayPreference,
+} from "@/lib/pwa-display-mode";
+import { CONTENT_APP_ACCENTS } from "@/lib/ui-accent-colors";
+
+type PwaDisplaySettingProps = {
+  onNotice: (message: string) => void;
+};
+
+export function PwaDisplaySetting({ onNotice }: PwaDisplaySettingProps) {
+  const [preference, setPreference] = useState<PwaDisplayPreference>(DEFAULT_PWA_DISPLAY_PREFERENCE);
+
+  useEffect(() => {
+    setPreference(readPwaDisplayPreference(document.cookie) ?? DEFAULT_PWA_DISPLAY_PREFERENCE);
+  }, []);
+
+  const setShowSystemStatusBar = (enabled: boolean) => {
+    const next: PwaDisplayPreference = enabled ? "standalone" : "fullscreen";
+    setPreference(next);
+    writePwaDisplayPreference(next);
+
+    if (next === "standalone" && document.fullscreenElement) {
+      void document.exitFullscreen?.().catch(() => {});
+    }
+
+    onNotice(enabled
+      ? "已开启系统状态栏，重新添加到桌面后完全生效"
+      : "已恢复沉浸全屏，重新添加到桌面后完全生效");
+  };
+
+  return (
+    <div className="app-card card-featured settings-toggle-card">
+      <span className="card-icon" style={{ "--icon-color": CONTENT_APP_ACCENTS.calendar } as CSSProperties}>
+        <Layers size={22} strokeWidth={1.75} />
+      </span>
+      <div className="card-featured-body">
+        <div className="card-featured-label">显示系统状态栏</div>
+        <div className="card-featured-desc">开启后退出沉浸全屏，避免安卓反复显示全屏提示；重新添加到桌面后完全生效</div>
+      </div>
+      <Toggle
+        checked={preference === "standalone"}
+        onChange={setShowSystemStatusBar}
+        className="settings-toggle-control"
+      />
+    </div>
+  );
+}

--- a/components/pwa-manifest-injector.tsx
+++ b/components/pwa-manifest-injector.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { getRuntimePwaDisplayMode, PWA_DISPLAY_MODE_CHANGED_EVENT } from "@/lib/pwa-display-mode";
+
+export function PWAManifestInjector() {
+  useEffect(() => {
+    const root = document.documentElement;
+    const displayModeQueries = ["fullscreen", "standalone", "minimal-ui"].map(mode => (
+      window.matchMedia(`(display-mode: ${mode})`)
+    ));
+
+    const syncRuntimeDisplayMode = () => {
+      root.dataset.pwaDisplayMode = getRuntimePwaDisplayMode();
+    };
+
+    const refreshManifest = () => {
+      const link = document.querySelector<HTMLLinkElement>('link[rel="manifest"]');
+      if (!link) return;
+      const base = (link.getAttribute("href") || "/manifest.webmanifest").split("?")[0];
+      link.setAttribute("href", `${base}?v=${Date.now()}`);
+    };
+
+    const handleSettingsChanged = () => {
+      syncRuntimeDisplayMode();
+      refreshManifest();
+    };
+
+    syncRuntimeDisplayMode();
+    refreshManifest();
+    document.addEventListener("fullscreenchange", syncRuntimeDisplayMode);
+    window.addEventListener("pageshow", syncRuntimeDisplayMode);
+    window.addEventListener(PWA_DISPLAY_MODE_CHANGED_EVENT, handleSettingsChanged);
+    displayModeQueries.forEach(query => query.addEventListener("change", syncRuntimeDisplayMode));
+
+    return () => {
+      document.removeEventListener("fullscreenchange", syncRuntimeDisplayMode);
+      window.removeEventListener("pageshow", syncRuntimeDisplayMode);
+      window.removeEventListener(PWA_DISPLAY_MODE_CHANGED_EVENT, handleSettingsChanged);
+      displayModeQueries.forEach(query => query.removeEventListener("change", syncRuntimeDisplayMode));
+      delete root.dataset.pwaDisplayMode;
+    };
+  }, []);
+
+  return null;
+}

--- a/lib/chat-input-keyboard.ts
+++ b/lib/chat-input-keyboard.ts
@@ -6,13 +6,14 @@ type ChatInputKeyboardEvent = {
     altKey?: boolean;
     nativeEvent?: {
         isComposing?: boolean;
-        keyCode?: number;
     };
 };
 
 export function shouldSendChatInputOnEnter(event: ChatInputKeyboardEvent, enterToSendEnabled: boolean): boolean {
     if (event.key !== "Enter") return false;
-    if (event.nativeEvent?.isComposing || event.nativeEvent?.keyCode === 229) return false;
+    // Android keyboards may report keyCode 229 for ordinary Latin/numeric Enter,
+    // so keyCode alone cannot be used as an IME-composition signal.
+    if (event.nativeEvent?.isComposing) return false;
     if (event.ctrlKey || event.metaKey) return true;
     return enterToSendEnabled && !event.shiftKey && !event.altKey;
 }

--- a/lib/pwa-display-mode.ts
+++ b/lib/pwa-display-mode.ts
@@ -1,0 +1,75 @@
+export type PwaDisplayPreference = "fullscreen" | "standalone";
+export type RuntimePwaDisplayMode = "fullscreen" | "standalone" | "minimal-ui" | "browser";
+export type PwaHostedSurface = "custom-app" | "game";
+
+export type PwaHostedSafeArea = {
+  top: string;
+  right: string;
+  bottom: string;
+  left: string;
+};
+
+export const PWA_DISPLAY_MODE_COOKIE = "pwa_display_mode";
+export const PWA_DISPLAY_MODE_CHANGED_EVENT = "pwa-display-mode-changed";
+export const DEFAULT_PWA_DISPLAY_PREFERENCE: PwaDisplayPreference = "fullscreen";
+
+function decodeCookieValue(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export function readPwaDisplayPreference(cookie: string): PwaDisplayPreference | null {
+  const match = cookie.match(new RegExp(`(?:^|;\\s*)${PWA_DISPLAY_MODE_COOKIE}=([^;]+)`));
+  if (!match) return null;
+  const value = decodeCookieValue(match[1]);
+  return value === "fullscreen" || value === "standalone" ? value : null;
+}
+
+export function writePwaDisplayPreference(preference: PwaDisplayPreference) {
+  if (typeof document === "undefined") return;
+  document.cookie = `${PWA_DISPLAY_MODE_COOKIE}=${preference}; path=/; max-age=31536000; samesite=lax`;
+  window.dispatchEvent(new CustomEvent(PWA_DISPLAY_MODE_CHANGED_EVENT, { detail: preference }));
+}
+
+/** Preserve the upstream default: mobile browsers request fullscreen unless Edge or explicitly disabled. */
+export function shouldRequestPwaFullscreen(): boolean {
+  if (typeof document === "undefined" || typeof navigator === "undefined") return false;
+  const preference = readPwaDisplayPreference(document.cookie);
+  if (preference === "standalone") return false;
+  if (preference === "fullscreen") return true;
+  return !/Edg/i.test(navigator.userAgent);
+}
+
+export function getRuntimePwaDisplayMode(): RuntimePwaDisplayMode {
+  if (typeof window === "undefined" || typeof document === "undefined") return "browser";
+  if (document.fullscreenElement || window.matchMedia("(display-mode: fullscreen)").matches) {
+    return "fullscreen";
+  }
+  if (window.matchMedia("(display-mode: standalone)").matches) {
+    return "standalone";
+  }
+  if (window.matchMedia("(display-mode: minimal-ui)").matches) {
+    return "minimal-ui";
+  }
+
+  const navigatorWithStandalone = navigator as Navigator & { standalone?: boolean };
+  return navigatorWithStandalone.standalone ? "standalone" : "browser";
+}
+
+/** Safe-area values injected into sandboxed apps, which cannot inherit host CSS variables. */
+export function getPwaHostedSafeArea(surface: PwaHostedSurface, embedded = false): PwaHostedSafeArea {
+  if (embedded) {
+    return { top: "0px", right: "0px", bottom: "0px", left: "0px" };
+  }
+
+  const nonImmersive = getRuntimePwaDisplayMode() !== "fullscreen";
+  return {
+    top: nonImmersive ? (surface === "game" ? "60px" : "48px") : "88px",
+    right: "16px",
+    bottom: "24px",
+    left: "16px",
+  };
+}

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -645,7 +645,7 @@
   left: 0;
   right: 0;
   z-index: 10;
-  padding: 10px 16px;
+  padding: 8px 16px max(8px, env(safe-area-inset-bottom, 0px));
   background: color-mix(in srgb, var(--c-input, var(--c-page-body-bg)) 55%, transparent);
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
@@ -726,7 +726,7 @@
   display: flex;
   justify-content: center;
   gap: 32px;
-  padding: 10px 0 24px;
+  padding: 6px 0 0;
 }
 
 .chat-input-bar .chat-input-actions .ui-bare-btn {

--- a/styles/game.css
+++ b/styles/game.css
@@ -1560,7 +1560,7 @@
 
 .game-runtime-floating-back {
   position: absolute;
-  top: max(38px, calc(env(safe-area-inset-top, 0px) + 8px));
+  top: max(8px, calc(var(--page-header-safe-top, 48px) - 10px));
   left: max(14px, calc(env(safe-area-inset-left, 0px) + 14px));
   z-index: 8;
   width: 44px;

--- a/styles/phone-shell.css
+++ b/styles/phone-shell.css
@@ -1058,22 +1058,45 @@
 
 @media (max-width: 500px) and (hover: none) and (pointer: coarse) {
 
+  /* 浏览器/PWA 已经显示真实状态栏时，所有 App 共用系统安全区，不再重复预留
+     48px 虚拟状态栏。进入真正的 fullscreen 后控制器会自动恢复原布局。 */
+  html[data-pwa-display-mode="standalone"] .phone-shell,
+  html[data-pwa-display-mode="minimal-ui"] .phone-shell,
+  html[data-pwa-display-mode="browser"] .phone-shell {
+    --safe-area-top: env(safe-area-inset-top, 0px);
+    --phone-titlebar-safe-top: env(safe-area-inset-top, 0px);
+    --page-header-safe-top: env(safe-area-inset-top, 0px);
+    --home-grid-top-offset: calc(env(safe-area-inset-top, 0px) + 16px);
+  }
+
+  html[data-pwa-display-mode="standalone"] .phone-shell > .phone-status-bar,
+  html[data-pwa-display-mode="minimal-ui"] .phone-shell > .phone-status-bar,
+  html[data-pwa-display-mode="browser"] .phone-shell > .phone-status-bar {
+    display: none;
+  }
+
+  html[data-pwa-display-mode="standalone"] .phone-shell-wrap,
+  html[data-pwa-display-mode="minimal-ui"] .phone-shell-wrap,
+  html[data-pwa-display-mode="browser"] .phone-shell-wrap {
+    margin-top: 0;
+  }
+
   :root {
     --phone-screen-width: 100vw;
-    --phone-screen-height: 100lvh;
+    --phone-screen-height: var(--mobile-visible-height, 100lvh);
   }
 
   html,
   body {
     overflow: hidden;
     width: 100%;
-    height: 100lvh;
+    height: var(--mobile-visible-height, 100lvh);
     background: var(--c-page-body-bg);
   }
 
   .app-root {
     width: 100vw;
-    height: 100lvh;
+    height: var(--mobile-visible-height, 100lvh);
     padding: 0;
     display: flex;
     justify-content: flex-start;
@@ -1099,9 +1122,6 @@
        .app-root 被裁掉，底部栏随之顶回可视区。上移量可在「状态栏」弹窗里按设备调节，
        让它约等于真实状态栏高度即可铺满。0 = 不上移（iOS 等能全屏的浏览器保持 0）。 */
     margin-top: calc(-1 * var(--status-bar-drop, 0px));
-    transform: translate3d(0, calc(-1 * var(--mobile-keyboard-lift, 0px)), 0);
-    transition: transform 0.18s cubic-bezier(0.22, 1, 0.36, 1);
-    will-change: transform;
   }
 
   .phone-shell-wrap .phone-case {
@@ -1129,7 +1149,7 @@
 
   .app-root.splash-root {
     width: 100vw;
-    height: 100lvh;
+    height: var(--mobile-visible-height, 100lvh);
     margin: 0;
     padding: 0;
     display: flex;


### PR DESCRIPTION
## Summary
- Add an explicit PWA display-mode preference while preserving the upstream immersive-fullscreen default.
- Derive shell headers, desktop layout, chat surfaces, custom apps, and games from the actual runtime display mode.
- Fix Enter-to-send for Latin/numeric Android keyboard events and apply the shared setting to the AI assistant floating chat.
- Reduce excess bottom spacing in all shared chat input action bars while preserving safe-area insets.

## Verification
- `npx tsc --noEmit`
- Targeted ESLint with the repository's legacy config
- `npm run build`
- Verified `/manifest.webmanifest` for default, `fullscreen`, and `standalone` cookie modes

The branch is based on the latest `upstream/main` and keeps the upstream desktop self-healing and AI assistant updates.