### PR TITLE
feat: 添加角色卡版本历史与小卷的自动备份

### DIFF
--- a/components/phone-character-app.tsx
+++ b/components/phone-character-app.tsx
@@ -38,7 +38,18 @@ import { loadMomentsConfig, saveMomentsConfig } from "@/lib/moments-storage";
 import type { CanvasBgItem } from "@/lib/character-types";
 import { PageShell } from "@/components/ui/page-shell";
 import { ConfirmDialog } from "@/components/ui/modal";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, History } from "lucide-react";
+import {
+  backupCharacterVersion,
+  clearCharacterVersions,
+  deleteCharacterVersion,
+  getCharacterCurrentVersion,
+  getCharacterNextVersion,
+  loadCharacterVersions,
+  overwriteCharacterVersion,
+  switchCharacterVersion,
+  type CharacterVersion,
+} from "@/lib/character-version-storage";
 import { notifyMascotPageContext } from "@/lib/mascot-events";
 import { kvGet, kvSet } from "@/lib/kv-db";
 import { normalizeTimeZone } from "@/lib/character-time";
@@ -239,6 +250,7 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
           <CharArchiveView
             char={view.id ? (characters.find((c) => c.id === view.id) ?? createCharacter({ name: "", persona: "", avatar: null })) : createCharacter({ name: "", persona: "", avatar: null })}
             isEditing={view.isEditing}
+            isExisting={Boolean(view.id)}
             onBack={handleBackFromDetail}
             onEdit={() => setView({ type: "detail", id: view.id, isEditing: true })}
             onCancelEdit={() => {
@@ -248,9 +260,12 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
                 setView({ type: "list", id: null, isEditing: false });
               }
             }}
-            onSave={(data) => {
+            onSave={(data, createVersion) => {
               const existing = view.id ? characters.find((c) => c.id === view.id) : null;
               if (existing) {
+                const nextVersion = createVersion
+                  ? backupCharacterVersion(existing, "manual", "手动编辑前备份")
+                  : overwriteCharacterVersion(existing.id);
                 const updated: Character = {
                   ...existing,
                   ...data,
@@ -258,7 +273,9 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
                 };
                 updateChars(characters.map((c) => (c.id === existing.id ? updated : c)));
                 setView({ type: "detail", id: existing.id, isEditing: false });
-                onNotice("档案已更新");
+                onNotice(createVersion
+                  ? `已备份旧卡，当前为 V${nextVersion}`
+                  : `已覆盖旧版本，当前为 V${nextVersion}`);
               } else {
                 const newChar = createCharacter(data);
                 newChar.polaroidStyle = pendingPolaroidStyle;
@@ -267,8 +284,23 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
                 onNotice("点击画布放置角色");
               }
             }}
+            onRestoreVersion={(version) => {
+              const existing = view.id ? characters.find((c) => c.id === view.id) : null;
+              if (!existing) return;
+              const activeVersion = switchCharacterVersion(existing, version);
+              const restored: Character = {
+                ...version.data,
+                id: existing.id,
+                createdAt: existing.createdAt,
+                updatedAt: new Date().toISOString(),
+              };
+              updateChars(characters.map((c) => (c.id === existing.id ? restored : c)));
+              setView({ type: "detail", id: existing.id, isEditing: false });
+              onNotice(`已切换到 V${activeVersion}，未创建新版本`);
+            }}
             onDelete={() => {
               if (view.id) {
+                clearCharacterVersions(view.id);
                 updateChars(characters.filter((c) => c.id !== view.id));
               }
               setView({ type: "list", id: null, isEditing: false });
@@ -1726,10 +1758,12 @@ function DraggableNode({
 function CharArchiveView({
   char,
   isEditing = false,
+  isExisting = false,
   onBack,
   onEdit,
   onCancelEdit,
   onSave,
+  onRestoreVersion,
   onDelete,
   onExportJson,
   onExportPng,
@@ -1737,10 +1771,12 @@ function CharArchiveView({
 }: {
   char: Character;
   isEditing?: boolean;
+  isExisting?: boolean;
   onBack: () => void;
   onEdit: () => void;
   onCancelEdit?: () => void;
-  onSave?: (data: CharacterImportData) => void;
+  onSave?: (data: CharacterImportData, createVersion: boolean) => void;
+  onRestoreVersion?: (version: CharacterVersion) => void;
   onDelete: () => void;
   onExportJson: () => void;
   onExportPng: () => Promise<void>;
@@ -1748,6 +1784,11 @@ function CharArchiveView({
 }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [showUnsavedConfirm, setShowUnsavedConfirm] = useState<"back" | "cancel" | null>(null);
+  const [showSaveVersionConfirm, setShowSaveVersionConfirm] = useState(false);
+  const [showVersions, setShowVersions] = useState(false);
+  const [versions, setVersions] = useState<CharacterVersion[]>([]);
+  const [restoreTarget, setRestoreTarget] = useState<CharacterVersion | null>(null);
+  const [deleteVersionTarget, setDeleteVersionTarget] = useState<CharacterVersion | null>(null);
   const [name, setName] = useState(char.name || "");
   const [persona, setPersona] = useState(char.persona || "");
   const [personality, setPersonality] = useState(char.personality || "");
@@ -1862,7 +1903,7 @@ function CharArchiveView({
     setTagInput("");
   }
 
-  function handleSave() {
+  function commitSave(createVersion: boolean) {
     const trimmedTimeZone = timeZone.trim();
     const normalizedTimeZone = trimmedTimeZone ? normalizeTimeZone(trimmedTimeZone) : undefined;
     if (onSave) {
@@ -1879,8 +1920,27 @@ function CharArchiveView({
         timeZone: normalizedTimeZone,
         tags,
         avatar: avatar ?? null
-      });
+      }, createVersion);
     }
+  }
+
+  function handleSave() {
+    if (isExisting) {
+      setShowSaveVersionConfirm(true);
+    } else {
+      commitSave(false);
+    }
+  }
+
+  function openVersionHistory() {
+    setVersions(loadCharacterVersions(char.id));
+    setShowVersions(true);
+  }
+
+  function removeVersion(version: CharacterVersion) {
+    deleteCharacterVersion(char.id, version.id);
+    setVersions(loadCharacterVersions(char.id));
+    setDeleteVersionTarget(null);
   }
 
   async function handleGenerateBrief() {
@@ -2231,12 +2291,161 @@ function CharArchiveView({
       onBack={handleBack}
       className="bg-[var(--c-page-body-bg)]"
       rightAction={!isEditing ? (
-        <button className="char-action-btn" onClick={onEdit}>
-          <IconEdit />
-        </button>
+        <div className="flex items-center gap-2">
+          {isExisting && (
+            <button
+              className="char-action-btn"
+              onClick={openVersionHistory}
+              aria-label="角色卡历史版本"
+              title="历史版本"
+            >
+              <History size={19} />
+            </button>
+          )}
+          <button className="char-action-btn" onClick={onEdit} aria-label="编辑角色卡">
+            <IconEdit />
+          </button>
+        </div>
       ) : undefined}
     >
       {archiveFrame}
+
+      {showSaveVersionConfirm && (
+        <div className="fixed inset-0 z-[10020] flex items-center justify-center bg-black/45 px-5" role="dialog" aria-modal="true" aria-label="保存角色卡">
+          <div className="w-full max-w-sm rounded-2xl border border-[var(--c-panel-border)] bg-[var(--c-page-body-bg)] p-5 text-[var(--c-text)] shadow-2xl">
+            <div className="text-base font-bold">保存角色卡</div>
+            <p className="mt-2 ts-12 leading-relaxed opacity-75">
+              当前是 V{getCharacterCurrentVersion(char.id)}。你可以先保存修改前的旧卡，也可以覆盖当前版本。
+            </p>
+            <div className="mt-4 flex flex-col gap-2">
+              <button
+                type="button"
+                className="rounded-xl bg-[var(--c-text)] px-4 py-3 font-semibold text-[var(--c-page-body-bg)]"
+                onClick={() => {
+                  setShowSaveVersionConfirm(false);
+                  commitSave(true);
+                }}
+              >
+                备份旧卡并保存为 V{getCharacterNextVersion(char.id)}
+              </button>
+              <button
+                type="button"
+                className="rounded-xl border border-[var(--c-panel-border)] px-4 py-3 font-semibold"
+                onClick={() => {
+                  setShowSaveVersionConfirm(false);
+                  commitSave(false);
+                }}
+              >
+                覆盖当前版本
+              </button>
+              <button
+                type="button"
+                className="px-4 py-2 opacity-65"
+                onClick={() => setShowSaveVersionConfirm(false)}
+              >
+                取消
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showVersions && (
+        <div
+          className="fixed inset-0 z-[10020] flex items-end justify-center bg-black/45 sm:items-center sm:px-5"
+          role="dialog"
+          aria-modal="true"
+          aria-label="角色卡历史版本"
+          onPointerDown={(event) => {
+            if (event.target === event.currentTarget) setShowVersions(false);
+          }}
+        >
+          <div className="max-h-[78vh] w-full max-w-md overflow-hidden rounded-t-2xl border border-[var(--c-panel-border)] bg-[var(--c-page-body-bg)] text-[var(--c-text)] shadow-2xl sm:rounded-2xl">
+            <div className="flex items-center justify-between border-b border-[var(--c-panel-border)] px-5 py-4">
+              <div>
+                <div className="font-bold">历史版本</div>
+                <div className="mt-0.5 ts-10 opacity-60">当前生效：V{getCharacterCurrentVersion(char.id)}</div>
+              </div>
+              <button type="button" className="px-2 py-1 font-semibold" onClick={() => setShowVersions(false)}>关闭</button>
+            </div>
+            <div className="max-h-[62vh] overflow-y-auto p-4">
+              {versions.length === 0 ? (
+                <div className="py-10 text-center ts-12 opacity-60">还没有历史版本。编辑保存或由小卷修改后会自动生成。</div>
+              ) : (
+                <div className="flex flex-col gap-3">
+                  {versions.map((version) => (
+                    <div key={version.id} className="rounded-xl border border-[var(--c-panel-border)] p-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="font-bold">V{version.version}</div>
+                          <div className="mt-1 ts-10 opacity-65">{version.label}</div>
+                          <div className="mt-1 ts-10 opacity-50">{new Date(version.createdAt).toLocaleString()}</div>
+                        </div>
+                        {getCharacterCurrentVersion(char.id) === version.version && (
+                          <span className="shrink-0 rounded-full border border-[var(--c-panel-border)] px-2 py-1 ts-10">当前</span>
+                        )}
+                      </div>
+                      <div className="mt-3 rounded-lg bg-black/5 p-3 ts-11 dark:bg-white/5">
+                        <div className="font-semibold">{version.data.name || "未命名角色"}</div>
+                        <div className="mt-1 line-clamp-3 whitespace-pre-wrap opacity-65">
+                          {version.data.persona || version.data.personality || "（无角色设定）"}
+                        </div>
+                      </div>
+                      <div className="mt-3 flex gap-2">
+                        <button
+                          type="button"
+                          className="flex-1 rounded-lg bg-[var(--c-text)] px-3 py-2 ts-12 font-semibold text-[var(--c-page-body-bg)] disabled:opacity-40"
+                          disabled={getCharacterCurrentVersion(char.id) === version.version}
+                          onClick={() => setRestoreTarget(version)}
+                        >
+                          切换到 V{version.version}
+                        </button>
+                        <button
+                          type="button"
+                          className="rounded-lg border border-red-400/60 px-3 py-2 ts-12 text-red-600"
+                          onClick={() => setDeleteVersionTarget(version)}
+                        >
+                          删除
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {restoreTarget && (
+        <ConfirmDialog
+          title={`切换到 V${restoreTarget.version}？`}
+          message="当前角色卡会切换为该快照。切走前会同步保存当前版本，切换本身不会创建新版本号。"
+          icon={History}
+          confirmLabel="确认切换"
+          cancelLabel="取消"
+          onConfirm={() => {
+            const target = restoreTarget;
+            setRestoreTarget(null);
+            setShowVersions(false);
+            onRestoreVersion?.(target);
+          }}
+          onCancel={() => setRestoreTarget(null)}
+        />
+      )}
+
+      {deleteVersionTarget && (
+        <ConfirmDialog
+          title={`删除 V${deleteVersionTarget.version}？`}
+          message="此历史快照删除后无法恢复，不会删除当前角色卡。"
+          icon={AlertCircle}
+          variant="danger"
+          confirmLabel="删除版本"
+          cancelLabel="取消"
+          onConfirm={() => removeVersion(deleteVersionTarget)}
+          onCancel={() => setDeleteVersionTarget(null)}
+        />
+      )}
 
       {isEditing && showTimeZonePicker && (
         <div

--- a/lib/character-version-storage.ts
+++ b/lib/character-version-storage.ts
@@ -1,0 +1,158 @@
+import type { Character } from "./character-types";
+import { kvGet, kvSet, registerKvMigration } from "./kv-db";
+
+const STORAGE_KEY = "ai_phone_character_versions_v1";
+const MAX_VERSIONS_PER_CHARACTER = 30;
+registerKvMigration(STORAGE_KEY);
+
+export type CharacterVersionSource = "manual" | "mascot" | "restore" | "switch";
+
+export type CharacterVersion = {
+  id: string;
+  characterId: string;
+  version: number;
+  label: string;
+  createdAt: string;
+  source: CharacterVersionSource;
+  data: Character;
+};
+
+type CharacterVersionState = {
+  currentVersion: number;
+  versions: CharacterVersion[];
+};
+
+type CharacterVersionStore = Record<string, CharacterVersionState>;
+
+function cloneCharacter(character: Character): Character {
+  return JSON.parse(JSON.stringify(character)) as Character;
+}
+
+function loadStore(): CharacterVersionStore {
+  if (typeof window === "undefined") return {};
+  try {
+    const parsed = JSON.parse(kvGet(STORAGE_KEY) || "{}") as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as CharacterVersionStore
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveStore(store: CharacterVersionStore): void {
+  if (typeof window === "undefined") return;
+  kvSet(STORAGE_KEY, JSON.stringify(store));
+}
+
+function normalizeState(state?: CharacterVersionState): CharacterVersionState {
+  return {
+    currentVersion: Math.max(1, Number(state?.currentVersion) || 1),
+    versions: Array.isArray(state?.versions) ? state.versions : [],
+  };
+}
+
+export function getCharacterCurrentVersion(characterId: string): number {
+  return normalizeState(loadStore()[characterId]).currentVersion;
+}
+
+export function getCharacterNextVersion(characterId: string): number {
+  const state = normalizeState(loadStore()[characterId]);
+  return Math.max(state.currentVersion, ...state.versions.map(item => item.version)) + 1;
+}
+
+/**
+ * 覆盖当前版本：删除当前编号的旧快照，并将修改后的角色推进到历史最高编号之后。
+ */
+export function overwriteCharacterVersion(characterId: string): number {
+  const store = loadStore();
+  const state = normalizeState(store[characterId]);
+  const overwrittenVersion = state.currentVersion;
+  const highestVersion = Math.max(overwrittenVersion, ...state.versions.map(item => item.version));
+
+  state.versions = state.versions.filter(item => item.version !== overwrittenVersion);
+  state.currentVersion = highestVersion + 1;
+  store[characterId] = state;
+  saveStore(store);
+  return state.currentVersion;
+}
+
+export function loadCharacterVersions(characterId: string): CharacterVersion[] {
+  return [...normalizeState(loadStore()[characterId]).versions]
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+/** 保存修改前的完整角色卡，并返回修改完成后的当前版本号。 */
+export function backupCharacterVersion(
+  character: Character,
+  source: CharacterVersionSource,
+  label?: string,
+): number {
+  const store = loadStore();
+  const state = normalizeState(store[character.id]);
+  const snapshotVersion = state.currentVersion;
+  const snapshot: CharacterVersion = {
+    id: `charver_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    characterId: character.id,
+    version: snapshotVersion,
+    label: label?.trim() || (source === "mascot"
+      ? "小卷修改前自动备份"
+      : source === "restore"
+        ? "恢复版本前自动备份"
+        : "修改前备份"),
+    createdAt: new Date().toISOString(),
+    source,
+    data: cloneCharacter(character),
+  };
+
+  const highestVersion = Math.max(snapshotVersion, ...state.versions.map(item => item.version));
+  state.currentVersion = highestVersion + 1;
+  state.versions = [...state.versions.filter(item => item.version !== snapshotVersion), snapshot]
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+    .slice(-MAX_VERSIONS_PER_CHARACTER);
+  store[character.id] = state;
+  saveStore(store);
+  return state.currentVersion;
+}
+
+/** 切换版本不创建新编号；切走前同步当前编号快照，保证之后可以无损切回。 */
+export function switchCharacterVersion(character: Character, target: CharacterVersion): number {
+  const store = loadStore();
+  const state = normalizeState(store[character.id]);
+  const currentVersion = state.currentVersion;
+  if (currentVersion === target.version) return currentVersion;
+
+  const existingSnapshot = state.versions.find(item => item.version === currentVersion);
+  const currentSnapshot: CharacterVersion = {
+    id: existingSnapshot?.id || `charver_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    characterId: character.id,
+    version: currentVersion,
+    label: existingSnapshot?.label || "切换时保留",
+    createdAt: existingSnapshot?.createdAt || new Date().toISOString(),
+    source: existingSnapshot?.source || "switch",
+    data: cloneCharacter(character),
+  };
+
+  state.versions = [...state.versions.filter(item => item.version !== currentVersion), currentSnapshot]
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+    .slice(-MAX_VERSIONS_PER_CHARACTER);
+  state.currentVersion = target.version;
+  store[character.id] = state;
+  saveStore(store);
+  return state.currentVersion;
+}
+
+export function deleteCharacterVersion(characterId: string, versionId: string): void {
+  const store = loadStore();
+  const state = normalizeState(store[characterId]);
+  state.versions = state.versions.filter(version => version.id !== versionId);
+  store[characterId] = state;
+  saveStore(store);
+}
+
+export function clearCharacterVersions(characterId: string): void {
+  const store = loadStore();
+  if (!(characterId in store)) return;
+  delete store[characterId];
+  saveStore(store);
+}

--- a/lib/mascot-chat-store.ts
+++ b/lib/mascot-chat-store.ts
@@ -508,7 +508,12 @@ export async function sendMascotMessage({
     const controller = new AbortController();
     abortController = controller;
     let expandedPackageIds = loadExpandedPackages();
-    const toolCtx: MascotToolContext = { pageContext: context, history: workingMessages };
+    // 每次用户发送消息就是一次独立任务；最多 8 轮工具调用共享同一备份集合。
+    const toolCtx: MascotToolContext = {
+        pageContext: context,
+        history: workingMessages,
+        characterBackupIds: new Set<string>(),
+    };
 
     try {
         for (let round = 0; round < MAX_ROUNDS; round += 1) {
@@ -654,7 +659,9 @@ export async function sendMascotMessage({
                     publishMessages(workingMessages);
                     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
-                    const result = await executeMascotToolCall(call, { ...toolCtx, history: workingMessages });
+                    // 复用同一上下文，确保多轮工具调用共享角色备份状态。
+                    toolCtx.history = workingMessages;
+                    const result = await executeMascotToolCall(call, toolCtx);
                     if (result.success) mascotFillField({ field: call.name, value: result.data || "" });
 
                     const resultText = result.success ? (result.data || "完成") : (result.error || "未知错误");

--- a/lib/mascot-tools.ts
+++ b/lib/mascot-tools.ts
@@ -1028,6 +1028,8 @@ export function buildMascotNativeNameMap(): Map<string, string> {
 export type MascotToolContext = {
     pageContext: MascotPageContext;
     history?: CssAssetUserImageHistoryMessage[];
+    /** 同一条用户消息触发的整轮任务共享，用于保证每个角色只备份一次。 */
+    characterBackupIds?: Set<string>;
 };
 
 /** 执行小卷工具调用 */
@@ -1054,7 +1056,7 @@ export async function executeMascotToolCall(call: ToolCall, ctx: MascotToolConte
             // ─── 角色 ───
             case "读取角色": return await handleReadCharacter(call.args);
             case "创建角色": return await handleCreateCharacter(call.args);
-            case "更新角色字段": return await handleUpdateCharacterField(call.args);
+            case "更新角色字段": return await handleUpdateCharacterField(call.args, ctx);
 
             // ─── 角色世界（世界卷宗）───
             case "列出世界卷宗": return await handleListCharacterWorlds();
@@ -1529,8 +1531,9 @@ async function handleCreateCharacter(args: Record<string, unknown>): Promise<Too
     return { name: "创建角色", success: true, data: `已创建角色 ${newChar.name} (${newChar.id})${briefPersona ? "，含简量人设" : ""}` };
 }
 
-async function handleUpdateCharacterField(args: Record<string, unknown>): Promise<ToolResult> {
+async function handleUpdateCharacterField(args: Record<string, unknown>, ctx: MascotToolContext): Promise<ToolResult> {
     const { loadCharacters, saveCharacters } = await import("./character-storage");
+    const { backupCharacterVersion, getCharacterCurrentVersion } = await import("./character-version-storage");
     const chars = loadCharacters();
     const idx = chars.findIndex((c) => c.name === args.name);
     if (idx < 0) return { name: "更新角色字段", success: false, error: `找不到角色：${args.name}` };
@@ -1546,10 +1549,22 @@ async function handleUpdateCharacterField(args: Record<string, unknown>): Promis
     } else {
         return { name: "更新角色字段", success: false, error: `不支持的字段：${field}` };
     }
+    // 一条用户消息触发的整轮小卷任务中，同一角色只在第一次写入前备份。
+    const backupIds = ctx.characterBackupIds ?? (ctx.characterBackupIds = new Set<string>());
+    const didBackup = !backupIds.has(chars[idx].id);
+    const nextVersion = didBackup
+        ? backupCharacterVersion(chars[idx], "mascot", "小卷本次任务修改前自动备份")
+        : getCharacterCurrentVersion(chars[idx].id);
+    backupIds.add(chars[idx].id);
+
     char.updatedAt = now;
     chars[idx] = char as typeof chars[number];
     saveCharacters(chars);
-    return { name: "更新角色字段", success: true, data: `已更新 ${args.name} 的 ${field}` };
+    return {
+        name: "更新角色字段",
+        success: true,
+        data: `${didBackup ? "已为本次任务自动备份旧卡，并" : "本次任务已备份，继续"}更新 ${args.name} 的 ${field}；当前版本 V${nextVersion}`,
+    };
 }
 
 // ── Worldbook Handlers ──────────────────────────


### PR DESCRIPTION
贡献者：什锦杂货铺（小红书）（@huaxingdictionar-art）

## 功能说明

为角色卡增加版本历史管理，并为小卷修改角色卡提供强制自动备份：

- 每个角色最多保留 30 份历史版本，版本统一显示为 V1、V2、V3；
- 用户编辑已有角色卡时，可选择“备份旧卡并保存”或“覆盖当前版本”；
- 小卷每次执行修改角色卡的任务时，会在首次实际写入前强制备份当前旧版；同一条用户消息触发的整轮任务中，同一角色只备份一次，后续连续字段修改不重复生成备份；下一条用户消息会重新触发备份；
- 小卷和角色对角色卡内容的认知，只取决于用户当前在页面切换并生效的那一版角色卡；历史版本不会被同时读取或混入当前上下文；
- 支持查看、切换、删除单个历史版本及清空角色历史；
- 切换历史版本时保留角色 id 和原始 createdAt，并更新 updatedAt，不额外创建新版本；
- 删除角色时同步清除该角色的版本快照，但不清理聊天数据；
- 保留官方角色世界套件、briefPersona、关系成员校验和小卷多会话管理；
- 不包含版本重命名、Minimax #109 或其他私人 DIY。

## 文件范围

- components/phone-character-app.tsx
- lib/character-version-storage.ts
- lib/mascot-chat-store.ts
- lib/mascot-tools.ts

## 兼容说明

改动基于官方最新代码拼合；版本数据存储在浏览器本地，不修改既有角色卡与聊天数据结构。

## 署名

什锦杂货铺（小红书）

---
_经小手机「共同建设」通道提交_