### PR TITLE
正则界面复制与 iframe 预览优化 + 小坊聊天复制/编辑 + 正则 historyOnly 标记

### DIFF
--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode, type TouchEvent } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
@@ -34,6 +34,7 @@ import {
   stopQaGeneration,
   subscribeQaChat,
   switchQaSession,
+  updateQaMessageContent,
   type QaMsg,
   type QaSession,
   type QaToolStatus,
@@ -273,8 +274,90 @@ function QaStreamingText({ text }: { text: string }) {
   );
 }
 
-function QaMessageItem({ msg, isStreaming, onRetry, onViewImage }: { msg: QaMsg; isStreaming: boolean; onRetry: (id: string) => void; onViewImage: (url: string) => void }) {
+function QaMessageItem({
+  msg,
+  isStreaming,
+  onRetry,
+  onViewImage,
+  onCopy,
+  onEdit,
+}: {
+  msg: QaMsg;
+  isStreaming: boolean;
+  onRetry: (id: string) => void;
+  onViewImage: (url: string) => void;
+  onCopy: (content: string) => void;
+  onEdit: (msg: QaMsg) => void;
+}) {
   const thinkingOnly = isStreaming && !msg.content && (!msg.tools || msg.tools.length === 0);
+  // 长按 / 右键弹出消息操作菜单：复制（复制原始内容）、编辑（编辑框展示未渲染的原始内容，
+  // 因为前端渲染会吞掉一些特殊标签，沟通时看不到原始内容）。
+  // 菜单出现在「手指长按的位置」，而不是固定在气泡右上角，方便单手操作。
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const pressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelPress = useCallback(() => {
+    if (pressTimer.current) {
+      clearTimeout(pressTimer.current);
+      pressTimer.current = null;
+    }
+  }, []);
+  const startPress = useCallback((e: TouchEvent) => {
+    cancelPress();
+    const touch = e.touches?.[0];
+    if (!touch) return;
+    const x = touch.clientX;
+    const y = touch.clientY;
+    pressTimer.current = setTimeout(() => setMenu({ x, y }), 500);
+  }, [cancelPress]);
+  // 菜单尺寸（用于边缘防溢出翻转）
+  const MENU_W = 150;
+  const MENU_H = 56;
+  const menuStyle = menu
+    ? {
+        left: menu.x + MENU_W > window.innerWidth ? Math.max(8, menu.x - MENU_W) : menu.x,
+        top: menu.y + MENU_H > window.innerHeight ? Math.max(8, menu.y - MENU_H) : menu.y,
+      }
+    : undefined;
+  const msgWrap = (node: ReactNode) => (
+    <div
+      className="qa-msg-wrap"
+      onContextMenu={(e) => {
+        e.preventDefault();
+        setMenu({ x: e.clientX, y: e.clientY });
+      }}
+      onTouchStart={startPress}
+      onTouchEnd={cancelPress}
+      onTouchMove={() => {
+        cancelPress();
+        setMenu(null);
+      }}
+      onTouchCancel={cancelPress}
+    >
+      {node}
+      {menu && (
+        <div className="qa-msg-menu" role="menu" style={menuStyle} onPointerDown={(e) => e.stopPropagation()}>
+          <button
+            type="button"
+            onClick={() => {
+              onCopy(msg.content);
+              setMenu(null);
+            }}
+          >
+            复制
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              onEdit(msg);
+              setMenu(null);
+            }}
+          >
+            编辑
+          </button>
+        </div>
+      )}
+    </div>
+  );
   // 时序分段渲染：文字与工具行按实际发生顺序交错（连续工具行合并成一组）；
   // 旧消息没有 segments 时回退「工具在顶、文字在下」布局。
   // hooks 必须在 user 分支 early-return 之前调用（rules-of-hooks）
@@ -295,7 +378,7 @@ function QaMessageItem({ msg, isStreaming, onRetry, onViewImage }: { msg: QaMsg;
   }, [msg.segments]);
 
   if (msg.role === "user") {
-    return (
+    return msgWrap(
       <div className="qa-msg-user-row">
         <div className="qa-msg-user">
           {msg.images && msg.images.length > 0 && (
@@ -309,11 +392,11 @@ function QaMessageItem({ msg, isStreaming, onRetry, onViewImage }: { msg: QaMsg;
           )}
           {msg.content}
         </div>
-      </div>
+      </div>,
     );
   }
 
-  return (
+  return msgWrap(
     <div className="qa-msg-assistant">
       {segmentBlocks ? (
         segmentBlocks.map((block, i) =>
@@ -369,7 +452,7 @@ function QaMessageItem({ msg, isStreaming, onRetry, onViewImage }: { msg: QaMsg;
           </button>
         </div>
       )}
-    </div>
+    </div>,
   );
 }
 
@@ -699,6 +782,8 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [pendingImages, setPendingImages] = useState<string[]>([]);
   const [viewerImage, setViewerImage] = useState<string | null>(null);
+  const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
+  const [editText, setEditText] = useState("");
   const [visionEnabled, setVisionEnabled] = useState(false);
   const imageInputRef = useRef<HTMLInputElement | null>(null);
   const [apiReady, setApiReady] = useState(true);
@@ -821,6 +906,25 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
     void retryQaMessage(assistantMsgId);
   }, []);
 
+  const handleCopyMessage = useCallback((content: string) => {
+    void navigator.clipboard?.writeText(content).then(
+      () => onNotice?.("已复制原始内容"),
+      () => onNotice?.("复制失败"),
+    );
+  }, [onNotice]);
+
+  const handleEditMessage = useCallback((msg: QaMsg) => {
+    setEditingMsg(msg);
+    setEditText(msg.content);
+  }, []);
+
+  const handleSaveEdit = useCallback(() => {
+    if (!editingMsg || !snapshot.activeSessionId) return;
+    updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText);
+    setEditingMsg(null);
+    onNotice?.("已保存消息内容");
+  }, [editingMsg, editText, snapshot.activeSessionId, onNotice]);
+
   const streamingMsgId =
     snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
       ? messages[messages.length - 1].id
@@ -911,7 +1015,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
         ) : (
           <div className="qa-messages">
             {messages.map((msg) => (
-              <QaMessageItem key={msg.id} msg={msg} isStreaming={msg.id === streamingMsgId} onRetry={handleRetry} onViewImage={setViewerImage} />
+              <QaMessageItem key={msg.id} msg={msg} isStreaming={msg.id === streamingMsgId} onRetry={handleRetry} onViewImage={setViewerImage} onCopy={handleCopyMessage} onEdit={handleEditMessage} />
             ))}
           </div>
         )}
@@ -1065,6 +1169,35 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
           <button type="button" className="qa-image-viewer-close" aria-label="关闭" onClick={() => setViewerImage(null)}>
             <X size={20} />
           </button>
+        </div>
+      )}
+
+      {editingMsg && (
+        <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
+          <div className="qa-edit-dialog" role="dialog" aria-label="编辑消息" onClick={(e) => e.stopPropagation()}>
+            <div className="qa-edit-head">
+              <span className="qa-edit-title">编辑消息（未渲染原始内容）</span>
+              <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
+                <X size={16} />
+              </button>
+            </div>
+            <textarea
+              className="qa-edit-textarea"
+              value={editText}
+              onChange={(e) => setEditText(e.target.value)}
+              spellCheck={false}
+              autoFocus
+              placeholder="这里显示的是消息的原始内容，不会被前端渲染，可放心查看特殊标签。"
+            />
+            <div className="qa-edit-actions">
+              <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
+                取消
+              </button>
+              <button type="button" className="qa-devnotice-btn is-primary" onClick={handleSaveEdit}>
+                保存
+              </button>
+            </div>
+          </div>
         </div>
       )}
 

--- a/components/settings/regex-manager.tsx
+++ b/components/settings/regex-manager.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useContext, useCallback, useMemo } from "react";
-import { Plus, Trash2, Download, Database, Play, Upload, ChevronLeft, AlertCircle, Maximize2, X, Replace } from "lucide-react";
+import { Plus, Trash2, Download, Database, Play, Upload, ChevronLeft, AlertCircle, Maximize2, X, Replace, Copy, Check } from "lucide-react";
 import {
     loadRegexes,
     saveRegexes,
@@ -20,6 +20,124 @@ import { SettingsContext } from "../phone-settings-app";
 import { BottomSheet, ConfirmDialog, TextExpandModal } from "@/components/ui/modal";
 import { SwipeActionRow, useSwipeActions } from "@/components/ui/swipe-actions";
 import { notifyMascotPageContext } from "@/lib/mascot-events";
+
+function copyTextToClipboard(text: string): void {
+    const fallbackCopy = () => {
+        const ta = document.createElement("textarea");
+        ta.value = text;
+        ta.style.cssText = "position:fixed;left:-9999px;top:-9999px;opacity:0";
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        try { document.execCommand("copy"); } catch {}
+        document.body.removeChild(ta);
+    };
+    if (navigator.clipboard?.writeText) {
+        navigator.clipboard.writeText(text).catch(fallbackCopy);
+    } else {
+        fallbackCopy();
+    }
+}
+
+/** 复制「起效后的代码」（正则替换结果）的小按钮：点击后短暂显示「已复制」。 */
+function CopyCodeButton({ text, className }: { text: string; className?: string }) {
+    const [copied, setCopied] = useState(false);
+    return (
+        <button
+            type="button"
+            className={className}
+            disabled={!text}
+            title={text ? "复制起效后的代码" : "无内容可复制"}
+            onClick={(e) => {
+                e.stopPropagation();
+                copyTextToClipboard(text);
+                setCopied(true);
+                window.setTimeout(() => setCopied(false), 1200);
+            }}
+            style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+                border: "1px solid var(--c-panel-border)",
+                background: "var(--c-card)",
+                borderRadius: 8,
+                padding: "2px 8px",
+                cursor: text ? "pointer" : "not-allowed",
+                color: "var(--c-icon)",
+                opacity: text ? 1 : 0.4,
+                flexShrink: 0,
+            }}
+        >
+            {copied ? <Check size={12} /> : <Copy size={12} />}
+            <span className="ts-11">{copied ? "已复制" : "复制"}</span>
+        </button>
+    );
+}
+
+/** 从 ```html 围栏里提取真正的 HTML 文档（渲染预览用）。 */
+function extractHtmlForPreview(text: string): string {
+    const m = text.match(/```html\s*\n([\s\S]*?)```/);
+    return m ? m[1].trim() : text.trim();
+}
+
+/**
+ * 渲染预览 iframe：与聊天里真正的 HTML 卡片同机制（iframe + 脚本可执行 + 高度自适应）。
+ * 之前的预览用 dangerouslySetInnerHTML 直接把 HTML 塞进当前文档：
+ * <style> 会生效、<script> 永不执行，导致带脚本的卡片只显示空壳、文字全丢。
+ */
+function HtmlPreviewFrame({ html }: { html: string }) {
+    const iframeRef = useRef<HTMLIFrameElement>(null);
+    const [height, setHeight] = useState(360);
+    const srcDoc = useMemo(() => {
+        const action = `document.addEventListener("click",function(e){var t=e.target.closest("[data-action]");if(t){e.preventDefault();window.parent.postMessage({type:"_chat_action",text:t.getAttribute("data-action")},"*")}},true);`;
+        const resize = `
+            var n=0;
+            var send=function(){
+                if(n>=12)return;
+                n++;
+                var b=document.body;
+                if(!b)return;
+                var h=Math.max(Math.ceil(b.getBoundingClientRect().height),b.scrollHeight||0,80);
+                window.parent.postMessage({type:"_chat_inline_html_resize",h:h},"*");
+            };
+            window.addEventListener("load",send);
+            if(window.ResizeObserver&&document.body){new ResizeObserver(function(){n=0;send();}).observe(document.body);}
+            document.addEventListener("toggle",function(){n=0;setTimeout(send,50);},true);
+            setTimeout(send,300);
+            setTimeout(send,1200);
+            setTimeout(send,2500);`;
+        const inject = `<script>(function(){${action}${resize}})();<\/script>`;
+        let h = html;
+        if (h.includes("</body>")) h = h.replace("</body>", inject + "</body>");
+        else h = h + inject;
+        return h;
+    }, [html]);
+
+    useEffect(() => {
+        setHeight(360);
+    }, [srcDoc]);
+
+    useEffect(() => {
+        const handler = (e: MessageEvent) => {
+            if (!e.data || typeof e.data !== "object") return;
+            if (iframeRef.current && e.source !== iframeRef.current.contentWindow) return;
+            if (e.data.type === "_chat_inline_html_resize" && typeof e.data.h === "number") {
+                setHeight(Math.max(80, Math.ceil(e.data.h)));
+            }
+        };
+        window.addEventListener("message", handler);
+        return () => window.removeEventListener("message", handler);
+    }, []);
+
+    return (
+        <iframe
+            ref={iframeRef}
+            srcDoc={srcDoc}
+            title="正则渲染预览"
+            style={{ width: "100%", height, border: "none", borderRadius: 12, background: "transparent" }}
+        />
+    );
+}
 
 function getRuleTags(rule: Pick<RegexRule, "tags">): string[] {
     return rule.tags && rule.tags.length > 0 ? [...rule.tags] : [];
@@ -324,6 +442,7 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
         if (typeof obj.markdownOnly === "boolean") rule.markdownOnly = obj.markdownOnly;
         if (typeof obj.promptOnly === "boolean") rule.promptOnly = obj.promptOnly;
         if (typeof obj.runOnEdit === "boolean") rule.runOnEdit = obj.runOnEdit;
+        if (typeof obj.historyOnly === "boolean") rule.historyOnly = obj.historyOnly;
         if (typeof obj.substituteRegex === "number") rule.substituteRegex = obj.substituteRegex;
         if (typeof obj.minDepth === "number") rule.minDepth = obj.minDepth;
         if (typeof obj.maxDepth === "number") rule.maxDepth = obj.maxDepth;
@@ -569,8 +688,13 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                                                                     {step.skipped && <span className="ts-11" style={{ color: "var(--c-icon)", opacity: 0.6 }}>{step.skipped}</span>}
                                                                 </button>
                                                                 {groupTestExpandStep === i && !step.skipped && (
-                                                                    <div className="ui-code-block" style={{ maxHeight: 200, overflow: "auto", whiteSpace: "pre-wrap", fontSize: "calc(12px*var(--app-text-scale,1))", margin: "4px 0 8px" }}>
-                                                                        {step.output || <span className="menu-desc !mt-0">(空)</span>}
+                                                                    <div className="flex flex-col gap-1" style={{ margin: "4px 0 8px" }}>
+                                                                        <div className="flex items-center justify-end">
+                                                                            <CopyCodeButton text={step.output} />
+                                                                        </div>
+                                                                        <div className="ui-code-block" style={{ maxHeight: 200, overflow: "auto", whiteSpace: "pre-wrap", fontSize: "calc(12px*var(--app-text-scale,1))" }}>
+                                                                            {step.output || <span className="menu-desc !mt-0">(空)</span>}
+                                                                        </div>
                                                                     </div>
                                                                 )}
                                                             </div>
@@ -578,7 +702,10 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                                                     </div>
                                                 </div>
                                                 <div className="flex flex-col gap-1">
-                                                    <label className="menu-desc">最终输出</label>
+                                                    <div className="flex items-center justify-between gap-2 flex-wrap">
+                                                        <label className="menu-desc !mt-0">最终输出</label>
+                                                        <CopyCodeButton text={groupOutput} />
+                                                    </div>
                                                     <div className="ui-code-block" style={{ maxHeight: 300, overflow: "auto", whiteSpace: "pre-wrap", fontSize: "calc(13px*var(--app-text-scale,1))" }}>
                                                         {groupOutput || <span className="menu-desc !mt-0">(空)</span>}
                                                     </div>
@@ -802,6 +929,14 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                                                                     编辑时执行
                                                                 </label>
                                                             </div>
+                                                            <div className="flex items-center justify-between gap-6 mt-2">
+                                                                <label className="ui-checkbox-label whitespace-nowrap">
+                                                                    <input type="checkbox" checked={rule.historyOnly ?? false}
+                                                                        onChange={(e) => updateRule(rule.id, { historyOnly: e.target.checked || undefined })} />
+                                                                    仅历史消息
+                                                                </label>
+                                                                <span className="menu-desc !mt-0">勾选后只作用于聊天历史消息，不碰系统提示词/预设/世界书</span>
+                                                            </div>
                                                         </div>
 
                                                         <div className="flex flex-col gap-1">
@@ -902,6 +1037,8 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                                                                                 <span className="ui-tag" data-variant={matchCount > 0 ? "success" : "muted"}>
                                                                                     {matchCount > 0 ? `${matchCount} 处匹配` : "无匹配"}
                                                                                 </span>
+                                                                                <span className="flex-1" />
+                                                                                <CopyCodeButton text={output} />
                                                                             </div>
                                                                             <div className="ui-code-block">{output || <span className="menu-desc !mt-0">(空)</span>}</div>
                                                                         </div>
@@ -1026,7 +1163,7 @@ export function RegexManager({ isActive = true }: { isActive?: boolean } = {}) {
                         </button>
                     </header>
                     <div className="flex-1 overflow-auto p-4">
-                        <div className="chat-markdown" dangerouslySetInnerHTML={{ __html: previewHtml }} />
+                        <HtmlPreviewFrame html={extractHtmlForPreview(previewHtml)} />
                     </div>
                 </div>
             )}

--- a/lib/qa-chat-store.ts
+++ b/lib/qa-chat-store.ts
@@ -355,6 +355,17 @@ export function deleteQaSession(sessionId: string) {
     publish();
 }
 
+/** 编辑一条已发送消息的内容（小坊助手界面"编辑"）。
+ *  只覆盖 content 并清掉时序分段缓存（保证渲染用新内容），工具行/提交卡等历史保留。 */
+export function updateQaMessageContent(sessionId: string, msgId: string, content: string): void {
+    sessions = sessions.map((s) =>
+        s.id !== sessionId
+            ? s
+            : { ...s, messages: s.messages.map((m) => (m.id === msgId ? { ...m, content, segments: undefined } : m)) }
+    );
+    publish();
+}
+
 function updateSession(sessionId: string, updater: (session: QaSession) => QaSession, options?: { persist?: boolean }) {
     sessions = sessions
         .map((s) => (s.id === sessionId ? updater(s) : s))

--- a/lib/settings-types.ts
+++ b/lib/settings-types.ts
@@ -101,6 +101,7 @@ export type RegexRule = {
     markdownOnly?: boolean;       // true → only apply during display rendering (non-destructive)
     promptOnly?: boolean;         // true → only apply during prompt assembly (non-destructive)
     runOnEdit?: boolean;          // true → also apply when user edits an existing message
+    historyOnly?: boolean;        // true → only apply to chat history message blocks, never to system prompts/preset/world book
     substituteRegex?: number;     // 0=NONE, 1=RAW macro substitution in findRegex, 2=ESCAPED
     minDepth?: number;            // Minimum message depth (-1 = unlimited)
     maxDepth?: number;            // Maximum message depth

--- a/styles/qa.css
+++ b/styles/qa.css
@@ -1446,6 +1446,98 @@
   box-shadow: none;
 }
 
+/* ── 消息操作菜单（长按 / 右键弹出：复制、编辑）── */
+.qa-msg-wrap {
+  position: relative;
+}
+.qa-msg-menu {
+  position: fixed;
+  z-index: 60;
+  display: flex;
+  gap: 6px;
+  padding: 4px;
+  border-radius: 12px;
+  background: var(--qa-bg-overlay);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  animation: qa-fade-in 0.12s ease;
+}
+.qa-msg-menu button {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--qa-text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.qa-msg-menu button:active {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+/* ── 编辑消息弹窗（展示未渲染原始内容）── */
+.qa-edit-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  animation: qa-fade-in 0.18s ease;
+}
+.qa-edit-dialog {
+  width: min(100%, 520px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 16px;
+  background: var(--qa-bg-overlay);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
+}
+.qa-edit-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.qa-edit-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--qa-text-primary);
+}
+.qa-edit-textarea {
+  width: 100%;
+  min-height: 220px;
+  max-height: 55vh;
+  resize: vertical;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  background: var(--qa-bg-raised);
+  color: var(--qa-text-primary);
+  font-size: 13px;
+  line-height: 1.6;
+  font-family: ui-monospace, "SF Mono", Consolas, monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+  outline: none;
+  box-sizing: border-box;
+}
+.qa-edit-textarea:focus {
+  border-color: var(--qa-accent, rgba(255, 255, 255, 0.35));
+}
+.qa-edit-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 /* 工坊配置面板 */
 .qa-settings-field {
   display: flex;


### PR DESCRIPTION
贡献者：温铎（@yechen1844）

三个功能 + 一项搭车改动：
1) 正则配置界面：每条规则「测试正则」的替换结果、整组测试的步骤输出与最终输出，新增一键复制按钮（复制起效后的代码）。
2) 正则渲染预览优化：预览由 dangerouslySetInnerHTML 改为 iframe 渲染（与聊天真实 HTML 卡片同机制，脚本可执行、高度自适应），修复带 <script> 的卡片在预览里只显示空壳的问题。
3) 小坊（工坊答疑）聊天界面：消息长按/右键弹出操作菜单，支持「复制」（复制未渲染的原始内容）与「编辑」（编辑框展示原始内容，保存后更新存储并清掉时序分段缓存以重渲染）。涉及 phone-qa-app.tsx / lib/qa-chat-store.ts（新增 updateQaMessageContent）/ styles/qa.css。
4) 附：正则配置里带上了 historyOnly（仅应用到历史消息块）标记——此项此前已推送过但官方还没来得及处理，因推送限制（同一文件混改）本次不得不一并带入（regex-manager.tsx 的 sanitizeRuleImport 与 settings-types.ts 的 RegexRule 字段）。
验证：iframe 预览下 tamagotchi 卡片脚本正常填充字段；长按菜单复制/编辑可用并即时生效。

---
_经小手机「共同建设」通道提交_