### PR TITLE
聊天窗口自动触发AI回复(聊天设置页开启)

### DIFF
--- a/components/chat/chat-room.tsx
+++ b/components/chat/chat-room.tsx
@@ -45,6 +45,7 @@ import { generateGroupChatCompletion, generateGroupOfflineChatCompletion, parseG
 import { appendChatOfflineTurn, deleteChatOfflineTurn, deleteChatOfflineTurnsFrom, loadChatOfflineTurns, parseOfflineResponse, saveChatOfflineTurns, updateChatOfflineTurn, type ChatOfflineTurn } from "@/lib/chat-offline-storage";
 import { applyDisplayRegex, applyEditRegex } from "@/lib/llm-prompt-assembler";
 import { scheduleFollowUp, cancelFollowUp } from "@/lib/follow-up-service";
+import { useKeyboardDismissAutoSend } from "@/components/chat/use-keyboard-dismiss-auto-send";
 import { PENDING_REPLY_PREFIX } from "@/lib/friend-request-engine";
 import type { UserIdentity } from "@/components/settings/user-identity";
 import { AlertCircle, Blocks, Check, Trash2, User, ChevronLeft, ChevronRight, Clapperboard, Clock, Gift, Languages, Loader2, MoreHorizontal, X } from "lucide-react";
@@ -3661,6 +3662,17 @@ export function ChatRoom({ session, onBack }: ChatRoomProps) {
         }
         if (shouldRunDeclineReply) await triggerReply();
     };
+
+    // 收起键盘（或关掉表情/加号面板）并安静 N 秒后自动触发回复，
+    // 等价于替用户点一次「触发回复」。判定全在 hook 内部，配置关掉后与手动模式一致。
+    useKeyboardDismissAutoSend(wrapperRef, {
+        active: !offlineMode && !isMultiSelectMode,
+        pending: pendingGenerate,
+        generating: isGenerating,
+        panelOpen: showEmojiPanel || showStickerPanel || showPlusMenu,
+        sessionId: session.id,
+        onTrigger: () => { void triggerAIResponse(); },
+    });
 
     useEffect(() => {
         const handleCustomAppReplyRequest = (event: Event) => {

--- a/components/chat/chat-settings-panel.tsx
+++ b/components/chat/chat-settings-panel.tsx
@@ -42,6 +42,7 @@ import { getStatusRegionConfig, saveStatusRegionConfig, presetSupportsStatusRegi
 import { downloadFile } from "@/lib/download-utils";
 import { getSchemes, saveScheme, deleteScheme, type CSSScheme } from "@/lib/css-scheme-storage";
 import { CustomStatusFrame } from "@/components/chat/custom-status-frame";
+import { KeyboardAutoSendDebounceItem } from "@/components/chat/keyboard-auto-send-debounce-item";
 import { ChevronRight, Image as ImageIcon, Video, Mic, UserMinus, UserPlus, Users, Pin, MessageSquare, Search, AlertCircle, Code, Laptop, Trash2, Smile, Sparkles, X, Play, Upload, Download, Save, FolderOpen, type LucideIcon } from "lucide-react";
 import { BINDING_ACCENTS, CONTENT_APP_ACCENTS } from "@/lib/ui-accent-colors";
 import CSSSchemeBar from "@/components/ui/css-scheme-picker";
@@ -1133,6 +1134,7 @@ export function ChatSettingsPanel({
 
                 {/* Advanced */}
                 <div className="menu-group">
+                    <KeyboardAutoSendDebounceItem sessionId={session.id} />
                     <button className="menu-item" onClick={() => setEditingCSS(true)}>
                         <ChatInfoIcon icon={Code} color={BINDING_ACCENTS.embedding} />
                         <div className="menu-label-group"><span className="menu-label">自定义 CSS 样式</span></div>

--- a/components/chat/keyboard-auto-send-debounce-item.tsx
+++ b/components/chat/keyboard-auto-send-debounce-item.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+// 聊天设置面板里的「收起键盘后自动回复」设置项，自包含：
+// 自己读写 keyboard-auto-send-config，不向面板要任何 props（sessionId 除外）。
+// 挂载方式：在 chat-settings-panel.tsx 的任意 menu-group 里插一行
+//   <KeyboardAutoSendDebounceItem sessionId={session.id} />
+//
+// 视觉与面板其他行保持一致：左侧彩色图标 + 标题/说明 + 右侧 Toggle；
+// 开启后下面多一行等待秒数的输入框。开关关掉后行为与原版完全一致。
+
+import { useState, type CSSProperties } from "react";
+import { KeyboardOff } from "lucide-react";
+import { Toggle } from "@/components/ui/form";
+import {
+    getKeyboardAutoSendDebounceMs,
+    isKeyboardAutoSendEnabled,
+    setSessionKeyboardAutoSendEnabled,
+    setSessionKeyboardAutoSendDebounce,
+    MAX_AUTO_SEND_DEBOUNCE_MS,
+} from "@/lib/keyboard-auto-send-config";
+
+export function KeyboardAutoSendDebounceItem({ sessionId }: { sessionId: string }) {
+    const [enabled, setEnabled] = useState(() => isKeyboardAutoSendEnabled(sessionId));
+    const [seconds, setSeconds] = useState(() => getKeyboardAutoSendDebounceMs(sessionId) / 1000);
+
+    const commit = (value: number) => {
+        const clamped = Math.max(0, Math.min(MAX_AUTO_SEND_DEBOUNCE_MS / 1000, value));
+        if (!Number.isFinite(clamped)) return;
+        setSeconds(clamped);
+        setSessionKeyboardAutoSendDebounce(sessionId, Math.round(clamped * 1000));
+    };
+
+    return (
+        <>
+            <div className="menu-item">
+                {/* 与面板其他行同款图标壳（chat-info-icon 吃 --icon-color 变量） */}
+                <span className="chat-info-icon" style={{ "--icon-color": "var(--c-icon-teal, #2a9d8f)" } as CSSProperties}>
+                    <KeyboardOff size={22} strokeWidth={1.75} />
+                </span>
+                <div className="menu-label-group">
+                    <span className="menu-label">收起键盘后自动回复</span>
+                    <span className="menu-desc">打完字收起键盘，TA 就会开始回；不用再点「触发回复」（只对本聊天生效）</span>
+                </div>
+                <div className="menu-right">
+                    <Toggle
+                        checked={enabled}
+                        onChange={next => {
+                            setEnabled(next);
+                            setSessionKeyboardAutoSendEnabled(sessionId, next);
+                        }}
+                    />
+                </div>
+            </div>
+            {/* 常驻 DOM、只用 display 收起：聊天信息页还有脚本在这组里动态插行
+                （隐藏思维链），条件挂载会让 React 以「自定义 CSS」为锚重新插入，
+                这行就会落到外来行的下面去 */}
+            <label className="menu-item" style={enabled ? undefined : { display: "none" }}>
+                <div className="menu-label-group" style={{ paddingLeft: 48 }}>
+                    <span className="menu-label">收起后等几秒再回</span>
+                    <span className="menu-desc">这几秒内又点回输入框，就当你还没说完，先不回</span>
+                </div>
+                <div className="menu-right">
+                    <input
+                        type="number"
+                        inputMode="decimal"
+                        autoComplete="off"
+                        min={0}
+                        max={MAX_AUTO_SEND_DEBOUNCE_MS / 1000}
+                        step={0.5}
+                        value={seconds}
+                        onChange={e => commit(Number(e.target.value))}
+                        className="ui-input h-8 w-16 text-center"
+                    />
+                </div>
+            </label>
+        </>
+    );
+}

--- a/components/chat/use-keyboard-dismiss-auto-send.ts
+++ b/components/chat/use-keyboard-dismiss-auto-send.ts
@@ -1,0 +1,200 @@
+"use client";
+
+// 「收起键盘 = 自动触发回复」，带防抖窗口。
+//
+// 行为：用户收起键盘（或关掉表情/加号面板）后开始等 N 秒；
+// N 秒内重新拉起键盘、点回输入框、打开表情面板，都会取消本次触发；
+// N 秒安静过去，才替用户按下「触发回复」按钮。
+//
+// 实现上就是一个定时器：收起时 setTimeout(fire, N)，用户有动作就 clearTimeout。
+// 所有业务判断（发过消息没被回、是否在生成等）都放在 fire 那一刻做，
+// 所以取消路径漏掉某个边缘情况也只是多等一轮，不会误发。
+//
+// 零侵入约定：所有判定都在这个文件里，聊天室只需一次调用；
+// 关掉配置开关后行为与原版完全一致。
+
+import { useCallback, useEffect, useRef, type RefObject } from "react";
+import { loadChatMessages } from "@/lib/chat-storage";
+import { getKeyboardAutoSendDebounceMs, isKeyboardAutoSendEnabled } from "@/lib/keyboard-auto-send-config";
+
+const KEYBOARD_INSET_THRESHOLD = 80;
+const KEYBOARD_HEIGHT_CHANGE_THRESHOLD = 48;
+const INPUT_SELECTOR = ".chat-input-textarea";
+
+interface KeyboardDismissAutoSendOptions {
+    /** 当前场景是否允许自动触发（离线模式 / 多选模式下传 false） */
+    active: boolean;
+    /** 确实发过东西、还没被回复 */
+    pending: boolean;
+    /** 正在生成 */
+    generating: boolean;
+    /** 表情/贴纸/加号面板开着 */
+    panelOpen: boolean;
+    /** 用于「最后一条是不是用户发的」校验 + 按会话防抖时长 */
+    sessionId: string;
+    onTrigger: () => void;
+}
+
+export function useKeyboardDismissAutoSend(
+    rootRef: RefObject<HTMLElement | null>,
+    options: KeyboardDismissAutoSendOptions,
+): void {
+    const optionsRef = useRef(options);
+    optionsRef.current = options;
+
+    const waitTimerRef = useRef(0);
+
+    /** 取消当前防抖窗口（如果有）。 */
+    const cancelWait = useCallback(() => {
+        if (waitTimerRef.current) {
+            window.clearTimeout(waitTimerRef.current);
+            waitTimerRef.current = 0;
+        }
+    }, []);
+
+    /** 最后一条非 system 消息必须是 user，否则「什么都没发也收键盘」会误触发。 */
+    const hasUnrepliedUserMessage = useCallback((sessionId: string) => {
+        const msgs = loadChatMessages(sessionId);
+        for (let i = msgs.length - 1; i >= 0; i -= 1) {
+            if (msgs[i].role === "system") continue;
+            return msgs[i].role === "user";
+        }
+        return false;
+    }, []);
+
+    /** 防抖窗口结束：触发前把现场完整查一遍，任何一条不满足都放弃。 */
+    const fire = useCallback(() => {
+        waitTimerRef.current = 0;
+        const cur = optionsRef.current;
+        if (!cur.active || !cur.pending || cur.generating || cur.panelOpen) return;
+        if (!isKeyboardAutoSendEnabled(cur.sessionId)) return;
+        // 焦点又回到输入框 = 用户还要接着说
+        const focused = document.activeElement;
+        if (focused instanceof HTMLElement && focused.matches(INPUT_SELECTOR)) return;
+        // 输入框里已有草稿同理
+        const draft = rootRef.current?.querySelector<HTMLTextAreaElement>(INPUT_SELECTOR);
+        if (draft?.value.trim()) return;
+        if (!hasUnrepliedUserMessage(cur.sessionId)) return;
+        cur.onTrigger();
+    }, [rootRef, hasUnrepliedUserMessage]);
+
+    /** 键盘收起 / 面板关闭 → 开一个 N 秒防抖窗口（重复调用会重置计时）。 */
+    const scheduleWait = useCallback(() => {
+        if (!isKeyboardAutoSendEnabled(optionsRef.current.sessionId)) return;
+        cancelWait();
+        const n = getKeyboardAutoSendDebounceMs(optionsRef.current.sessionId);
+        waitTimerRef.current = window.setTimeout(fire, Math.max(0, n));
+    }, [cancelWait, fire]);
+
+    // 面板「开 → 关」等价于收起键盘；面板打开则取消等待。
+    const prevPanelOpenRef = useRef(false);
+    useEffect(() => {
+        const wasOpen = prevPanelOpenRef.current;
+        prevPanelOpenRef.current = options.panelOpen;
+        if (options.panelOpen) { cancelWait(); return; }
+        if (wasOpen) scheduleWait();
+    }, [options.panelOpen, cancelWait, scheduleWait]);
+
+    // 输入框重新获得焦点 / 有输入 → 用户还要说，取消等待。
+    // 用捕获阶段的 document 监听：输入框在子组件里，state 传不进 hook。
+    useEffect(() => {
+        const isOurInput = (target: EventTarget | null) =>
+            target instanceof HTMLElement
+            && target.matches(INPUT_SELECTOR)
+            && Boolean(rootRef.current?.contains(target));
+        const onFocusIn = (event: FocusEvent) => { if (isOurInput(event.target)) cancelWait(); };
+        const onInput = (event: Event) => { if (isOurInput(event.target)) cancelWait(); };
+        document.addEventListener("focusin", onFocusIn, true);
+        document.addEventListener("input", onInput, true);
+        return () => {
+            document.removeEventListener("focusin", onFocusIn, true);
+            document.removeEventListener("input", onInput, true);
+        };
+    }, [rootRef, cancelWait]);
+
+    // 卸载时清掉定时器
+    useEffect(() => () => cancelWait(), [cancelWait]);
+
+    // 键盘开合检测：浏览器没有键盘事件，只能靠 visualViewport 尺寸 + 输入框焦点推断。
+    useEffect(() => {
+        const viewport = window.visualViewport;
+
+        let keyboardWasOpen = false;
+        let inputWasFocused = false;
+        let stableViewportHeight = viewport?.height ?? window.innerHeight;
+        let stableWindowHeight = window.innerHeight;
+        let frame = 0;
+
+        const keyboardInset = () => Math.max(
+            0,
+            viewport ? window.innerHeight - viewport.height - viewport.offsetTop : 0,
+        );
+        const chatInputFocused = () => {
+            const focused = document.activeElement;
+            return focused instanceof HTMLElement
+                && focused.matches(INPUT_SELECTOR)
+                && Boolean(rootRef.current?.contains(focused));
+        };
+
+        const measure = () => {
+            frame = 0;
+            const viewportHeight = viewport?.height ?? window.innerHeight;
+            const keyboardOpen = inputWasFocused && (
+                keyboardInset() >= KEYBOARD_INSET_THRESHOLD
+                || stableViewportHeight - viewportHeight >= KEYBOARD_HEIGHT_CHANGE_THRESHOLD
+                || stableWindowHeight - window.innerHeight >= KEYBOARD_HEIGHT_CHANGE_THRESHOLD
+            );
+            if (keyboardOpen) {
+                // iOS 的 focusout 可能早于最后一次 visualViewport resize，
+                // 焦点单独维护，关闭事件才不会丢。
+                if (inputWasFocused || chatInputFocused()) keyboardWasOpen = true;
+                cancelWait(); // 键盘（重新）弹起 → 上一个防抖窗口作废
+                return;
+            }
+            if (!keyboardWasOpen) return; // 没开过就不算「收起」，旋屏/地址栏收缩不误触发
+            keyboardWasOpen = false;
+            inputWasFocused = false;
+            stableViewportHeight = viewportHeight; // 重新采基线，否则下一轮判断用的是旧值
+            stableWindowHeight = window.innerHeight;
+            scheduleWait(); // 收起 → 开 N 秒防抖窗口
+        };
+
+        const requestMeasure = () => {
+            if (frame) cancelAnimationFrame(frame);
+            frame = requestAnimationFrame(measure);
+        };
+
+        const handleFocusIn = (event: FocusEvent) => {
+            const target = event.target;
+            if (target instanceof HTMLElement
+                && target.matches(INPUT_SELECTOR)
+                && Boolean(rootRef.current?.contains(target))) {
+                inputWasFocused = true;
+                stableViewportHeight = Math.max(stableViewportHeight, viewport?.height ?? window.innerHeight);
+                stableWindowHeight = Math.max(stableWindowHeight, window.innerHeight);
+            } else if (!keyboardWasOpen) {
+                inputWasFocused = false;
+                stableViewportHeight = viewport?.height ?? window.innerHeight;
+                stableWindowHeight = window.innerHeight;
+            }
+            requestMeasure();
+        };
+        const handleFocusOut = () => requestMeasure();
+
+        viewport?.addEventListener("resize", requestMeasure);
+        viewport?.addEventListener("scroll", requestMeasure);
+        window.addEventListener("resize", requestMeasure);
+        document.addEventListener("focusin", handleFocusIn);
+        document.addEventListener("focusout", handleFocusOut);
+        requestMeasure();
+
+        return () => {
+            if (frame) cancelAnimationFrame(frame);
+            viewport?.removeEventListener("resize", requestMeasure);
+            viewport?.removeEventListener("scroll", requestMeasure);
+            window.removeEventListener("resize", requestMeasure);
+            document.removeEventListener("focusin", handleFocusIn);
+            document.removeEventListener("focusout", handleFocusOut);
+        };
+    }, [rootRef, cancelWait, scheduleWait]);
+}

--- a/lib/keyboard-auto-send-config.ts
+++ b/lib/keyboard-auto-send-config.ts
@@ -1,0 +1,92 @@
+// 「收起键盘自动触发回复」的独立配置。
+// 刻意不复用 settings-storage：整个功能只由新增文件 + 少量纯插入组成，
+// 与主设置文件互不影响，全部关闭时行为与原版完全一致。
+//
+// 开关和等待秒数都按聊天窗口（sessionId）各存各的：设置页本来就是单个聊天的，
+// 在哪拨开就只对哪个聊天生效，「这个角色开、那个角色不开」天然成立。
+const CONFIG_KEY = "float_keyboard_auto_send_v1";
+
+export interface KeyboardAutoSendConfig {
+    /** 按会话的开关。缺省 = 关（不改变任何存量行为）。key = sessionId。 */
+    sessionEnabled: Record<string, boolean>;
+    /** 按会话的等待时长（毫秒）。缺省用 DEFAULT_DEBOUNCE_MS。key = sessionId。 */
+    sessionDebounceMs: Record<string, number>;
+}
+
+export const MIN_AUTO_SEND_DEBOUNCE_MS = 0;
+export const MAX_AUTO_SEND_DEBOUNCE_MS = 30_000;
+export const DEFAULT_DEBOUNCE_MS = 1000;
+
+const DEFAULT_CONFIG: KeyboardAutoSendConfig = {
+    sessionEnabled: {},
+    sessionDebounceMs: {},
+};
+
+export function normalizeDebounceMs(value: unknown, fallback = DEFAULT_DEBOUNCE_MS): number {
+    const raw = Number(value);
+    if (!Number.isFinite(raw)) return fallback;
+    return Math.max(MIN_AUTO_SEND_DEBOUNCE_MS, Math.min(MAX_AUTO_SEND_DEBOUNCE_MS, Math.round(raw)));
+}
+
+export function loadKeyboardAutoSendConfig(): KeyboardAutoSendConfig {
+    if (typeof window === "undefined") return { sessionEnabled: {}, sessionDebounceMs: {} };
+    try {
+        const raw = localStorage.getItem(CONFIG_KEY);
+        if (!raw) return { sessionEnabled: {}, sessionDebounceMs: {} };
+        const saved = JSON.parse(raw) as Partial<KeyboardAutoSendConfig>;
+        const enabledMap: Record<string, boolean> = {};
+        if (saved.sessionEnabled && typeof saved.sessionEnabled === "object") {
+            for (const [key, value] of Object.entries(saved.sessionEnabled)) {
+                if (typeof value === "boolean") enabledMap[key] = value;
+            }
+        }
+        const debounceMap: Record<string, number> = {};
+        if (saved.sessionDebounceMs && typeof saved.sessionDebounceMs === "object") {
+            for (const [key, value] of Object.entries(saved.sessionDebounceMs)) {
+                const ms = Number(value);
+                if (Number.isFinite(ms)) debounceMap[key] = normalizeDebounceMs(ms);
+            }
+        }
+        return { sessionEnabled: enabledMap, sessionDebounceMs: debounceMap };
+    } catch {
+        return { sessionEnabled: {}, sessionDebounceMs: {} };
+    }
+}
+
+function saveConfig(config: KeyboardAutoSendConfig): void {
+    try { localStorage.setItem(CONFIG_KEY, JSON.stringify(config)); } catch { /* ignore */ }
+}
+
+/** 该会话是否开启了收起键盘自动触发（缺省关）。 */
+export function isKeyboardAutoSendEnabled(sessionId: string): boolean {
+    return loadKeyboardAutoSendConfig().sessionEnabled[sessionId] === true;
+}
+
+export function setSessionKeyboardAutoSendEnabled(sessionId: string, enabled: boolean): void {
+    const config = loadKeyboardAutoSendConfig();
+    const enabledMap = { ...config.sessionEnabled };
+    if (enabled) enabledMap[sessionId] = true;
+    else delete enabledMap[sessionId];
+    saveConfig({ ...config, sessionEnabled: enabledMap });
+}
+
+/** 取该会话生效的等待时长：存过用存的，否则用默认 1 秒。 */
+export function getKeyboardAutoSendDebounceMs(sessionId?: string): number {
+    const config = loadKeyboardAutoSendConfig();
+    if (sessionId && sessionId in config.sessionDebounceMs) {
+        return config.sessionDebounceMs[sessionId];
+    }
+    return DEFAULT_DEBOUNCE_MS;
+}
+
+/** 写该会话的等待时长；传 null 表示清掉、回到默认。 */
+export function setSessionKeyboardAutoSendDebounce(sessionId: string, ms: number | null): void {
+    const config = loadKeyboardAutoSendConfig();
+    const debounceMap = { ...config.sessionDebounceMs };
+    if (ms === null) {
+        delete debounceMap[sessionId];
+    } else {
+        debounceMap[sessionId] = normalizeDebounceMs(ms);
+    }
+    saveConfig({ ...config, sessionDebounceMs: debounceMap });
+}


### PR DESCRIPTION
贡献者：但求一睡君莫笑（@ichicicada）

发消息只落库、不请求 AI 是原本的设计，每次都要再点一下「触发回复」。这个改动让收起键盘（或关掉表情/加号面板）后安静 N 秒自动触发一次——键盘展开期间连发几条，收起后一次性回复，一次调用带完整语境。

等待窗口内拉回键盘、点回输入框、打字、开面板都会取消本次触发；触发前重查全部条件（有待回复消息/非生成中/面板关着/焦点不在输入框/无草稿/最后一条非 system 消息是 user），任何一条不满足就放弃。群聊同样生效，线下模式与多选模式不参与。

开关和等待秒数在聊天设置页按聊天窗口各存各的，默认关闭——不开启时行为与现版完全一致。全部逻辑在三个新增文件里，既有文件仅 14 行纯插入、零删除。

验证：tsc / next build / ESLint 通过；配置层 11 条断言（按会话开关互不影响、秒数钳制、坏数据回落）；iOS PWA 真机实测键盘开合、防抖取消、群聊、Enter 连发。

---
_经小手机「共同建设」通道提交_