### PR TITLE
提示词查看器支持线下聊天提示词预览

### DIFF
--- a/components/debug-prompt-panel.tsx
+++ b/components/debug-prompt-panel.tsx
@@ -22,6 +22,8 @@ import { loadStorySessions, loadStoryMessages } from "@/lib/story-storage";
 import { previewStoryPromptPayload } from "@/lib/story-engine";
 import { loadVnSessions, loadVnMessages } from "@/lib/vn-storage";
 import { previewVnPromptPayload } from "@/lib/vn-engine";
+import { loadChatOfflineTurns } from "@/lib/chat-offline-storage";
+import { buildOfflinePromptHistory } from "@/lib/offline-prompt-builder";
 import { EXTRA_PROMPT_APPS, type ExtraPromptAppId } from "@/components/debug-prompt-registry";
 import { previewCheckPhonePromptPayload } from "@/lib/checkphone-engine";
 import { CHECKPHONE_APP_SPECS, type CheckPhoneAppId } from "@/lib/checkphone-config";
@@ -104,6 +106,8 @@ export function DebugPromptPanel() {
     const suppressFloatingClickRef = useRef(false);
     const [selectedChatSessionId, setSelectedChatSessionId] = useState("");
     const [followUpMode, setFollowUpMode] = useState(false);
+    const [offlinePreviewMode, setOfflinePreviewMode] = useState(false);
+    const [offlinePendingText, setOfflinePendingText] = useState("");
 
     // Moments state
     const [momentsResult, setMomentsResult] = useState<MomentsPreviewResult | null>(null);
@@ -319,17 +323,41 @@ export function DebugPromptPanel() {
         setError(null);
         setLoading(true);
         try {
-            const latestMessages = loadChatMessages(activeChatSession.id);
-            if (activeChatSession.isGroup) {
-                await previewGroupPromptRequestSnapshot(activeChatSession, latestMessages);
+            if (offlinePreviewMode) {
+                // 线下模式：历史来自「线下轮次」，assistant 内容为 <content>+摘要 XML，
+                // 与 chat-room 真实线下生成完全一致（appTags 带 offline）。
+                const offlineTurns = loadChatOfflineTurns(activeChatSession.id);
+                if (offlineTurns.length === 0 && !offlinePendingText.trim()) {
+                    setError("该会话还没有线下记录，请先在输入框填写一条线下消息再预览");
+                    setLoading(false);
+                    return;
+                }
+                const offlineHistory = buildOfflinePromptHistory(activeChatSession, offlineTurns, offlinePendingText);
+                if (activeChatSession.isGroup) {
+                    await previewGroupPromptRequestSnapshot(activeChatSession, offlineHistory, {
+                        appTags: ["group_chat", "offline"],
+                        excludeOfflineSessionId: activeChatSession.id,
+                        disableTools: true,
+                    });
+                } else {
+                    await previewPromptRequestSnapshot(activeChatSession, offlineHistory, {
+                        appTags: ["chat", "offline"],
+                        excludeOfflineSessionId: activeChatSession.id,
+                    });
+                }
             } else {
-                await previewPromptRequestSnapshot(
-                    activeChatSession,
-                    latestMessages,
-                    followUpMode
-                        ? { followUpAuto: true, appTags: ["chat", "text", "followup"] }
-                        : { appTags: ["chat", "text"] }
-                );
+                const latestMessages = loadChatMessages(activeChatSession.id);
+                if (activeChatSession.isGroup) {
+                    await previewGroupPromptRequestSnapshot(activeChatSession, latestMessages);
+                } else {
+                    await previewPromptRequestSnapshot(
+                        activeChatSession,
+                        latestMessages,
+                        followUpMode
+                            ? { followUpAuto: true, appTags: ["chat", "text", "followup"] }
+                            : { appTags: ["chat", "text"] }
+                    );
+                }
             }
             setExpandedIdx(new Set());
             requestAnimationFrame(() => { scrollRef.current?.scrollTo(0, 0); });
@@ -930,6 +958,21 @@ export function DebugPromptPanel() {
                                 {followUpMode ? "追发 ON" : "追发 OFF"}
                             </button>
                         )}
+                        {activeChatSession && (
+                            <>
+                                <button onClick={() => { setOfflinePreviewMode(v => !v); }} className="pv-toggle" {...(offlinePreviewMode ? { "data-active": "" } : {})}>
+                                    {offlinePreviewMode ? "线下 ON" : "线下 OFF"}
+                                </button>
+                                {offlinePreviewMode && (
+                                    <input
+                                        value={offlinePendingText}
+                                        onChange={e => setOfflinePendingText(e.target.value)}
+                                        className="pv-select"
+                                        placeholder="输入下一条线下消息（可选）"
+                                    />
+                                )}
+                            </>
+                        )}
                     </>
                 )}
                 {mode === "moments" && (
@@ -1020,7 +1063,9 @@ export function DebugPromptPanel() {
                 {displayMessages.length === 0 && !error && (
                     <div className="pv-empty">
                         {mode === "chat"
-                            ? (activeChatSession ? "点击「预览 Prompt」查看下一轮会发送的真实提示词" : "选择聊天对象后点击「预览 Prompt」")
+                            ? (activeChatSession
+                                ? (offlinePreviewMode ? "点击「预览 Prompt」查看线下模式的真实提示词（含 <content> 与摘要 XML）" : "点击「预览 Prompt」查看下一轮会发送的真实提示词")
+                                : "选择聊天对象后点击「预览 Prompt」")
                             : mode === "moments" ? "选择角色后点击「预览」查看朋友圈 Prompt"
                             : mode === "calendar" ? "选择角色与日期后点击「预览」"
                             : mode === "vn" ? "选择角色后点击「预览」查看漫卷 Prompt"

--- a/lib/offline-prompt-builder.ts
+++ b/lib/offline-prompt-builder.ts
@@ -1,0 +1,64 @@
+// lib/offline-prompt-builder.ts
+// 线下聊天历史构造：把「线下轮次」（ChatOfflineTurn）转成与线上同构的 ChatMessage[]。
+// assistant 消息内容用 <content> + 摘要 XML 包裹，与真实线下生成（generateOfflineChatCompletion
+// / generateGroupOfflineChatCompletion）完全一致。
+// chat-room（真实发送）与提示词查看器（预览）共用本模块，保证「预览 = 即将发出的提示词」。
+
+import type { ChatSession, ChatMessage } from "./chat-storage";
+import type { ChatOfflineTurn } from "./chat-offline-storage";
+
+export function formatOfflineTurnXml(turn: ChatOfflineTurn): string {
+    if (turn.rawText?.trim()) return turn.rawText.trim();
+    const summaryTag = turn.summaryTag?.trim() || "summary";
+    return [
+        "<content>",
+        turn.assistantContent,
+        "</content>",
+        `<${summaryTag}>`,
+        turn.summary,
+        `</${summaryTag}>`,
+    ].join("\n");
+}
+
+export function buildOfflinePromptHistory(
+    session: ChatSession,
+    turns: ChatOfflineTurn[],
+    pendingUserContent: string,
+): ChatMessage[] {
+    const history: ChatMessage[] = [];
+    for (const turn of turns) {
+        const assistantAt = turn.createdAt;
+        const userAtMs = new Date(turn.createdAt).getTime() - 1;
+        const userAt = Number.isFinite(userAtMs) ? new Date(userAtMs).toISOString() : turn.createdAt;
+        if (turn.userContent.trim()) {
+            history.push({
+                id: `${turn.id}_user`,
+                sessionId: session.id,
+                role: "user",
+                content: turn.userContent,
+                status: "sent",
+                createdAt: userAt,
+            });
+        }
+        history.push({
+            id: `${turn.id}_assistant`,
+            sessionId: session.id,
+            role: "assistant",
+            content: formatOfflineTurnXml(turn),
+            status: "sent",
+            createdAt: assistantAt,
+            ...(session.isGroup ? { senderName: session.groupName || "群聊线下" } : {}),
+        });
+    }
+    if (pendingUserContent.trim()) {
+        history.push({
+            id: `offline_pending_${Date.now()}`,
+            sessionId: session.id,
+            role: "user",
+            content: pendingUserContent.trim(),
+            status: "sent",
+            createdAt: new Date().toISOString(),
+        });
+    }
+    return history;
+}


### PR DESCRIPTION
贡献者：温铎

提示词查看器（debug-prompt-panel）的「聊天」tab 目前只能预览线上聊天的提示词，看不到线下模式的提示词。线下聊天（角色离线时的互动叙事）走的提示词与线上不同：appTags 带 "offline"，且历史不是聊天记录，而是「线下轮次」（ChatOfflineTurn，assistant 内容为 <content>+摘要 XML 包裹）。

本次改动：
1. 新增 lib/offline-prompt-builder.ts：把线下轮次构造为 ChatMessage[] 历史，与真实线下生成（generateOfflineChatCompletion / generateGroupOfflineChatCompletion）完全一致；
2. debug-prompt-panel 聊天 tab 增加「线下」开关与「下一条线下消息」输入框：线下模式下按 appTags ["chat"/"group_chat", "offline"]（群聊另带 excludeOfflineSessionId + disableTools）组装并预览提示词，历史与真实请求同源；无线下记录且未填消息时给出明确提示。

验证方式：在聊天界面开启提示词查看器 → 聊天 tab → 线下 ON → 填一条线下消息 → 预览 Prompt，能正确看到含 <content> 与摘要 XML 的线下提示词；线上预览行为不变。

---
_经小手机「共同建设」通道提交_