### PR TITLE
feat(memory): 允许用户自定义勾选短期记忆的数据来源

### DIFF
--- a/components/memory/memory-bank-page.tsx
+++ b/components/memory/memory-bank-page.tsx
@@ -879,6 +879,54 @@ export function MemoryBankPage({ view, selectedCharId, onSelectChar, onNotice }:
                     </>
                 )}
 
+                {/* Source filters for Short-term memory */}
+                <p className="menu-group-desc mx-2">短期记忆来源选择</p>
+                <div className="menu-group">
+                    {([
+                        { key: "chat", label: "私聊上下文" },
+                        { key: "group_chat", label: "群聊上下文" },
+                        { key: "moments", label: "朋友圈" },
+                        { key: "checkphone", label: "查手机" },
+                        { key: "diary", label: "手记与便签墙" },
+                        { key: "xiaohongshu", label: "小红书" },
+                        { key: "interview_magazine", label: "在场访谈" },
+                        { key: "cocreate", label: "共创" },
+                        { key: "game", label: "内置小游戏" },
+                        { key: "story", label: "剧情/小剧场" },
+                        { key: "vn", label: "漫卷" },
+                        { key: "adventure", label: "地图冒险" },
+                        { key: "custom_app", label: "自定义应用" },
+                    ] as const).map(source => {
+                        const allowed = config.shortTermAllowedSources ?? {};
+                        const isChecked = allowed[source.key] !== false;
+                        return (
+                            <div className="menu-item" key={source.key}>
+                                <MemorySettingsIcon icon={Clock} color={BINDING_ACCENTS.memory} />
+                                <div className="menu-label-group">
+                                    <span className="menu-label">{source.label}</span>
+                                    <span className="menu-desc">是否允许「{source.label}」的数据放入短期记忆上下文</span>
+                                </div>
+                                <div className="menu-right">
+                                    <Toggle 
+                                        checked={isChecked} 
+                                        onChange={(v) => {
+                                            const next = {
+                                                ...config,
+                                                shortTermAllowedSources: {
+                                                    ...allowed,
+                                                    [source.key]: v
+                                                }
+                                            };
+                                            setConfig(next);
+                                            saveMemoryConfig(next);
+                                        }} 
+                                    />
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+
                 {/* Feature toggles */}
                 <p className="menu-group-desc mx-2">自动化</p>
                 <div className="menu-group">

--- a/lib/memory-types.ts
+++ b/lib/memory-types.ts
@@ -29,6 +29,21 @@ export type MemoryConfig = {
     summarizationPrompt: string;            // user-editable prompt template for memory summarization
     coreMemoryPrompt: string;               // user-editable prompt template for core-memory extraction
     vnSummaryPrompt: string;                // user-editable prompt for VN chapter summarization
+    shortTermAllowedSources?: {
+        chat?: boolean;
+        group_chat?: boolean;
+        moments?: boolean;
+        checkphone?: boolean;
+        diary?: boolean;
+        xiaohongshu?: boolean;
+        interview_magazine?: boolean;
+        cocreate?: boolean;
+        game?: boolean;
+        story?: boolean;
+        vn?: boolean;
+        adventure?: boolean;
+        custom_app?: boolean;
+    };
 };
 
 export type MemorySearchResult = {
@@ -101,4 +116,19 @@ export const DEFAULT_MEMORY_CONFIG: MemoryConfig = {
     summarizationPrompt: DEFAULT_SUMMARIZATION_PROMPT,
     coreMemoryPrompt: DEFAULT_CORE_MEMORY_PROMPT,
     vnSummaryPrompt: "",
+    shortTermAllowedSources: {
+        chat: true,
+        group_chat: true,
+        moments: true,
+        checkphone: true,
+        diary: true,
+        xiaohongshu: true,
+        interview_magazine: true,
+        cocreate: true,
+        game: true,
+        story: true,
+        vn: true,
+        adventure: true,
+        custom_app: true,
+    },
 };

--- a/lib/short-term-assembler.ts
+++ b/lib/short-term-assembler.ts
@@ -913,17 +913,38 @@ export function prepareShortTermContext(
     unifiedRecentItems: UnifiedRecentItem[];
 } {
     const timeAware = resolvePromptTimeAware(options?.timeAware);
-    const timeline = loadNativeTimeline(characterId, {
+    let timeline = loadNativeTimeline(characterId, {
         userName: options?.userName,
         appId: appId as import("./settings-types").ContentAppId,
         excludeOfflineSessionId: options?.excludeOfflineSessionId,
         timeAware,
         promptTimestampOptions: options?.promptTimestampOptions,
     });
-    // Activation context: full timeline for keyword matching (not truncated)
-    const wbActivationContext = timeline.slice(-10).map(e => e.content).join("\n");
 
     const memConfig = loadMemoryConfig();
+    const allowed = memConfig.shortTermAllowedSources ?? {};
+    timeline = timeline.filter(entry => {
+        const source = entry.sourceApp;
+        if (source === "chat") {
+            if (entry.sourceDetail === "group") {
+                return allowed.group_chat !== false;
+            }
+            return allowed.chat !== false;
+        }
+        if (source === "story") {
+            return allowed.story !== false;
+        }
+        if (source === "vn") {
+            return allowed.vn !== false;
+        }
+        if (source === "map") {
+            return allowed.adventure !== false;
+        }
+        return (allowed as any)[source] !== false;
+    });
+
+    // Activation context: full timeline for keyword matching (not truncated)
+    const wbActivationContext = timeline.slice(-10).map(e => e.content).join("\n");
     const budget = memConfig.shortTermTokenBudget;
     const currentTag = getFeatureTag(appId);
     const history = options?.history ?? [];
@@ -1169,14 +1190,35 @@ export function prepareGroupShortTermContext(
     const uniqueCharacterIds = [...new Set(characterIds)];
     const timelineByKey = new Map<string, NativeTimelineEntry>();
     const timeAware = resolvePromptTimeAware(options?.timeAware);
+    const memConfig = loadMemoryConfig();
+    const allowed = memConfig.shortTermAllowedSources ?? {};
 
     for (const characterId of uniqueCharacterIds) {
-        const timeline = loadNativeTimeline(characterId, {
+        let timeline = loadNativeTimeline(characterId, {
             userName: options?.userName,
             appId: "group_chat",
             excludeOfflineSessionId: options?.excludeOfflineSessionId,
             timeAware,
             promptTimestampOptions: options?.promptTimestampOptions,
+        });
+        timeline = timeline.filter(entry => {
+            const source = entry.sourceApp;
+            if (source === "chat") {
+                if (entry.sourceDetail === "group") {
+                    return allowed.group_chat !== false;
+                }
+                return allowed.chat !== false;
+            }
+            if (source === "story") {
+                return allowed.story !== false;
+            }
+            if (source === "vn") {
+                return allowed.vn !== false;
+            }
+            if (source === "map") {
+                return allowed.adventure !== false;
+            }
+            return (allowed as any)[source] !== false;
         });
         for (const entry of timeline) {
             if (entry.sourceApp === "chat" && entry.sourceDetail === "group" && entry.groupSessionId === options?.excludeGroupSessionId) {
@@ -1193,7 +1235,6 @@ export function prepareGroupShortTermContext(
     ].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
     const wbActivationContext = activationPool.slice(-10).map(item => item.content).join("\n");
 
-    const memConfig = loadMemoryConfig();
     const budget = memConfig.shortTermTokenBudget;
 
     const raw: { tag: string; order: number; entries: NativeTimelineEntry[] }[] = [];


### PR DESCRIPTION
贡献者：meltedfox02（@meltedfox02）

允许用户在记忆观察（记忆库）设置页面中自由勾选短期记忆的来源模块。支持针对私聊、群聊、朋友圈、查手机、手记、共创、内置游戏、剧情、漫卷、地图冒险等 13 个数据来源进行过滤拦截，防止不想记录的上下文数据污染短期记忆。

---
_经小手机「共同建设」通道提交_