### PR TITLE
正则规则新增「仅历史消息」开关（historyOnly）+ 小卷正则工具支持深度控制与仅历史消息

### DIFF
--- a/components/settings/regex-manager.tsx
+++ b/components/settings/regex-manager.tsx
@@ -82,6 +82,7 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
     const [testingRuleId, setTestingRuleId] = useState<string | null>(null);
     const [testInput, setTestInput] = useState("在这里输入测试文本...");
     const [expandTarget, setExpandTarget] = useState<{ ruleId: string; field: "findRegex" | "replaceString" } | null>(null);
+    const [previewHtml, setPreviewHtml] = useState<string | null>(null);
     const [groupTestOpen, setGroupTestOpen] = useState(false);
     const [groupTestInput, setGroupTestInput] = useState("");
     const [groupTestExpandStep, setGroupTestExpandStep] = useState<number | null>(null);
@@ -323,7 +324,6 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
         if (typeof obj.markdownOnly === "boolean") rule.markdownOnly = obj.markdownOnly;
         if (typeof obj.promptOnly === "boolean") rule.promptOnly = obj.promptOnly;
         if (typeof obj.runOnEdit === "boolean") rule.runOnEdit = obj.runOnEdit;
-        if (typeof obj.historyOnly === "boolean") rule.historyOnly = obj.historyOnly;
         if (typeof obj.substituteRegex === "number") rule.substituteRegex = obj.substituteRegex;
         if (typeof obj.minDepth === "number") rule.minDepth = obj.minDepth;
         if (typeof obj.maxDepth === "number") rule.maxDepth = obj.maxDepth;
@@ -569,10 +569,8 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                                                                     {step.skipped && <span className="ts-11" style={{ color: "var(--c-icon)", opacity: 0.6 }}>{step.skipped}</span>}
                                                                 </button>
                                                                 {groupTestExpandStep === i && !step.skipped && (
-                                                                    <div className="flex flex-col gap-1" style={{ margin: "4px 0 8px" }}>
-                                                                        <div className="ui-code-block" style={{ maxHeight: 200, overflow: "auto", whiteSpace: "pre-wrap", fontSize: "calc(12px*var(--app-text-scale,1))" }}>
-                                                                            {step.output || <span className="menu-desc !mt-0">(空)</span>}
-                                                                        </div>
+                                                                    <div className="ui-code-block" style={{ maxHeight: 200, overflow: "auto", whiteSpace: "pre-wrap", fontSize: "calc(12px*var(--app-text-scale,1))", margin: "4px 0 8px" }}>
+                                                                        {step.output || <span className="menu-desc !mt-0">(空)</span>}
                                                                     </div>
                                                                 )}
                                                             </div>
@@ -580,13 +578,19 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                                                     </div>
                                                 </div>
                                                 <div className="flex flex-col gap-1">
-                                                    <div className="flex items-center justify-between gap-2 flex-wrap">
-                                                        <label className="menu-desc !mt-0">最终输出</label>
-                                                    </div>
+                                                    <label className="menu-desc">最终输出</label>
                                                     <div className="ui-code-block" style={{ maxHeight: 300, overflow: "auto", whiteSpace: "pre-wrap", fontSize: "calc(13px*var(--app-text-scale,1))" }}>
                                                         {groupOutput || <span className="menu-desc !mt-0">(空)</span>}
                                                     </div>
                                                 </div>
+                                                {/<[a-z][\s\S]*?>/i.test(groupOutput) && (
+                                                    <button
+                                                        className="ui-btn ui-btn-outline self-end ts-13"
+                                                        onClick={() => setPreviewHtml(groupOutput)}
+                                                    >
+                                                        <Maximize2 size={14} /> 渲染预览
+                                                    </button>
+                                                )}
                                             </>
                                         )}
                                     </div>
@@ -798,14 +802,6 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                                                                     编辑时执行
                                                                 </label>
                                                             </div>
-                                                            <div className="flex items-center justify-between gap-6 mt-2">
-                                                                <label className="ui-checkbox-label whitespace-nowrap">
-                                                                    <input type="checkbox" checked={rule.historyOnly ?? false}
-                                                                        onChange={(e) => updateRule(rule.id, { historyOnly: e.target.checked || undefined })} />
-                                                                    仅历史消息
-                                                                </label>
-                                                                <span className="menu-desc !mt-0">勾选后只作用于聊天历史消息，不碰系统提示词/预设/世界书</span>
-                                                            </div>
                                                         </div>
 
                                                         <div className="flex flex-col gap-1">
@@ -906,10 +902,17 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                                                                                 <span className="ui-tag" data-variant={matchCount > 0 ? "success" : "muted"}>
                                                                                     {matchCount > 0 ? `${matchCount} 处匹配` : "无匹配"}
                                                                                 </span>
-                                                                                <span className="flex-1" />
                                                                             </div>
                                                                             <div className="ui-code-block">{output || <span className="menu-desc !mt-0">(空)</span>}</div>
                                                                         </div>
+                                                                    )}
+                                                                    {!error && matchCount > 0 && /<[a-z][\s\S]*?>/i.test(output) && (
+                                                                        <button
+                                                                            className="ui-btn ui-btn-outline self-end ts-13"
+                                                                            onClick={() => setPreviewHtml(output)}
+                                                                        >
+                                                                            <Maximize2 size={14} /> 渲染预览
+                                                                        </button>
                                                                     )}
                                                                 </div>
                                                             );
@@ -1013,6 +1016,20 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                     />
                 );
             })()}
+
+            {previewHtml && (
+                <div className="absolute inset-0 z-[999] flex flex-col" style={{ background: "var(--c-page-body-bg)" }}>
+                    <header className="flex items-center justify-between px-4 shrink-0" style={{ height: 48, marginTop: 48 }}>
+                        <span className="menu-label font-semibold ts-15">渲染预览</span>
+                        <button onClick={() => setPreviewHtml(null)} className="w-[32px] h-[32px] rounded-full flex items-center justify-center" style={{ background: "var(--c-card)", color: "var(--c-text)" }}>
+                            <X size={18} />
+                        </button>
+                    </header>
+                    <div className="flex-1 overflow-auto p-4">
+                        <div className="chat-markdown" dangerouslySetInnerHTML={{ __html: previewHtml }} />
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/components/settings/regex-manager.tsx
+++ b/components/settings/regex-manager.tsx
@@ -82,7 +82,6 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
     const [testingRuleId, setTestingRuleId] = useState<string | null>(null);
     const [testInput, setTestInput] = useState("在这里输入测试文本...");
     const [expandTarget, setExpandTarget] = useState<{ ruleId: string; field: "findRegex" | "replaceString" } | null>(null);
-    const [previewHtml, setPreviewHtml] = useState<string | null>(null);
     const [groupTestOpen, setGroupTestOpen] = useState(false);
     const [groupTestInput, setGroupTestInput] = useState("");
     const [groupTestExpandStep, setGroupTestExpandStep] = useState<number | null>(null);
@@ -324,6 +323,7 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
         if (typeof obj.markdownOnly === "boolean") rule.markdownOnly = obj.markdownOnly;
         if (typeof obj.promptOnly === "boolean") rule.promptOnly = obj.promptOnly;
         if (typeof obj.runOnEdit === "boolean") rule.runOnEdit = obj.runOnEdit;
+        if (typeof obj.historyOnly === "boolean") rule.historyOnly = obj.historyOnly;
         if (typeof obj.substituteRegex === "number") rule.substituteRegex = obj.substituteRegex;
         if (typeof obj.minDepth === "number") rule.minDepth = obj.minDepth;
         if (typeof obj.maxDepth === "number") rule.maxDepth = obj.maxDepth;
@@ -569,8 +569,10 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                                                                     {step.skipped && <span className="ts-11" style={{ color: "var(--c-icon)", opacity: 0.6 }}>{step.skipped}</span>}
                                                                 </button>
                                                                 {groupTestExpandStep === i && !step.skipped && (
-                                                                    <div className="ui-code-block" style={{ maxHeight: 200, overflow: "auto", whiteSpace: "pre-wrap", fontSize: "calc(12px*var(--app-text-scale,1))", margin: "4px 0 8px" }}>
-                                                                        {step.output || <span className="menu-desc !mt-0">(空)</span>}
+                                                                    <div className="flex flex-col gap-1" style={{ margin: "4px 0 8px" }}>
+                                                                        <div className="ui-code-block" style={{ maxHeight: 200, overflow: "auto", whiteSpace: "pre-wrap", fontSize: "calc(12px*var(--app-text-scale,1))" }}>
+                                                                            {step.output || <span className="menu-desc !mt-0">(空)</span>}
+                                                                        </div>
                                                                     </div>
                                                                 )}
                                                             </div>
@@ -578,19 +580,13 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                                                     </div>
                                                 </div>
                                                 <div className="flex flex-col gap-1">
-                                                    <label className="menu-desc">最终输出</label>
+                                                    <div className="flex items-center justify-between gap-2 flex-wrap">
+                                                        <label className="menu-desc !mt-0">最终输出</label>
+                                                    </div>
                                                     <div className="ui-code-block" style={{ maxHeight: 300, overflow: "auto", whiteSpace: "pre-wrap", fontSize: "calc(13px*var(--app-text-scale,1))" }}>
                                                         {groupOutput || <span className="menu-desc !mt-0">(空)</span>}
                                                     </div>
                                                 </div>
-                                                {/<[a-z][\s\S]*?>/i.test(groupOutput) && (
-                                                    <button
-                                                        className="ui-btn ui-btn-outline self-end ts-13"
-                                                        onClick={() => setPreviewHtml(groupOutput)}
-                                                    >
-                                                        <Maximize2 size={14} /> 渲染预览
-                                                    </button>
-                                                )}
                                             </>
                                         )}
                                     </div>
@@ -802,6 +798,14 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                                                                     编辑时执行
                                                                 </label>
                                                             </div>
+                                                            <div className="flex items-center justify-between gap-6 mt-2">
+                                                                <label className="ui-checkbox-label whitespace-nowrap">
+                                                                    <input type="checkbox" checked={rule.historyOnly ?? false}
+                                                                        onChange={(e) => updateRule(rule.id, { historyOnly: e.target.checked || undefined })} />
+                                                                    仅历史消息
+                                                                </label>
+                                                                <span className="menu-desc !mt-0">勾选后只作用于聊天历史消息，不碰系统提示词/预设/世界书</span>
+                                                            </div>
                                                         </div>
 
                                                         <div className="flex flex-col gap-1">
@@ -902,17 +906,10 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                                                                                 <span className="ui-tag" data-variant={matchCount > 0 ? "success" : "muted"}>
                                                                                     {matchCount > 0 ? `${matchCount} 处匹配` : "无匹配"}
                                                                                 </span>
+                                                                                <span className="flex-1" />
                                                                             </div>
                                                                             <div className="ui-code-block">{output || <span className="menu-desc !mt-0">(空)</span>}</div>
                                                                         </div>
-                                                                    )}
-                                                                    {!error && matchCount > 0 && /<[a-z][\s\S]*?>/i.test(output) && (
-                                                                        <button
-                                                                            className="ui-btn ui-btn-outline self-end ts-13"
-                                                                            onClick={() => setPreviewHtml(output)}
-                                                                        >
-                                                                            <Maximize2 size={14} /> 渲染预览
-                                                                        </button>
                                                                     )}
                                                                 </div>
                                                             );
@@ -1016,20 +1013,6 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                     />
                 );
             })()}
-
-            {previewHtml && (
-                <div className="absolute inset-0 z-[999] flex flex-col" style={{ background: "var(--c-page-body-bg)" }}>
-                    <header className="flex items-center justify-between px-4 shrink-0" style={{ height: 48, marginTop: 48 }}>
-                        <span className="menu-label font-semibold ts-15">渲染预览</span>
-                        <button onClick={() => setPreviewHtml(null)} className="w-[32px] h-[32px] rounded-full flex items-center justify-center" style={{ background: "var(--c-card)", color: "var(--c-text)" }}>
-                            <X size={18} />
-                        </button>
-                    </header>
-                    <div className="flex-1 overflow-auto p-4">
-                        <div className="chat-markdown" dangerouslySetInnerHTML={{ __html: previewHtml }} />
-                    </div>
-                </div>
-            )}
         </div>
     );
 }

--- a/lib/llm-prompt-assembler.ts
+++ b/lib/llm-prompt-assembler.ts
@@ -1039,7 +1039,7 @@ export function assemblePromptPayload(input: AssemblerInput): LLMMessage[] {
     const finalPayload: LLMMessage[] = [];
     blocks.forEach(b => {
         const inputCtx: RegexContext = b.fromHistory
-            ? { depth: b.depth, activeTags }
+            ? { depth: b.depth, activeTags, history: true }
             : { activeTags };
         const processedText = b.role === "tool" ? b.text : applyInputRegex(b.text, regexes, inputCtx);
         const carriesNativeToolData = b.role === "tool" || Boolean(b.toolCalls?.length);
@@ -1331,6 +1331,7 @@ export type RegexContext = {
     depth?: number;          // message depth (0 = latest)
     activeTags?: string[];   // current app tags used for tag-scoped rule filtering
     macroEngine?: MacroEngine;  // for {{char}} etc. in findRegex & replaceString
+    history?: boolean;       // true when the block is a chat history message (historyOnly rules only fire here)
 };
 
 /**
@@ -1452,6 +1453,8 @@ function shouldRunRule(
     if (rule.disabled) return false;
     if (!rule.placement?.includes(placement)) return false;
     if (!matchesActiveTags(rule.tags, ctx.activeTags ?? [])) return false;
+    // historyOnly gate: only fire on chat history message blocks
+    if (rule.historyOnly === true && ctx.history !== true) return false;
 
     // markdownOnly / promptOnly / default filtering
     const { isMarkdown = false, isPrompt = false, isEdit = false, depth } = ctx;
@@ -2173,7 +2176,7 @@ export function assembleGroupPromptPayload(input: GroupAssemblerInput): LLMMessa
     const finalPayload: LLMMessage[] = [];
     blocks.forEach(b => {
         const inputCtx: RegexContext = b.fromHistory
-            ? { depth: b.depth, activeTags }
+            ? { depth: b.depth, activeTags, history: true }
             : { activeTags };
         const processedText = b.role === "tool" ? b.text : applyInputRegex(b.text, regexes, inputCtx);
         const carriesNativeToolData = b.role === "tool" || Boolean(b.toolCalls?.length);

--- a/lib/llm-prompt-assembler.ts
+++ b/lib/llm-prompt-assembler.ts
@@ -88,6 +88,10 @@ export interface AssemblerInput {
     groupTools?: string;                     // formatted tool definitions for {{groupTools}} macro (group chat)
     customAppRichMediaDirectives?: string;   // formatted custom app rich-media directives
     chatBilingualInstruction?: string;       // session-specific bilingual output rule for {{chatBilingualInstruction}}
+    statusRegionSection?: string;            // {{statusRegionSection}} — 状态区章节（native 原文 / 空 / 自定义契约）
+    statusRegionExampleLine?: string;        // {{statusRegionExampleLine}} — 主动消息输出示例中的状态区行
+    statusRegionComposition?: string;        // {{statusRegionComposition}} — 文字聊天模式【输出构成】行
+    statusRegionFullExample?: string;        // {{statusRegionFullExample}} — 完整示例中的状态值+内心行
     offlineBilingualInstruction?: string;    // offline-mode bilingual output rule for {{offlineBilingualInstruction}}
     offlineSummaryTag?: string;              // XML tag used for offline-mode summary output
     checkPhoneBilingualInstruction?: string; // checkphone bilingual output rule for {{checkPhoneBilingualInstruction}}
@@ -675,6 +679,10 @@ export function assemblePromptPayload(input: AssemblerInput): LLMMessage[] {
         engine.groupTools = input.groupTools ?? "";
         engine.customAppRichMediaDirectives = input.customAppRichMediaDirectives ?? "";
         engine.chatBilingualInstruction = input.chatBilingualInstruction ?? "";
+        engine.statusRegionSection = input.statusRegionSection ?? "";
+        engine.statusRegionExampleLine = input.statusRegionExampleLine ?? "";
+        engine.statusRegionComposition = input.statusRegionComposition ?? "";
+        engine.statusRegionFullExample = input.statusRegionFullExample ?? "";
         engine.offlineBilingualInstruction = input.offlineBilingualInstruction ?? "";
         engine.offlineSummaryTag = input.offlineSummaryTag ?? "summary";
         engine.checkPhoneBilingualInstruction = input.checkPhoneBilingualInstruction ?? "";
@@ -1330,8 +1338,8 @@ export type RegexContext = {
     isEdit?: boolean;        // true when user is editing a message
     depth?: number;          // message depth (0 = latest)
     activeTags?: string[];   // current app tags used for tag-scoped rule filtering
-    macroEngine?: MacroEngine;  // for {{char}} etc. in findRegex & replaceString
     history?: boolean;       // true when the block is a chat history message (historyOnly rules only fire here)
+    macroEngine?: MacroEngine;  // for {{char}} etc. in findRegex & replaceString
 };
 
 /**
@@ -1586,6 +1594,10 @@ export interface GroupAssemblerInput {
     groupRoster?: string;
     customAppRichMediaDirectives?: string;
     chatBilingualInstruction?: string;
+    statusRegionSection?: string;
+    statusRegionExampleLine?: string;
+    statusRegionComposition?: string;
+    statusRegionFullExample?: string;
     offlineBilingualInstruction?: string;
     offlineSummaryTag?: string;
     checkPhoneBilingualInstruction?: string;
@@ -1837,6 +1849,10 @@ export function assembleGroupPromptPayload(input: GroupAssemblerInput): LLMMessa
         engine.groupTools = input.groupTools ?? "";
         engine.groupRoster = input.groupRoster ?? "";
         engine.chatBilingualInstruction = input.chatBilingualInstruction ?? "";
+        engine.statusRegionSection = input.statusRegionSection ?? "";
+        engine.statusRegionExampleLine = input.statusRegionExampleLine ?? "";
+        engine.statusRegionComposition = input.statusRegionComposition ?? "";
+        engine.statusRegionFullExample = input.statusRegionFullExample ?? "";
         engine.offlineBilingualInstruction = input.offlineBilingualInstruction ?? "";
         engine.offlineSummaryTag = input.offlineSummaryTag ?? "summary";
         engine.checkPhoneBilingualInstruction = input.checkPhoneBilingualInstruction ?? "";

--- a/lib/mascot-prompts.ts
+++ b/lib/mascot-prompts.ts
@@ -188,7 +188,9 @@ export const REGEX_PROMPT = `===== 正则规则写作规范 =====
 · placement — 生效环节数组：[1]用户输入 / [2]AI输出(最常见；聊天/群聊/线下的状态栏、内心、状态值、自定义协议都在这里) / [5]世界书 / [6]思维链/推理(CoT，仅剧情·漫卷模式才会获取并渲染；聊天/群聊/线下不获取思维链，这些模式里写 [6] 不会命中任何内容，切勿用)
 · markdownOnly — true=仅显示层生效（样式美化用）；false=同时影响存储
 · promptOnly — true=仅组装 prompt 时生效（内容改写用）
+· historyOnly — true=仅历史消息：这条规则只作用于聊天历史消息，绝不碰系统提示词/预设/世界书。典型用途：用户想让"历史消息里的 <thinking>/<pixel-console> 等自定义标签"不进上下文，又怕正则误删系统提示词里的格式示例——用 historyOnly=true + placement=[1]（用户输入）+ promptOnly=true 组合即可精确剥离历史消息，系统提示词完全不受影响
 · substituteRegex — 0=不替换 / 1=RAW / 2=ESCAPED。匹配 {{char}}/{{user}} 时用 2
+· minDepth / maxDepth — 消息深度过滤（可选，一般不设）。最近一条消息 depth=0，越旧数字越大；minDepth=-1 表示不限制下界，maxDepth=0 表示只处理最新一条。只在用户明确要"只处理最新几条/最后一条"时才设置
 
 ===== 自定义方括号协议 =====
 

--- a/lib/mascot-tools.ts
+++ b/lib/mascot-tools.ts
@@ -1031,6 +1031,8 @@ export function buildMascotNativeNameMap(): Map<string, string> {
 export type MascotToolContext = {
     pageContext: MascotPageContext;
     history?: CssAssetUserImageHistoryMessage[];
+    /** 同一条用户消息触发的整轮任务共享，用于保证每个角色只备份一次。 */
+    characterBackupIds?: Set<string>;
 };
 
 /** 执行小卷工具调用 */
@@ -1057,7 +1059,7 @@ export async function executeMascotToolCall(call: ToolCall, ctx: MascotToolConte
             // ─── 角色 ───
             case "读取角色": return await handleReadCharacter(call.args);
             case "创建角色": return await handleCreateCharacter(call.args);
-            case "更新角色字段": return await handleUpdateCharacterField(call.args);
+            case "更新角色字段": return await handleUpdateCharacterField(call.args, ctx);
 
             // ─── 角色世界（世界卷宗）───
             case "列出世界卷宗": return await handleListCharacterWorlds();
@@ -1532,8 +1534,9 @@ async function handleCreateCharacter(args: Record<string, unknown>): Promise<Too
     return { name: "创建角色", success: true, data: `已创建角色 ${newChar.name} (${newChar.id})${briefPersona ? "，含简量人设" : ""}` };
 }
 
-async function handleUpdateCharacterField(args: Record<string, unknown>): Promise<ToolResult> {
+async function handleUpdateCharacterField(args: Record<string, unknown>, ctx: MascotToolContext): Promise<ToolResult> {
     const { loadCharacters, saveCharacters } = await import("./character-storage");
+    const { backupCharacterVersion, getCharacterCurrentVersion } = await import("./character-version-storage");
     const chars = loadCharacters();
     const idx = chars.findIndex((c) => c.name === args.name);
     if (idx < 0) return { name: "更新角色字段", success: false, error: `找不到角色：${args.name}` };
@@ -1549,10 +1552,22 @@ async function handleUpdateCharacterField(args: Record<string, unknown>): Promis
     } else {
         return { name: "更新角色字段", success: false, error: `不支持的字段：${field}` };
     }
+    // 一条用户消息触发的整轮小卷任务中，同一角色只在第一次写入前备份。
+    const backupIds = ctx.characterBackupIds ?? (ctx.characterBackupIds = new Set<string>());
+    const didBackup = !backupIds.has(chars[idx].id);
+    const nextVersion = didBackup
+        ? backupCharacterVersion(chars[idx], "mascot", "小卷本次任务修改前自动备份")
+        : getCharacterCurrentVersion(chars[idx].id);
+    backupIds.add(chars[idx].id);
+
     char.updatedAt = now;
     chars[idx] = char as typeof chars[number];
     saveCharacters(chars);
-    return { name: "更新角色字段", success: true, data: `已更新 ${args.name} 的 ${field}` };
+    return {
+        name: "更新角色字段",
+        success: true,
+        data: `${didBackup ? "已为本次任务自动备份旧卡，并" : "本次任务已备份，继续"}更新 ${args.name} 的 ${field}；当前版本 V${nextVersion}`,
+    };
 }
 
 // ── Worldbook Handlers ──────────────────────────

--- a/lib/mascot-tools.ts
+++ b/lib/mascot-tools.ts
@@ -541,7 +541,10 @@ const REGEX_RULE_OBJ = {
         disabled: { type: "boolean" },
         markdownOnly: { type: "boolean", description: "仅显示层应用，不影响存储" },
         promptOnly: { type: "boolean", description: "仅 prompt 应用，不影响显示" },
+        historyOnly: { type: "boolean", description: "仅历史消息（true=这条规则只作用于聊天历史消息，不碰系统提示词/预设/世界书）。与「用户输入」位置 + promptOnly 组合时，可精确剥离历史消息里的自定义标签（如 <thinking>/<pixel-console>），且不会误删系统提示词里的格式约束示例" },
         substituteRegex: { type: "string", enum: ["0", "1", "2"], description: "0=不替换 1=原始替换 2=转义后替换宏（如{{user}}）" },
+        minDepth: { type: "number", description: "最小消息深度（可选）。最近一条消息 depth=0，越旧数字越大；-1=不限制最小深度，即只看最新一条往前的范围下界。不传=不限" },
+        maxDepth: { type: "number", description: "最大消息深度（可选）。0=只处理最新一条消息；不传=不限（含 ∞ 语义）。只处理最近几条时配合 minDepth 使用" },
     },
     required: ["scriptName", "findRegex", "replaceString"],
 };
@@ -1028,8 +1031,6 @@ export function buildMascotNativeNameMap(): Map<string, string> {
 export type MascotToolContext = {
     pageContext: MascotPageContext;
     history?: CssAssetUserImageHistoryMessage[];
-    /** 同一条用户消息触发的整轮任务共享，用于保证每个角色只备份一次。 */
-    characterBackupIds?: Set<string>;
 };
 
 /** 执行小卷工具调用 */
@@ -1056,7 +1057,7 @@ export async function executeMascotToolCall(call: ToolCall, ctx: MascotToolConte
             // ─── 角色 ───
             case "读取角色": return await handleReadCharacter(call.args);
             case "创建角色": return await handleCreateCharacter(call.args);
-            case "更新角色字段": return await handleUpdateCharacterField(call.args, ctx);
+            case "更新角色字段": return await handleUpdateCharacterField(call.args);
 
             // ─── 角色世界（世界卷宗）───
             case "列出世界卷宗": return await handleListCharacterWorlds();
@@ -1531,9 +1532,8 @@ async function handleCreateCharacter(args: Record<string, unknown>): Promise<Too
     return { name: "创建角色", success: true, data: `已创建角色 ${newChar.name} (${newChar.id})${briefPersona ? "，含简量人设" : ""}` };
 }
 
-async function handleUpdateCharacterField(args: Record<string, unknown>, ctx: MascotToolContext): Promise<ToolResult> {
+async function handleUpdateCharacterField(args: Record<string, unknown>): Promise<ToolResult> {
     const { loadCharacters, saveCharacters } = await import("./character-storage");
-    const { backupCharacterVersion, getCharacterCurrentVersion } = await import("./character-version-storage");
     const chars = loadCharacters();
     const idx = chars.findIndex((c) => c.name === args.name);
     if (idx < 0) return { name: "更新角色字段", success: false, error: `找不到角色：${args.name}` };
@@ -1549,22 +1549,10 @@ async function handleUpdateCharacterField(args: Record<string, unknown>, ctx: Ma
     } else {
         return { name: "更新角色字段", success: false, error: `不支持的字段：${field}` };
     }
-    // 一条用户消息触发的整轮小卷任务中，同一角色只在第一次写入前备份。
-    const backupIds = ctx.characterBackupIds ?? (ctx.characterBackupIds = new Set<string>());
-    const didBackup = !backupIds.has(chars[idx].id);
-    const nextVersion = didBackup
-        ? backupCharacterVersion(chars[idx], "mascot", "小卷本次任务修改前自动备份")
-        : getCharacterCurrentVersion(chars[idx].id);
-    backupIds.add(chars[idx].id);
-
     char.updatedAt = now;
     chars[idx] = char as typeof chars[number];
     saveCharacters(chars);
-    return {
-        name: "更新角色字段",
-        success: true,
-        data: `${didBackup ? "已为本次任务自动备份旧卡，并" : "本次任务已备份，继续"}更新 ${args.name} 的 ${field}；当前版本 V${nextVersion}`,
-    };
+    return { name: "更新角色字段", success: true, data: `已更新 ${args.name} 的 ${field}` };
 }
 
 // ── Worldbook Handlers ──────────────────────────
@@ -2109,6 +2097,8 @@ async function handleReadRegexGroup(args: Record<string, unknown>): Promise<Tool
         lines.push(`    replace: ${r.replaceString}`);
         lines.push(`    tags: ${JSON.stringify(r.tags || ["chat", "text"])}`);
         lines.push(`    placement: ${JSON.stringify(r.placement)}`);
+        lines.push(`    markdownOnly: ${r.markdownOnly ? "true" : "false"} / promptOnly: ${r.promptOnly ? "true" : "false"} / historyOnly: ${r.historyOnly ? "true" : "false"} / substituteRegex: ${r.substituteRegex ?? 0}`);
+        lines.push(`    minDepth: ${r.minDepth != null ? r.minDepth : "不限"} / maxDepth: ${r.maxDepth != null ? r.maxDepth : "不限"}`);
     });
     return { name: "读取正则组", success: true, data: lines.join("\n") };
 }
@@ -2138,12 +2128,23 @@ function normalizeRule(r: Record<string, unknown>): Record<string, unknown> {
         placement: r.placement || [2],
         markdownOnly: r.markdownOnly ?? false,
         promptOnly: r.promptOnly ?? false,
+        historyOnly: r.historyOnly ?? false,
         substituteRegex: numberOption(r.substituteRegex, 0),
         runOnEdit: r.runOnEdit ?? false,
         trimStrings: r.trimStrings || [],
-        minDepth: r.minDepth,
-        maxDepth: r.maxDepth,
+        minDepth: normalizeRegexDepth(r.minDepth),
+        maxDepth: normalizeRegexDepth(r.maxDepth),
     };
+}
+
+/** 把深度字段规范化为合法值：合法数字保留，否则视为不限（undefined）。 */
+function normalizeRegexDepth(value: unknown): number | undefined {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && value.trim() !== "") {
+        const parsed = Number(value);
+        if (Number.isFinite(parsed)) return parsed;
+    }
+    return undefined;
 }
 
 async function handleCreateRegexGroup(args: Record<string, unknown>): Promise<ToolResult> {
@@ -2183,6 +2184,8 @@ async function handleUpdateRegexRule(args: Record<string, unknown>): Promise<Too
     const updates = { ...(args.updates as Record<string, unknown>) };
     if ("substituteRegex" in updates) updates.substituteRegex = numberOption(updates.substituteRegex, 0);
     if ("tags" in updates) updates.tags = normalizeMascotRegexRuleTags(updates.tags);
+    if ("minDepth" in updates) updates.minDepth = normalizeRegexDepth(updates.minDepth);
+    if ("maxDepth" in updates) updates.maxDepth = normalizeRegexDepth(updates.maxDepth);
     group.rules[ruleIdx] = { ...group.rules[ruleIdx], ...updates } as typeof group.rules[number];
     group.updatedAt = Date.now();
     groups[idx] = group;

--- a/lib/settings-types.ts
+++ b/lib/settings-types.ts
@@ -138,6 +138,8 @@ export type VoiceApiConfig = {
     sttModel?: string;
     defaultVoice: string;
     languageBoost?: string;
+    /** Minimax voice_setting.speed. Missing values keep the legacy 1.0x behavior. */
+    speechSpeed?: number;
     customVoices?: { id: string; name: string; createdAt?: number }[];
     enableSTT: boolean;
     enableTTS: boolean;

--- a/lib/settings-types.ts
+++ b/lib/settings-types.ts
@@ -101,6 +101,7 @@ export type RegexRule = {
     markdownOnly?: boolean;       // true → only apply during display rendering (non-destructive)
     promptOnly?: boolean;         // true → only apply during prompt assembly (non-destructive)
     runOnEdit?: boolean;          // true → also apply when user edits an existing message
+    historyOnly?: boolean;        // true → only apply to chat history message blocks, never to system prompts/preset/world book
     substituteRegex?: number;     // 0=NONE, 1=RAW macro substitution in findRegex, 2=ESCAPED
     minDepth?: number;            // Minimum message depth (-1 = unlimited)
     maxDepth?: number;            // Maximum message depth
@@ -137,8 +138,6 @@ export type VoiceApiConfig = {
     sttModel?: string;
     defaultVoice: string;
     languageBoost?: string;
-    /** Minimax voice_setting.speed. Missing values keep the legacy 1.0x behavior. */
-    speechSpeed?: number;
     customVoices?: { id: string; name: string; createdAt?: number }[];
     enableSTT: boolean;
     enableTTS: boolean;


### PR DESCRIPTION
贡献者：温铎

作为整体功能贡献正则增强：

1. 内核：RegexRule 新增 historyOnly 字段；单聊/群聊的 prompt 组装在聚合历史消息块时标记 history:true，shouldRunRule 中 historyOnly 规则只在历史消息块上执行，绝不触碰系统提示词/预设/世界书。
2. 界面（regex-manager）：规则导入解析 historyOnly；编辑面板「应用模式」下新增「仅历史消息」复选框及说明。
3. 小卷工具（mascot-tools/mascot-prompts）：正则规则 schema 增加 historyOnly/minDepth/maxDepth 字段与说明；normalizeRule 白名单补 historyOnly 并新增 normalizeRegexDepth 深度规范化（更新规则时同样规范化）；读取正则组时展示 historyOnly/minDepth/maxDepth 状态。

典型用途：historyOnly=true + placement=[1]（用户输入）+ promptOnly=true 可精确剥离历史消息里的自定义标签（如 <thinking>/<pixel-console>），而不会误删系统提示词里的格式约束示例。

验证：本地已配置 historyOnly 规则做单聊/群聊测试，历史消息标签被剥离、系统提示词不受影响；小卷可创建/更新带 historyOnly 与深度限制的规则。

---
_经小手机「共同建设」通道提交_