### PR TITLE
fix: 同步安卓状态栏颜色并修复助手控件

### DIFF
--- a/components/chat/mascot-chat-room.tsx
+++ b/components/chat/mascot-chat-room.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { CSSProperties, PointerEvent as ReactPointerEvent, ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { AlertCircle, ChevronLeft, Code, Image as ImageIcon, MessageSquare, MoreHorizontal, RotateCcw, Trash2, UserRound } from "lucide-react";
+import { AlertCircle, ChevronLeft, Code, Image as ImageIcon, MessageSquare, MoreHorizontal, RotateCcw, Sparkles, Trash2, UserRound } from "lucide-react";
 import { PageShell } from "@/components/ui/page-shell";
 import { ConfirmDialog } from "@/components/ui/modal";
 import { MediaPreviewOverlay } from "@/components/chat/media-preview-overlay";
@@ -12,15 +12,16 @@ import CSSSchemeBar from "@/components/ui/css-scheme-picker";
 import { SessionCustomCSS } from "@/components/ui/session-custom-css";
 import { CHAT_SESSION_CSS_EXAMPLE } from "@/lib/css-examples";
 import {
+    appendMascotMessage,
     clearMascotToolHistoryMessages,
     createMascotSession,
     deleteMascotMessageWithLinkedTools,
     deleteMascotSession,
+    generateMascotReply,
     getMascotChatSnapshot,
     hasMascotToolHistoryMessages,
     hydrateMascotChat,
     renameMascotSession,
-    sendMascotMessage,
     setMascotMessages,
     stopMascotGeneration,
     subscribeMascotChat,
@@ -490,6 +491,8 @@ export function MascotChatRoom({ onBack, onDeleted }: MascotChatRoomProps) {
         allVisibleMessageEntries.slice(-visibleMascotMessageCount)
     ), [allVisibleMessageEntries, visibleMascotMessageCount]);
     const hasMoreMascotMessages = allVisibleMessageEntries.length > visibleMessageEntries.length;
+    const latestVisibleChatMessage = [...chat.messages].reverse().find((msg) => !msg.hidden && msg.role !== "tool");
+    const canGenerateReply = !chat.isThinking && latestVisibleChatMessage?.role === "user";
     const scrollSignature = useMemo(() => {
         const last = visibleMessageEntries[visibleMessageEntries.length - 1]?.msg;
         const lastText = last ? getMascotMessageText(last) : "";
@@ -689,7 +692,13 @@ export function MascotChatRoom({ onBack, onDeleted }: MascotChatRoomProps) {
         const images = pendingImages;
         setPendingImages([]);
         setShowEmojiPanel(false);
-        await sendMascotMessage({ text, images, context });
+        await appendMascotMessage({ text, images });
+    };
+
+    const handleGenerateReply = async () => {
+        if (!canGenerateReply) return;
+        setShowEmojiPanel(false);
+        await generateMascotReply({ context });
     };
 
     const closeMascotContextMenu = useCallback(() => {
@@ -1184,6 +1193,16 @@ export function MascotChatRoom({ onBack, onDeleted }: MascotChatRoomProps) {
                         ) : (
                             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><line x1="22" y1="2" x2="11" y2="13" /><polygon points="22 2 15 22 11 13 2 9 22 2" /></svg>
                         )}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => void handleGenerateReply()}
+                        disabled={!canGenerateReply}
+                        className="ui-bare-btn text-[var(--c-text)]"
+                        aria-label="生成回复"
+                        title="生成回复"
+                    >
+                        <Sparkles size={24} strokeWidth={1.5} />
                     </button>
                 </div>
                 {showEmojiPanel && <EmojiPanel onSelect={appendEmoji} />}

--- a/lib/bg-tone.ts
+++ b/lib/bg-tone.ts
@@ -1,8 +1,91 @@
-/**
- * 检测图片亮度，返回 "light" 或 "dark"。
- * 采样图片上部 40% 区域（状态栏所在位置）的平均亮度。
- */
-export function detectImageBrightness(url: string): Promise<"light" | "dark"> {
+type RgbColor = { r: number; g: number; b: number };
+type CssColor = RgbColor & { a: number };
+
+function clampChannel(value: number): number {
+  return Math.max(0, Math.min(255, Math.round(value)));
+}
+
+function parseCssColor(value: string): CssColor | null {
+  const normalized = value.trim();
+  const commaRgb = normalized.match(
+    /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*([\d.]+))?\s*\)/i,
+  );
+  const spaceRgb = normalized.match(
+    /rgba?\(\s*(\d+)\s+(\d+)\s+(\d+)(?:\s*\/\s*([\d.]+%?))?\s*\)/i,
+  );
+  const rgb = commaRgb || spaceRgb;
+  if (rgb) {
+    const rawAlpha = rgb[4];
+    const alpha = rawAlpha?.endsWith("%")
+      ? Number(rawAlpha.slice(0, -1)) / 100
+      : Number(rawAlpha ?? 1);
+    return {
+      r: clampChannel(Number(rgb[1])),
+      g: clampChannel(Number(rgb[2])),
+      b: clampChannel(Number(rgb[3])),
+      a: Math.max(0, Math.min(1, alpha)),
+    };
+  }
+
+  const srgb = normalized.match(
+    /color\(\s*srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)(?:\s*\/\s*([\d.]+%?))?\s*\)/i,
+  );
+  if (srgb) {
+    const rawAlpha = srgb[4];
+    const alpha = rawAlpha?.endsWith("%")
+      ? Number(rawAlpha.slice(0, -1)) / 100
+      : Number(rawAlpha ?? 1);
+    return {
+      r: clampChannel(Number(srgb[1]) * 255),
+      g: clampChannel(Number(srgb[2]) * 255),
+      b: clampChannel(Number(srgb[3]) * 255),
+      a: Math.max(0, Math.min(1, alpha)),
+    };
+  }
+
+  const hex = normalized.match(/^#([\da-f]{3,8})$/i)?.[1];
+  if (!hex) return null;
+  const expanded = hex.length <= 4
+    ? hex.split("").map((part) => part + part).join("")
+    : hex;
+  return {
+    r: parseInt(expanded.slice(0, 2), 16),
+    g: parseInt(expanded.slice(2, 4), 16),
+    b: parseInt(expanded.slice(4, 6), 16),
+    a: expanded.length >= 8 ? parseInt(expanded.slice(6, 8), 16) / 255 : 1,
+  };
+}
+
+function colorBrightness(color: RgbColor): number {
+  return 0.299 * color.r + 0.587 * color.g + 0.114 * color.b;
+}
+
+function composite(foreground: CssColor, background: RgbColor): RgbColor {
+  return {
+    r: foreground.r * foreground.a + background.r * (1 - foreground.a),
+    g: foreground.g * foreground.a + background.g * (1 - foreground.a),
+    b: foreground.b * foreground.a + background.b * (1 - foreground.a),
+  };
+}
+
+function toHex(color: RgbColor): string {
+  return `#${[color.r, color.g, color.b]
+    .map((channel) => clampChannel(channel).toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
+function firstBackgroundImageUrl(backgroundImage: string): string | null {
+  return backgroundImage.match(/url\(\s*["']?(.+?)["']?\s*\)/i)?.[1] || null;
+}
+
+function firstGradientColor(backgroundImage: string): CssColor | null {
+  if (!/(?:linear|radial)-gradient\(/i.test(backgroundImage)) return null;
+  const gradient = backgroundImage.match(/rgba?\([^)]*\)|#[\da-f]{3,8}/i)?.[0];
+  return gradient ? parseCssColor(gradient) : null;
+}
+
+/** 采样图片上部 40% 区域（状态栏所在位置）的平均颜色。 */
+function sampleImageColor(url: string): Promise<RgbColor | null> {
   return new Promise((resolve) => {
     const img = new Image();
     img.crossOrigin = "anonymous";
@@ -12,94 +95,139 @@ export function detectImageBrightness(url: string): Promise<"light" | "dark"> {
       canvas.width = size;
       canvas.height = size;
       const ctx = canvas.getContext("2d");
-      if (!ctx) { resolve("light"); return; }
+      if (!ctx) { resolve(null); return; }
       ctx.drawImage(img, 0, 0, size, size);
       const sampleH = Math.round(size * 0.4);
-      const data = ctx.getImageData(0, 0, size, sampleH).data;
-      let total = 0;
-      const count = data.length / 4;
-      for (let i = 0; i < data.length; i += 4) {
-        total += 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
+      let data: Uint8ClampedArray;
+      try {
+        data = ctx.getImageData(0, 0, size, sampleH).data;
+      } catch {
+        resolve(null);
+        return;
       }
-      resolve(total / count < 128 ? "dark" : "light");
+      let red = 0;
+      let green = 0;
+      let blue = 0;
+      let weight = 0;
+      for (let i = 0; i < data.length; i += 4) {
+        const alpha = data[i + 3] / 255;
+        red += (data[i] * alpha) + (255 * (1 - alpha));
+        green += (data[i + 1] * alpha) + (255 * (1 - alpha));
+        blue += (data[i + 2] * alpha) + (255 * (1 - alpha));
+        weight += 1;
+      }
+      resolve(weight > 0 ? { r: red / weight, g: green / weight, b: blue / weight } : null);
     };
-    img.onerror = () => resolve("light");
+    img.onerror = () => resolve(null);
     img.src = url;
   });
 }
 
-/** 解析 rgb()/rgba() 字符串的亮度 */
-function colorBrightness(color: string): number | null {
-  const m = color.match(/rgba?\(\s*(\d+),\s*(\d+),\s*(\d+)/);
-  if (!m) return null;
-  return 0.299 * +m[1] + 0.587 * +m[2] + 0.114 * +m[3];
+/** 保留亮度检测 API，供旧调用方使用。 */
+export async function detectImageBrightness(url: string): Promise<"light" | "dark"> {
+  const color = await sampleImageColor(url);
+  return colorBrightness(color || { r: 248, g: 247, b: 242 }) < 128 ? "dark" : "light";
 }
 
 /**
- * 检测任意 DOM 元素的视觉背景亮度。
+ * 检测任意 DOM 元素的视觉背景颜色。
  * 依次检查 background-image（URL）和 background-color。
  */
-export async function detectElementTone(el: HTMLElement): Promise<"light" | "dark"> {
+async function detectElementColor(el: HTMLElement): Promise<RgbColor | null> {
   const style = getComputedStyle(el);
+  const backgroundColor = parseCssColor(style.backgroundColor);
+  const solidBackground = backgroundColor && backgroundColor.a > 0
+    ? composite(backgroundColor, { r: 255, g: 255, b: 255 })
+    : null;
 
   // 1. 优先检测背景图片
   const bgImage = style.backgroundImage;
-  const urlMatch = bgImage.match(/url\(["']?(.+?)["']?\)/);
-  if (urlMatch) {
-    return detectImageBrightness(urlMatch[1]);
+  const imageUrl = firstBackgroundImageUrl(bgImage);
+  if (imageUrl) {
+    const sampled = await sampleImageColor(imageUrl);
+    if (sampled) {
+      // 主题壁纸使用白色 linear-gradient 作为透明度蒙层，合成后才是屏幕实际颜色。
+      const overlay = firstGradientColor(bgImage);
+      return overlay ? composite(overlay, sampled) : sampled;
+    }
   }
 
-  // 2. 检测背景色
-  const bgColor = style.backgroundColor;
-  if (bgColor && bgColor !== "transparent" && bgColor !== "rgba(0, 0, 0, 0)") {
-    const b = colorBrightness(bgColor);
-    if (b !== null) return b < 128 ? "dark" : "light";
-  }
+  // 2. 纯 CSS 渐变没有 URL，用首个渐变色与底色合成近似顶部主色。
+  const gradient = firstGradientColor(bgImage);
+  if (gradient) return composite(gradient, solidBackground || { r: 255, g: 255, b: 255 });
 
-  return "light";
+  // 3. 检测背景色
+  if (solidBackground) return solidBackground;
+
+  return null;
+}
+
+/** 检测任意 DOM 元素的视觉背景亮度。 */
+export async function detectElementTone(el: HTMLElement): Promise<"light" | "dark"> {
+  const color = await detectElementColor(el);
+  return colorBrightness(color || { r: 248, g: 247, b: 242 }) < 128 ? "dark" : "light";
 }
 
 /**
  * 按优先级查找当前可见的背景元素。
  * 更具体的（如聊天室）优先于更通用的（如 app 外壳）。
  */
-function findBgElement(shell: HTMLElement, activeApp: string | null): HTMLElement | null {
+function findBgElements(shell: HTMLElement, activeApp: string | null): HTMLElement[] {
   if (!activeApp) {
     // 主页 → 壁纸
-    return shell.querySelector(".phone-wallpaper");
+    const wallpaper = shell.querySelector(".phone-wallpaper") as HTMLElement | null;
+    return wallpaper ? [wallpaper] : [];
   }
 
   // 按优先级：具体子页面 > app 容器 > workspace 兜底
   const selectors = [
     '[class*="session-"]',        // 聊天室（z-20，最上层）
+    '.qa-app-shell',               // 工坊
+    '.page-body',                  // 页面内容底色（page-shell 自身通常透明）
     '.page-shell',                // 设置/外观/资源库
     '[class*="char-page"]',       // 角色管理
     '.chat-app',                  // 聊天 app 容器（联系人/会话列表）
     '.phone-app-pane > *',        // 任何 app 最外层容器（改进 fallback）
   ];
 
+  const found: HTMLElement[] = [];
   for (const sel of selectors) {
-    const el = shell.querySelector(sel) as HTMLElement | null;
-    if (el) return el;
+    const elements = Array.from(shell.querySelectorAll(sel)) as HTMLElement[];
+    for (const el of elements) {
+      const style = getComputedStyle(el);
+      const visible = style.display !== "none" && style.visibility !== "hidden" && el.getClientRects().length > 0;
+      if (visible && !found.includes(el)) found.push(el);
+    }
   }
-  return null;
+  return found;
 }
+
+let latestToneUpdate = 0;
 
 /**
  * 检测当前可见背景的亮度并设置 --status-bar-color。
  * 由 desktop-shell 在 app 切换和 DOM 变化时调用。
  */
 export async function updateStatusBarTone(shell: HTMLElement, activeApp: string | null) {
-  const el = findBgElement(shell, activeApp);
-  const tone = el ? await detectElementTone(el) : "light";
+  const updateId = ++latestToneUpdate;
+  const elements = findBgElements(shell, activeApp);
+  let color: RgbColor | null = null;
+  for (const el of elements) {
+    color = await detectElementColor(el);
+    if (color || updateId !== latestToneUpdate) break;
+  }
+  color ||= parseCssColor(getComputedStyle(document.documentElement).getPropertyValue("--c-page-body-bg"));
+  if (updateId !== latestToneUpdate) return;
+  const resolvedColor = color || { r: 248, g: 247, b: 242 };
+  const tone = colorBrightness(resolvedColor) < 128 ? "dark" : "light";
 
   shell.style.setProperty(
     "--status-bar-color",
     tone === "dark" ? "rgba(255,255,255,0.9)" : "#1a1a1a"
   );
 
-  // Drive the browser/PWA status-bar background to follow the page (light/dark).
-  // This is what colors Edge's minimal-ui status bar; harmless on other browsers.
+  // Drive the browser/PWA status-bar background to follow the actual page color.
+  // Chrome/Edge use this meta tag for the Android status bar in standalone/minimal-ui.
   if (typeof document !== "undefined") {
     let meta = document.querySelector('meta[name="theme-color"]') as HTMLMetaElement | null;
     if (!meta) {
@@ -107,6 +235,6 @@ export async function updateStatusBarTone(shell: HTMLElement, activeApp: string 
       meta.name = "theme-color";
       document.head.appendChild(meta);
     }
-    meta.content = tone === "dark" ? "#121110" : "#f8f7f2";
+    meta.content = toHex(resolvedColor);
   }
 }

--- a/lib/bg-tone.ts
+++ b/lib/bg-tone.ts
@@ -183,6 +183,7 @@ function findBgElements(shell: HTMLElement, activeApp: string | null): HTMLEleme
   const selectors = [
     '[class*="session-"]',        // 聊天室（z-20，最上层）
     '.qa-app-shell',               // 工坊
+    '.reading-app-surface',        // 阅读书架/阅读器（暖黄色背景）
     '.page-body',                  // 页面内容底色（page-shell 自身通常透明）
     '.page-shell',                // 设置/外观/资源库
     '[class*="char-page"]',       // 角色管理

--- a/lib/mascot-chat-store.ts
+++ b/lib/mascot-chat-store.ts
@@ -477,30 +477,42 @@ export function stopMascotGeneration() {
     abortController?.abort();
 }
 
-export async function sendMascotMessage({
+export async function appendMascotMessage({
     text,
     images = [],
-    context = getMascotContext(),
 }: {
     text: string;
     images?: string[];
-    context?: MascotPageContext;
-}): Promise<void> {
+}): Promise<boolean> {
     await hydrateMascotChat();
     const trimmed = text.trim();
-    if ((!trimmed && images.length === 0) || isThinking) return;
+    if ((!trimmed && images.length === 0) || isThinking) return false;
 
     const userMsg: MascotMsg = images.length > 0
         ? { role: "user", text: trimmed, images, createdAt: new Date().toISOString() }
         : { role: "user", text: trimmed, createdAt: new Date().toISOString() };
     const shouldAutoTitle = !messages.some((msg) => msg.role === "user");
-    let workingMessages = normalizeMessages([...messages, userMsg]);
+    const workingMessages = normalizeMessages([...messages, userMsg]);
     if (shouldAutoTitle && activeSessionId) {
         sessions = sessions.map((session) => session.id === activeSessionId
             ? { ...session, title: autoMascotSessionTitle(trimmed || "（图片）") }
             : session);
     }
     publishMessages(workingMessages);
+    return true;
+}
+
+export async function generateMascotReply({
+    context = getMascotContext(),
+}: {
+    context?: MascotPageContext;
+} = {}): Promise<void> {
+    await hydrateMascotChat();
+    if (isThinking) return;
+    const latestVisibleMessage = [...messages].reverse().find((msg) => !msg.hidden && msg.role !== "tool");
+    if (latestVisibleMessage?.role !== "user") return;
+
+    let workingMessages = normalizeMessages(messages);
     setThinking(true);
 
     const MAX_ROUNDS = 8;
@@ -697,6 +709,19 @@ export async function sendMascotMessage({
         setThinking(false);
         abortController = null;
     }
+}
+
+export async function sendMascotMessage({
+    text,
+    images = [],
+    context = getMascotContext(),
+}: {
+    text: string;
+    images?: string[];
+    context?: MascotPageContext;
+}): Promise<void> {
+    const accepted = await appendMascotMessage({ text, images });
+    if (accepted) await generateMascotReply({ context });
 }
 
 export function getMascotLastPreview(): string {

--- a/styles/qa.css
+++ b/styles/qa.css
@@ -3,6 +3,7 @@
    全部变量 scope 在 .qa-app-shell 内，不污染全局。 */
 
 .qa-app-shell {
+  --qa-header-safe-top: max(12px, var(--page-header-safe-top, 48px));
   /* 浅色（暖米白，Claude Light 风）：干净、无描边、柔和阴影 */
   --qa-bg-canvas: #fafaf7;
   --qa-bg-sidebar: #f3f2ec;
@@ -93,8 +94,8 @@
   top: 0;
   left: 0;
   right: 0;
-  height: calc(var(--page-header-safe-top, 48px) + var(--page-header-content-height, 42px));
-  padding: var(--page-header-safe-top, 48px) 14px 0;
+  height: calc(var(--qa-header-safe-top) + var(--page-header-content-height, 42px));
+  padding: var(--qa-header-safe-top) 14px 0;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
@@ -193,7 +194,7 @@
   overscroll-behavior-y: contain;
   /* 顶部留出顶栏高度；底部留足输入栏高度，避免最后一条被压住 */
   padding:
-    calc(var(--page-header-safe-top, 48px) + var(--page-header-content-height, 42px) + 8px)
+    calc(var(--qa-header-safe-top) + var(--page-header-content-height, 42px) + 8px)
     16px
     calc(env(safe-area-inset-bottom, 0px) + 152px);
   position: relative;
@@ -775,7 +776,7 @@
 .qa-image-viewer-close {
   position: absolute;
   /* 避开手机壳状态栏（独立层级，会拦截点击） */
-  top: calc(var(--page-header-safe-top, 48px) + 10px);
+  top: calc(var(--qa-header-safe-top) + 10px);
   right: 14px;
   width: 36px;
   height: 36px;
@@ -1354,7 +1355,7 @@
   display: flex;
   flex-direction: column;
   background: #ffffff;
-  padding-top: var(--page-header-safe-top, 48px);
+  padding-top: var(--qa-header-safe-top);
 }
 .qa-drawer-head {
   flex-shrink: 0;


### PR DESCRIPTION
## 变更

- AI 助手聊天框区分纸飞机发送与星星生成回复。
- 修复工坊非沉浸式顶栏按钮过度贴顶的问题。
- 让 Android Chrome/Edge 的状态栏颜色跟随当前页面背景，并修复阅读 App 暖黄色背景识别。

## 验证

- `npx tsc --noEmit`
- 目标模块 ESLint（无错误）
- `git diff --check`