### PR TITLE
feat(语音): 为 Minimax 增加按配置保存的语速调节

### DIFF
--- a/components/settings/voice-settings.tsx
+++ b/components/settings/voice-settings.tsx
@@ -17,6 +17,10 @@ const MINIMAX_BASE_URL_OPTIONS = [
 ];
 const DEFAULT_MINIMAX_BASE_URL = MINIMAX_BASE_URL_OPTIONS[0].baseUrl;
 const GLOBAL_MINIMAX_BASE_URL = MINIMAX_BASE_URL_OPTIONS[1].baseUrl;
+const MINIMAX_SPEED_MIN = 0.5;
+const MINIMAX_SPEED_MAX = 2.0;
+const MINIMAX_SPEED_STEP = 0.1;
+const DEFAULT_SPEECH_SPEED = 1.0;
 const VOICE_PROVIDER_OPTIONS = [
     { value: "OpenAI", label: "OpenAI TTS" },
     { value: "MinimaxCN", label: "Minimax 语音国内版" },
@@ -32,6 +36,7 @@ const DEFAULT_VOICE_CONFIGS: VoiceApiConfig[] = [
         baseUrl: DEFAULT_MINIMAX_BASE_URL,
         model: "speech-2.8-turbo",
         defaultVoice: "male-qn-qingse",
+        speechSpeed: DEFAULT_SPEECH_SPEED,
         enableSTT: true,
         enableTTS: true,
     }
@@ -190,7 +195,10 @@ function normalizeVoiceConfigs(configs: VoiceApiConfig[]): VoiceApiConfig[] {
             const baseUrl = MINIMAX_BASE_URL_OPTIONS.some(option => option.baseUrl === config.baseUrl)
                 ? config.baseUrl
                 : DEFAULT_MINIMAX_BASE_URL;
-            return { ...config, baseUrl };
+            const speechSpeed = typeof config.speechSpeed === "number" && Number.isFinite(config.speechSpeed)
+                ? Math.min(MINIMAX_SPEED_MAX, Math.max(MINIMAX_SPEED_MIN, config.speechSpeed))
+                : DEFAULT_SPEECH_SPEED;
+            return { ...config, baseUrl, speechSpeed };
         });
 }
 
@@ -259,6 +267,7 @@ export function VoiceSettings() {
             region: "",
             model: "speech-2.8-turbo",
             defaultVoice: "male-qn-qingse",
+            speechSpeed: DEFAULT_SPEECH_SPEED,
             enableSTT: true,
             enableTTS: true,
         };
@@ -303,6 +312,7 @@ export function VoiceSettings() {
             baseUrl: providerOption === "MinimaxGlobal" ? GLOBAL_MINIMAX_BASE_URL : DEFAULT_MINIMAX_BASE_URL,
             model: wasMinimax ? (current?.model || "speech-2.8-turbo") : "speech-2.8-turbo",
             defaultVoice: wasMinimax ? (current?.defaultVoice || "male-qn-qingse") : "male-qn-qingse",
+            speechSpeed: wasMinimax ? (current?.speechSpeed ?? DEFAULT_SPEECH_SPEED) : DEFAULT_SPEECH_SPEED,
         });
         if (!wasMinimax) {
             setManualModelIds(prev => ({ ...prev, [id]: false }));
@@ -713,6 +723,27 @@ export function VoiceSettings() {
 
                                         {config.provider === "Minimax" && (
                                             <>
+                                                <div className="flex flex-col gap-1">
+                                                    <div className="flex items-center justify-between px-1">
+                                                        <label className="menu-desc">语速</label>
+                                                        <span className="menu-label font-medium">{(config.speechSpeed ?? DEFAULT_SPEECH_SPEED).toFixed(1)}×</span>
+                                                    </div>
+                                                    <input
+                                                        type="range"
+                                                        min={MINIMAX_SPEED_MIN}
+                                                        max={MINIMAX_SPEED_MAX}
+                                                        step={MINIMAX_SPEED_STEP}
+                                                        value={config.speechSpeed ?? DEFAULT_SPEECH_SPEED}
+                                                        onChange={(e) => updateConfig(config.id, { speechSpeed: Number(e.target.value) })}
+                                                        className="w-full accent-black"
+                                                        aria-label="Minimax 语速"
+                                                    />
+                                                    <div className="relative mt-1 h-5 px-1 text-xs text-gray-500" aria-hidden="true">
+                                                        <span className="absolute left-1 whitespace-nowrap">{MINIMAX_SPEED_MIN.toFixed(1)}×</span>
+                                                        <span className="absolute whitespace-nowrap" style={{ left: "33.333%", transform: "translateX(-50%)" }}>1.0× 默认</span>
+                                                        <span className="absolute right-1 whitespace-nowrap">{MINIMAX_SPEED_MAX.toFixed(1)}×</span>
+                                                    </div>
+                                                </div>
                                                 <div className="flex flex-col gap-1">
                                                     <label className="menu-desc ml-1">朗读语言</label>
                                                     <select

--- a/lib/settings-types.ts
+++ b/lib/settings-types.ts
@@ -137,6 +137,8 @@ export type VoiceApiConfig = {
     sttModel?: string;
     defaultVoice: string;
     languageBoost?: string;
+    /** Minimax voice_setting.speed. Missing values keep the legacy 1.0x behavior. */
+    speechSpeed?: number;
     customVoices?: { id: string; name: string; createdAt?: number }[];
     enableSTT: boolean;
     enableTTS: boolean;

--- a/lib/tts-service.ts
+++ b/lib/tts-service.ts
@@ -74,13 +74,21 @@ const MINIMAX_EMOTIONS = new Set([
     "happy", "sad", "angry", "fearful", "disgusted", "surprised", "calm", "neutral", "fluent",
 ]);
 
+const MINIMAX_SPEED_MIN = 0.5;
+const MINIMAX_SPEED_MAX = 2.0;
+
+function normalizeMinimaxSpeed(speed: number | undefined): number {
+    if (typeof speed !== "number" || !Number.isFinite(speed)) return 1.0;
+    return Math.min(MINIMAX_SPEED_MAX, Math.max(MINIMAX_SPEED_MIN, speed));
+}
+
 async function synthesizeMinimax(text: string, config: VoiceApiConfig, emotion?: string): Promise<Blob | null> {
     if (!config.apiKey) throw new Error("Minimax API Key 未配置");
 
     const baseUrl = (config.baseUrl || "https://api.minimaxi.com/v1").replace(/\/$/, "");
     const voiceSetting: Record<string, unknown> = {
         voice_id: config.defaultVoice || "male-qn-qingse",
-        speed: 1.0,
+        speed: normalizeMinimaxSpeed(config.speechSpeed),
         vol: 1.0,
         pitch: 0,
     };


### PR DESCRIPTION
贡献者：什锦杂货铺（小红书）（@huaxingdictionar-art）

贡献者：什锦杂货铺（小红书）（@huaxingdictionar-art）

为 Minimax 语音配置增加可持久保存的语速调节：
- 调节范围 0.5～2.0，步进 0.1，默认 1.0；
- 每个 Minimax 配置分别保存语速；
- 对旧配置保持 1.0 倍速兼容，并对异常值进行范围归一化；
- 合成请求将所选语速写入 Minimax 的 voice_setting.speed。

本次仅包含 Minimax 语速功能，不包含角色卡版本备份、小卷多会话或其他 DIY。该功能已进行实际使用测试；本次未在工坊环境运行 npm run lint 或 npm run build。

---
_经小手机「共同建设」通道提交_