### PR TITLE
阅读器优化（一）：悬浮球拖动与位置记忆、连续滚动阅读、批注预生成与失败重试、TXT 导入段落解析增强

### DIFF
--- a/components/reading/reading-interaction-dialog.tsx
+++ b/components/reading/reading-interaction-dialog.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useState } from "react";
+import { BookOpenText, LocateFixed, Minus, Plus, Repeat2, Rocket, RotateCcw, Settings } from "lucide-react";
+import { ContentDialog } from "@/components/ui/modal";
+import { Toggle } from "@/components/ui/form";
+import {
+    loadReadingInteractionConfig,
+    saveReadingInteractionConfig,
+    type ReadingInteractionConfig,
+    type ReadingParagraphMode,
+    type ReadingViewMode,
+} from "@/lib/reading-storage";
+
+const PARAGRAPH_MODE_OPTIONS: { value: ReadingParagraphMode; label: string; desc: string }[] = [
+    { value: "auto", label: "自动", desc: "自动识别书的段落格式（推荐）" },
+    { value: "blank", label: "空行", desc: "段落之间有空行（标准导出格式）" },
+    { value: "indent", label: "段首缩进", desc: "每段以全角空格缩进、无空行" },
+    { value: "line", label: "每行一段", desc: "纯回车换行分段落（无空行无缩进）" },
+];
+
+const VIEW_MODE_OPTIONS: { value: ReadingViewMode; label: string; desc: string }[] = [
+    { value: "page", label: "翻页", desc: "一屏一页，左右点击/滑动翻页" },
+    { value: "scroll", label: "滚动", desc: "连续滚动阅读，上下滑动翻读" },
+];
+
+const RETRY_MIN = 0;
+const RETRY_MAX = 5;
+
+/** 批注预生成触发时机：读到上一批批注的比例 */
+const PREFETCH_THRESHOLD_OPTIONS: { value: number; label: string; desc: string }[] = [
+    { value: 1 / 2, label: "读到一半", desc: "预留生成时间更充足" },
+    { value: 2 / 3, label: "读到 2/3", desc: "默认推荐" },
+    { value: 3 / 4, label: "读到 3/4", desc: "接近读完才生成" },
+];
+
+/** 浮点档位比较容差 */
+function prefetchThresholdMatches(a: number, b: number): boolean {
+    return Math.abs(a - b) < 0.01;
+}
+
+type Props = {
+    onClose: () => void;
+};
+
+/** 阅读交互设置：导入段落划分 / 阅读模式 / 自动批注失败静默重试次数 */
+export function ReadingInteractionDialog({ onClose }: Props) {
+    const [config, setConfig] = useState<ReadingInteractionConfig>(() => loadReadingInteractionConfig());
+    const [saving, setSaving] = useState(false);
+
+    const handleSave = () => {
+        setSaving(true);
+        saveReadingInteractionConfig(config);
+        setSaving(false);
+        // 阅读器保持挂载，通过事件让它在下次显示时同步新配置
+        if (typeof window !== "undefined") {
+            window.dispatchEvent(new CustomEvent("reading-interaction-config-changed"));
+        }
+        onClose();
+    };
+
+    const setRetry = (delta: number) => {
+        setConfig((prev) => ({
+            ...prev,
+            annotationRetryCount: Math.max(RETRY_MIN, Math.min(RETRY_MAX, prev.annotationRetryCount + delta)),
+        }));
+    };
+
+    return (
+        <ContentDialog
+            title="阅读设置"
+            confirmLabel={saving ? "保存中..." : "保存"}
+            cancelLabel="取消"
+            onConfirm={handleSave}
+            onCancel={onClose}
+        >
+            <div className="reading-settings-grid">
+                <section className="reading-settings-group">
+                    <div className="reading-settings-heading">
+                        <Settings size={15} />
+                        <span>导入段落划分</span>
+                    </div>
+                    <p className="reading-settings-inline-note">
+                        <span>导入 TXT 小说时如何划分段落。选错可在导入后重新导入生效。</span>
+                    </p>
+                    <div className="reading-option-grid">
+                        {PARAGRAPH_MODE_OPTIONS.map((opt) => (
+                            <button
+                                key={opt.value}
+                                type="button"
+                                className={`reading-option-card ${config.paragraphMode === opt.value ? "is-active" : ""}`}
+                                onClick={() => setConfig((prev) => ({ ...prev, paragraphMode: opt.value }))}
+                            >
+                                <span className="reading-option-card-label">{opt.label}</span>
+                                <span className="reading-option-card-desc">{opt.desc}</span>
+                            </button>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="reading-settings-group">
+                    <div className="reading-settings-heading">
+                        <BookOpenText size={15} />
+                        <span>阅读模式</span>
+                    </div>
+                    <p className="reading-settings-inline-note">
+                        <span>切换后重新打开书籍生效。</span>
+                    </p>
+                    <div className="reading-option-grid reading-option-grid--two">
+                        {VIEW_MODE_OPTIONS.map((opt) => (
+                            <button
+                                key={opt.value}
+                                type="button"
+                                className={`reading-option-card ${config.readingMode === opt.value ? "is-active" : ""}`}
+                                onClick={() => setConfig((prev) => ({ ...prev, readingMode: opt.value }))}
+                            >
+                                <span className="reading-option-card-label">{opt.label}</span>
+                                <span className="reading-option-card-desc">{opt.desc}</span>
+                            </button>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="reading-settings-group">
+                    <div className="reading-settings-heading">
+                        <Repeat2 size={15} />
+                        <span>自动批注失败重试</span>
+                    </div>
+                    <p className="reading-settings-inline-note">
+                        <span>生成失败时静默重试的次数，全部失败后才提示错误。</span>
+                    </p>
+                    <div className="reading-retry-row">
+                        <button
+                            type="button"
+                            className="reading-retry-btn"
+                            onClick={() => setRetry(-1)}
+                            disabled={config.annotationRetryCount <= RETRY_MIN}
+                            aria-label="减少重试次数"
+                        >
+                            <Minus size={15} strokeWidth={2} />
+                        </button>
+                        <span className="reading-retry-value">
+                            {config.annotationRetryCount}
+                            <em>次</em>
+                        </span>
+                        <button
+                            type="button"
+                            className="reading-retry-btn"
+                            onClick={() => setRetry(1)}
+                            disabled={config.annotationRetryCount >= RETRY_MAX}
+                            aria-label="增加重试次数"
+                        >
+                            <Plus size={15} strokeWidth={2} />
+                        </button>
+                    </div>
+                </section>
+
+                <section className="reading-settings-group">
+                    <div className="reading-settings-heading">
+                        <Rocket size={15} />
+                        <span>批注预生成</span>
+                    </div>
+                    <div className="reading-settings-toggle-row">
+                        <span className="reading-settings-toggle-label">
+                            提前生成下一批批注
+                        </span>
+                        <Toggle
+                            checked={config.autoAnnotatePrefetch === true}
+                            onChange={(next) => setConfig((prev) => ({ ...prev, autoAnnotatePrefetch: next }))}
+                        />
+                    </div>
+                    {config.autoAnnotatePrefetch && (
+                        <>
+                            <p className="reading-settings-inline-note">
+                                <span>读到上一批批注的多少时开始生成下一批：</span>
+                            </p>
+                            <div className="reading-option-grid reading-option-grid--three">
+                                {PREFETCH_THRESHOLD_OPTIONS.map((opt) => (
+                                    <button
+                                        key={opt.value}
+                                        type="button"
+                                        className={`reading-option-card ${prefetchThresholdMatches(config.annotationPrefetchThreshold ?? 2 / 3, opt.value) ? "is-active" : ""}`}
+                                        onClick={() => setConfig((prev) => ({ ...prev, annotationPrefetchThreshold: opt.value }))}
+                                    >
+                                        <span className="reading-option-card-label">{opt.label}</span>
+                                        <span className="reading-option-card-desc">{opt.desc}</span>
+                                    </button>
+                                ))}
+                            </div>
+                        </>
+                    )}
+                    <p className="reading-settings-inline-note">
+                        <span>利用读上一批批注的时间生成下一批，避免你读到时批注还没生成完。不会重复批注。</span>
+                    </p>
+                </section>
+
+                <section className="reading-settings-group">
+                    <div className="reading-settings-heading">
+                        <LocateFixed size={15} />
+                        <span>悬浮聊天窗</span>
+                    </div>
+                    <div className="reading-settings-toggle-row">
+                        <span className="reading-settings-toggle-label">
+                            展开时自动滚动到最新消息
+                        </span>
+                        <Toggle
+                            checked={config.chatAutoScrollOnOpen !== false}
+                            onChange={(next) => setConfig((prev) => ({ ...prev, chatAutoScrollOnOpen: next }))}
+                        />
+                    </div>
+                    <p className="reading-settings-inline-note">
+                        <span>打开讨论窗口时自动滚到最新消息；打开后你可自由上下滑动打断，不会被拉回。</span>
+                    </p>
+                    <p className="reading-settings-inline-note">
+                        <span>悬浮球/悬浮条被拖到屏幕外、无法交互时，点此恢复到默认位置。</span>
+                    </p>
+                    <button
+                        type="button"
+                        className="reading-reset-float-btn"
+                        onClick={() => {
+                            if (typeof window !== "undefined") {
+                                window.dispatchEvent(new CustomEvent("reading-chat-float-reset"));
+                            }
+                        }}
+                    >
+                        <RotateCcw size={15} strokeWidth={2} />
+                        重置悬浮球位置
+                    </button>
+                </section>
+            </div>
+        </ContentDialog>
+    );
+}

--- a/components/reading/reading-shelf.tsx
+++ b/components/reading/reading-shelf.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { ChevronLeft, Palette } from "lucide-react";
+import { ChevronLeft, Palette, Settings } from "lucide-react";
 import { loadBooks, addBook, deleteBook, saveChapters, loadProgress, saveRawFile } from "@/lib/reading-storage";
 import { decodeTxtArrayBuffer, parseTxtContent, parseEpubFile, PDF_PAGES_PER_CHAPTER } from "@/lib/reading-parser";
+import { loadReadingInteractionConfig } from "@/lib/reading-storage";
 import type { Book, BookChapter } from "@/lib/reading-types";
 import type { ReadingAppearance } from "@/lib/reading-appearance";
 import { ReadingAppearanceDialog } from "./reading-appearance-dialog";
+import { ReadingInteractionDialog } from "./reading-interaction-dialog";
 import { kvGet, kvSet, kvRemove } from "@/lib/kv-db";
 
 type Props = {
@@ -100,6 +102,7 @@ export function ReadingShelf({ onOpenBook, onClose, appearance, backgroundUrl, o
     const [importError, setImportError] = useState<{ summary: string; detail?: string } | null>(null);
     const [search, setSearch] = useState("");
     const [showAppearanceDialog, setShowAppearanceDialog] = useState(false);
+    const [showInteractionDialog, setShowInteractionDialog] = useState(false);
     const fileRef = useRef<HTMLInputElement>(null);
 
     const persistImportDiagnostic = (payload: ImportDiagnostic | null) => {
@@ -199,7 +202,7 @@ export function ReadingShelf({ onOpenBook, onClose, appearance, backgroundUrl, o
                     updatedAt: new Date().toISOString(),
                 });
                 const { text } = decodeTxtArrayBuffer(await file.arrayBuffer());
-                parsed = parseTxtContent(text, file.name);
+                parsed = parseTxtContent(text, file.name, loadReadingInteractionConfig().paragraphMode);
                 format = "txt";
             } else if (ext === "epub") {
                 importStage = "读取 EPUB 文件";
@@ -361,6 +364,9 @@ export function ReadingShelf({ onOpenBook, onClose, appearance, backgroundUrl, o
                         <ChevronLeft size={22} strokeWidth={2.5} />
                     </button>
                     <div className="reading-shelf-actions">
+                        <button className="reading-shelf-action-btn" type="button" onClick={() => setShowInteractionDialog(true)} aria-label="阅读设置">
+                            <Settings size={16} strokeWidth={1.7} />
+                        </button>
                         <button className="reading-shelf-action-btn" type="button" onClick={() => setShowAppearanceDialog(true)} aria-label="阅读外观">
                             <Palette size={16} strokeWidth={1.7} />
                         </button>
@@ -488,6 +494,10 @@ export function ReadingShelf({ onOpenBook, onClose, appearance, backgroundUrl, o
                     onClose={() => setShowAppearanceDialog(false)}
                     onSave={onSaveAppearance}
                 />
+            )}
+
+            {showInteractionDialog && (
+                <ReadingInteractionDialog onClose={() => setShowInteractionDialog(false)} />
             )}
         </div>
     );

--- a/components/reading/reading-viewer.tsx
+++ b/components/reading/reading-viewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect } from "react";
 import { Bot, ChevronDown, ChevronRight, Languages, Menu, Minus, PenLine, SendHorizontal, X } from "lucide-react";
 import {
     loadChapters,
@@ -18,7 +18,7 @@ import {
     DEFAULT_READING_INTERACTION_CONFIG,
 } from "@/lib/reading-storage";
 import { generateAnnotationBatch, generateReadingChat, parseReadingDiscussResponse, type ReadingDiscussAction, type ReadingDiscussContext } from "@/lib/reading-engine";
-import { loadChatMessages, pushChatMessage, deleteChatMessage, editChatMessage, loadChatContacts, loadChatSessions, isReadingDiscussMessage } from "@/lib/chat-storage";
+import { loadChatMessages, pushChatMessage, deleteChatMessage, editChatMessage, loadChatContacts, createOrGetSession, isReadingDiscussMessage } from "@/lib/chat-storage";
 import type { ChatMessage, ChatSession } from "@/lib/chat-storage";
 import { loadCharacters } from "@/lib/character-storage";
 import { parseAIResponse } from "@/lib/rich-message-parser";
@@ -60,6 +60,10 @@ const DISCUSS_MIN_CHARS = 700;
 const DISCUSS_MAX_CHARS = 1600;
 const DISCUSS_MAX_PARAGRAPHS = 16;
 
+/** 聊天悬浮球/悬浮条/悬浮窗的位置记忆键 */
+const CHAT_FLOAT_POS_KEY = "reading-chat-float-pos-v1";
+const CHAT_FLOAT_MARGIN = 12;
+
 function toCanvasFont(style: CSSStyleDeclaration): string {
     return [
         style.fontStyle,
@@ -76,6 +80,22 @@ function formatParagraphRangeLabel(start: number, end: number): string {
 
 function getParagraphLength(text: string): number {
     return text.replace(/\s+/g, "").length || text.trim().length;
+}
+
+/** 静默重试：生成失败时按用户配置的次数重试，重试间隔逐渐加大，全部失败后抛出最后一次错误 */
+async function withAnnotationRetry<T>(task: () => Promise<T>, retryCount: number): Promise<T> {
+    const maxAttempts = Math.max(1, retryCount + 1);
+    let lastError: unknown = null;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        try {
+            return await task();
+        } catch (err) {
+            lastError = err;
+            if (attempt >= maxAttempts) break;
+            await new Promise<void>((resolve) => setTimeout(resolve, Math.min(1200, 400 * attempt)));
+        }
+    }
+    throw lastError;
 }
 
 function buildPdfChunkTitle(startPage: number, endPage: number): string {
@@ -213,6 +233,12 @@ type Props = {
 export function ReadingViewer({ book, onBack }: Props) {
     const isPdf = book.format === "pdf";
     const [readingConfig, setReadingConfig] = useState(() => loadReadingInteractionConfig());
+    // 阅读器保持挂载（返回书架不卸载），书架设置页保存后通过事件同步最新配置
+    useEffect(() => {
+        const reload = () => setReadingConfig(loadReadingInteractionConfig());
+        window.addEventListener("reading-interaction-config-changed", reload);
+        return () => window.removeEventListener("reading-interaction-config-changed", reload);
+    }, []);
     const [chapters, setChapters] = useState<BookChapter[]>([]);
     const [chapterIndex, setChapterIndex] = useState(0);
     const [pdfCurrentPage, setPdfCurrentPage] = useState(1);
@@ -231,7 +257,19 @@ export function ReadingViewer({ book, onBack }: Props) {
     }, [showCharPicker, charPickerClosing]);
     const [showChat, setShowChat] = useState(false);
     const [chatExpanded, setChatExpanded] = useState(false);
-    const [chatOffset, setChatOffset] = useState({ x: 0, y: 0 });
+    const [chatOffset, setChatOffset] = useState<{ x: number; y: number }>(() => {
+        try {
+            const raw = localStorage.getItem(CHAT_FLOAT_POS_KEY);
+            if (!raw) return { x: 0, y: 0 };
+            const parsed = JSON.parse(raw) as { x?: unknown; y?: unknown };
+            if (typeof parsed.x === "number" && typeof parsed.y === "number" && Number.isFinite(parsed.x) && Number.isFinite(parsed.y)) {
+                return { x: parsed.x, y: parsed.y };
+            }
+        } catch {
+            // ignore storage errors
+        }
+        return { x: 0, y: 0 };
+    });
     const [isDragging, setIsDragging] = useState(false);
     const [chatInput, setChatInput] = useState("");
     const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
@@ -256,15 +294,31 @@ export function ReadingViewer({ book, onBack }: Props) {
     const chatDragRef = useRef<{ pointerId: number; startX: number; startY: number; originX: number; originY: number } | null>(null);
     const chatMovedRef = useRef(false);
     const scrollRef = useRef<HTMLDivElement>(null);
+    const chatListRef = useRef<HTMLDivElement>(null); // 共读讨论悬浮窗消息列表（滚动容器）
     const txtMeasureLineRef = useRef<HTMLParagraphElement>(null);
     const txtMeasureGapRef = useRef<HTMLDivElement>(null);
     const txtMeasureAnnotationRef = useRef<HTMLDivElement>(null);
     const generatedBatchesRef = useRef<Set<string>>(new Set());
-    const autoBootstrapInFlightRef = useRef(false);
+    /** 同步「生成中」锁：防止 auto/prefetch 竞态导致同一帧内并发发起多个批注生成任务 */
+    const annotationInFlightRef = useRef(false);
+    /** 正在生成中的批次 key：防止同一批在生成完成前被再次发起 */
+    const inFlightBatchesRef = useRef<Set<string>>(new Set());
     const pendingTxtPageFractionRef = useRef<number | null>(null);
     const lastTxtPaginationSignatureRef = useRef("");
+    // 滚动阅读模式：连续滚动（多章窗口无缝衔接）
+    const scrollFractionRef = useRef(0);
+    const initialScrollFractionRef = useRef<number | null>(null); // 打开书时保存的章节内比例
+    const pendingScrollFractionRef = useRef<number | null>(null); // 滑块跨章待定位比例
+    const scrollContentRef = useRef<HTMLDivElement>(null);        // 滚动内容容器（含多章块）
+    const chapterMetricsRef = useRef<Map<number, { top: number; height: number }>>(new Map()); // 各章块在滚动坐标系中的 top/height
+    const pendingScrollActionRef = useRef<{ kind: "shift-forward"; oldScrollTop: number; removedHeight: number } | { kind: "shift-backward"; oldScrollTop: number } | null>(null);
+    const shiftCooldownRef = useRef(false);                      // 窗口平移后的冷却期，防止边界来回抖动
+    const scrollPositionedKeyRef = useRef("");                   // 已做过初始定位的「书+模式」标识
+    const chapterIndexRef = useRef(0);
+    const chaptersLenRef = useRef(0);
     const [txtLayoutVersion, setTxtLayoutVersion] = useState(0);
     const [txtPages, setTxtPages] = useState<TxtPageItem[][]>([]);
+    const [scrollFraction, setScrollFraction] = useState(0);
     const [flipAnim, setFlipAnim] = useState<{ direction: 'forward' | 'backward'; items: TxtPageItem[] } | null>(null);
 
     const [enrichedContacts, setEnrichedContacts] = useState<(ReturnType<typeof loadChatContacts>[number] & { char: Character })[]>([]);
@@ -293,12 +347,39 @@ export function ReadingViewer({ book, onBack }: Props) {
     const companion = companionId ? (enrichedContacts.find(c => c.characterId === companionId)?.char || loadCharacters().find(c => c.id === companionId)) : null;
     const bilingualTranslationEnabled = readingConfig.bilingualTranslationEnabled === true;
     const defaultTranslationExpanded = readingConfig.collapseBilingualTranslation !== true;
+    const isScrollMode = !isPdf && readingConfig.readingMode === "scroll";
+    // 保持 ref 与最新状态同步（供长生命周期滚动回调读取）
+    chapterIndexRef.current = chapterIndex;
+    chaptersLenRef.current = chapters.length;
+    // 滚动模式渲染的章节窗口：上一章 + 当前章 + 下一章（无缝衔接用）
+    const windowChapters = useMemo(() => {
+        if (chapters.length === 0) return [] as BookChapter[];
+        const start = Math.max(0, chapterIndex - 1);
+        const end = Math.min(chapters.length - 1, chapterIndex + 1);
+        const out: BookChapter[] = [];
+        for (let i = start; i <= end; i++) out.push(chapters[i]);
+        return out;
+    }, [chapters, chapterIndex]);
+    // 滚动模式：将「章节内比例(0-1)」换算为具体滚动位置（窗口布局下按当前章块定位）
+    const scrollToChapterFraction = useCallback((fraction: number, targetChapterIndex: number) => {
+        const body = scrollRef.current;
+        if (!body) return;
+        const metrics = chapterMetricsRef.current.get(targetChapterIndex);
+        if (!metrics) return;
+        const maxScroll = Math.max(0, body.scrollHeight - body.clientHeight);
+        const span = Math.max(0, metrics.height - body.clientHeight);
+        const target = Math.max(0, Math.min(maxScroll, metrics.top + Math.max(0, Math.min(1, fraction)) * span));
+        body.scrollTop = target;
+        const actual = span > 0 ? Math.min(1, Math.max(0, (target - metrics.top) / span)) : 0;
+        scrollFractionRef.current = actual;
+        setScrollFraction(actual);
+    }, []);
     const currentChapter = chapters[chapterIndex];
     const txtPagesChapterIndex = txtPages[0]?.find((item) => item.kind !== "gap")?.chapterIndex ?? txtPages[0]?.[0]?.chapterIndex;
-    const txtPagesReadyForCurrentChapter = !isPdf && txtPages.length > 0 && txtPagesChapterIndex === chapterIndex;
+    const txtPagesReadyForCurrentChapter = !isPdf && !isScrollMode && txtPages.length > 0 && txtPagesChapterIndex === chapterIndex;
     const showTxtLoading = !isPdf && (
         !chaptersLoaded ||
-        (chaptersLoaded && chapters.length > 0 && Boolean(currentChapter) && !txtPagesReadyForCurrentChapter)
+        (chaptersLoaded && chapters.length > 0 && Boolean(currentChapter) && !isScrollMode && !txtPagesReadyForCurrentChapter)
     );
 
     const renderTxtPage = (pageIndex: number) => {
@@ -310,58 +391,61 @@ export function ReadingViewer({ book, onBack }: Props) {
                     item.kind === "gap"
                         ? <div key={i} className="reading-line-gap" />
                         : item.kind === "annotation"
-                            ? (
-                                <div
-                                    key={item.annotation.id}
-                                    className="reading-annotation reading-annotation-interactive"
-                                    data-no-nav="true"
-                                    onPointerDown={() => {
-                                        longPressTimer.current = setTimeout(() => {
-                                            setActiveMessageId(null);
-                                            setActiveAnnotationId(item.annotation.id);
-                                        }, 500);
-                                    }}
-                                    onPointerUp={() => { if (longPressTimer.current) clearTimeout(longPressTimer.current); }}
-                                    onPointerCancel={() => { if (longPressTimer.current) clearTimeout(longPressTimer.current); }}
-                                    onPointerLeave={() => { if (longPressTimer.current) clearTimeout(longPressTimer.current); }}
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        if (activeAnnotationId && activeAnnotationId !== item.annotation.id) setActiveAnnotationId(null);
-                                    }}
-                                >
-                                    <span className="reading-annotation-name">{item.annotation.characterName}</span>
-                                    <ReadingAnnotationContent
-                                        text={item.annotation.content}
-                                        bilingualEnabled={bilingualTranslationEnabled}
-                                        expanded={isAnnotationTranslationExpanded(item.annotation.id)}
-                                        onToggle={() => handleAnnotationTranslationToggle(item.annotation.id)}
-                                    />
-                                    {activeAnnotationId === item.annotation.id && (
-                                        <div className="ctx-menu reading-annotation-menu" onClick={(e) => e.stopPropagation()}>
-                                            <button
-                                                onClick={() => {
-                                                    copyToClipboard(item.annotation.content);
-                                                    setActiveAnnotationId(null);
-                                                }}
-                                                className="ctx-menu-btn"
-                                            >
-                                                复制
-                                            </button>
-                                            <button
-                                                onClick={() => { void handleDeleteReadingAnnotation(item.annotation.id); }}
-                                                className="ctx-menu-btn ctx-menu-btn-danger"
-                                            >
-                                                删除
-                                            </button>
-                                        </div>
-                                    )}
-                                </div>
-                            )
+                            ? renderAnnotationItem(item.annotation)
                             : <p key={i} className={`reading-line${item.indent ? " reading-line-indent" : ""}${item.segEnd ? " reading-line-seg-end" : ""}`}>{item.text}</p>
                 ))}
             </div>
         );
     };
+
+    // 批注块（翻页与滚动模式共用）：长按呼出 复制/删除 菜单
+    const renderAnnotationItem = (annotation: ReadingAnnotation) => (
+        <div
+            key={annotation.id}
+            className="reading-annotation reading-annotation-interactive"
+            data-no-nav="true"
+            onPointerDown={() => {
+                longPressTimer.current = setTimeout(() => {
+                    setActiveMessageId(null);
+                    setActiveAnnotationId(annotation.id);
+                }, 500);
+            }}
+            onPointerUp={() => { if (longPressTimer.current) clearTimeout(longPressTimer.current); }}
+            onPointerCancel={() => { if (longPressTimer.current) clearTimeout(longPressTimer.current); }}
+            onPointerLeave={() => { if (longPressTimer.current) clearTimeout(longPressTimer.current); }}
+            onClick={(e) => {
+                e.stopPropagation();
+                if (activeAnnotationId && activeAnnotationId !== annotation.id) setActiveAnnotationId(null);
+            }}
+        >
+            <span className="reading-annotation-name">{annotation.characterName}</span>
+            <ReadingAnnotationContent
+                text={annotation.content}
+                bilingualEnabled={bilingualTranslationEnabled}
+                expanded={isAnnotationTranslationExpanded(annotation.id)}
+                onToggle={() => handleAnnotationTranslationToggle(annotation.id)}
+            />
+            {activeAnnotationId === annotation.id && (
+                <div className="ctx-menu reading-annotation-menu" onClick={(e) => e.stopPropagation()}>
+                    <button
+                        onClick={() => {
+                            copyToClipboard(annotation.content);
+                            setActiveAnnotationId(null);
+                        }}
+                        className="ctx-menu-btn"
+                    >
+                        复制
+                    </button>
+                    <button
+                        onClick={() => { void handleDeleteReadingAnnotation(annotation.id); }}
+                        className="ctx-menu-btn ctx-menu-btn-danger"
+                    >
+                        删除
+                    </button>
+                </div>
+            )}
+        </div>
+    );
 
     const renderStaticPage = (items: TxtPageItem[]) => (
         <div className="reading-page-content">
@@ -439,13 +523,19 @@ export function ReadingViewer({ book, onBack }: Props) {
     // Find or create chat session for companion
     const getSession = useCallback((): ChatSession | null => {
         if (!companionId) return null;
-        const sessions = loadChatSessions();
-        return sessions.find(s => !s.isGroup && s.contactId === companionId) || null;
+        // 找不到与角色的一对一会话时自动创建（否则发送会静默无响应）
+        return createOrGetSession(companionId);
     }, [companionId]);
 
 
     // Load book data
     useEffect(() => {
+        // 清空上一本书遗留的滚动定位状态
+        initialScrollFractionRef.current = null;
+        pendingScrollFractionRef.current = null;
+        pendingScrollActionRef.current = null;
+        shiftCooldownRef.current = false;
+        scrollPositionedKeyRef.current = "";
         setChaptersLoaded(false);
         (async () => {
             let chs = await loadChapters(book.id);
@@ -486,7 +576,14 @@ export function ReadingViewer({ book, onBack }: Props) {
                     : 0;
                 setChapterIndex(safeChapterIndex);
                 setCompanionId(progress.companionCharacterId || null);
-                if (!isPdf) setTxtPage(Math.max(0, progress.scrollPosition || 0));
+                if (!isPdf) {
+                    if (progress.readingMode === "scroll") {
+                        // 滚动模式：scrollPosition 存的是章节内滚动比例(0-1)
+                        initialScrollFractionRef.current = Math.max(0, Math.min(1, progress.scrollPosition || 0));
+                    } else {
+                        setTxtPage(Math.max(0, progress.scrollPosition || 0));
+                    }
+                }
             }
             // Default companion: first contact
             if (!progress?.companionCharacterId && enrichedContacts.length > 0) {
@@ -548,10 +645,15 @@ export function ReadingViewer({ book, onBack }: Props) {
                 setAnnotations(groups.flat());
                 return;
             }
-            const annots = await loadAnnotations(book.id, chapterIndex);
-            setAnnotations(annots);
+            // 滚动模式：加载窗口内所有章节（上一章+当前章+下一章）的批注，
+            // 否则交界处批注缺失，且窗口平移时整组替换导致批注「时有时无」
+            const chapterIndexes = isScrollMode
+                ? [...new Set(windowChapters.map((c) => c.index))]
+                : [chapterIndex];
+            const groups = await Promise.all(chapterIndexes.map((idx) => loadAnnotations(book.id, idx)));
+            setAnnotations(groups.flat());
         })();
-    }, [book.id, chapterIndex, chapters, isPdf]);
+    }, [book.id, isPdf, isScrollMode, windowChapters]);
 
     // Load reading-discuss chat messages
     const refreshChatMessages = useCallback(() => {
@@ -626,16 +728,29 @@ export function ReadingViewer({ book, onBack }: Props) {
     }, [book.id, chapters, isPdf]);
 
     const buildTxtBatchRequest = useCallback((size: number, mode: AnnotationBatchMode): AnnotationBatchRequest | null => {
-        const pageItems = txtPages[txtPage] || [];
-        const visibleParagraphIndexes = [...new Set(
-            pageItems
-                .filter((item): item is Extract<TxtPageItem, { kind: "line" | "annotation" }> => item.kind === "line" || item.kind === "annotation")
-                .map((item) => item.paragraphIndex),
-        )].sort((a, b) => a - b);
-        if (visibleParagraphIndexes.length === 0) return null;
+        let minParagraphIndex: number;
+        let maxParagraphIndex: number;
 
-        const minParagraphIndex = visibleParagraphIndexes[0];
-        const maxParagraphIndex = visibleParagraphIndexes[visibleParagraphIndexes.length - 1];
+        if (isScrollMode) {
+            // 滚动模式没有分页：以当前滚动比例估算「正在阅读」的段落窗口
+            const total = currentChapter?.paragraphs.length || 0;
+            if (total === 0) return null;
+            const center = Math.round(Math.max(0, Math.min(1, scrollFraction)) * (total - 1));
+            const half = Math.max(1, Math.ceil(size / 2));
+            minParagraphIndex = Math.max(0, center - half);
+            maxParagraphIndex = Math.min(total - 1, center + half);
+        } else {
+            const pageItems = txtPages[txtPage] || [];
+            const visibleParagraphIndexes = [...new Set(
+                pageItems
+                    .filter((item): item is Extract<TxtPageItem, { kind: "line" | "annotation" }> => item.kind === "line" || item.kind === "annotation")
+                    .map((item) => item.paragraphIndex),
+            )].sort((a, b) => a - b);
+            if (visibleParagraphIndexes.length === 0) return null;
+            minParagraphIndex = visibleParagraphIndexes[0];
+            maxParagraphIndex = visibleParagraphIndexes[visibleParagraphIndexes.length - 1];
+        }
+
         const visibleRefs = paragraphRefs.filter((item) => item.chapterIndex === chapterIndex && item.paragraphIndex >= minParagraphIndex && item.paragraphIndex <= maxParagraphIndex);
         if (visibleRefs.length === 0) return null;
 
@@ -664,7 +779,7 @@ export function ReadingViewer({ book, onBack }: Props) {
             size,
             items,
         };
-    }, [chapterIndex, paragraphRefs, txtPage, txtPages]);
+    }, [chapterIndex, currentChapter, isScrollMode, paragraphRefs, scrollFraction, txtPage, txtPages]);
 
     const getPdfBatchWindow = useCallback((size: number, mode: AnnotationBatchMode) => {
         const chapterMaxPage = Math.max(0, ...chapters.map((chapter) => chapter.pageEnd ?? 0));
@@ -708,31 +823,39 @@ export function ReadingViewer({ book, onBack }: Props) {
         return buildPdfBatchRequest(size, mode, refs);
     }, [buildPdfBatchRequest, buildTxtBatchRequest, ensurePdfPageRangeParsed, getPdfBatchWindow, isPdf]);
 
-    const executeBatchAnnotation = useCallback(async (request: AnnotationBatchRequest, options?: { force?: boolean }) => {
-        if (!companionId || generating) return;
+    const executeBatchAnnotation = useCallback(async (request: AnnotationBatchRequest, options?: { force?: boolean }): Promise<boolean> => {
+        if (!companionId) return false;
         const batchKey = `${book.id}:${companionId}:${request.key}`;
-        if (!options?.force && generatedBatchesRef.current.has(batchKey)) return;
-
+        if (!options?.force && generatedBatchesRef.current.has(batchKey)) return false;
+        // 同步锁：同一时间只允许一个批注生成任务（auto/prefetch 竞态时后面的请求直接跳过，
+        // 避免闭包里的 generating 旧值放行并发请求，导致同一批被重复生成）
+        if (annotationInFlightRef.current) return false;
+        // 同一批已在生成中：跳过（生成完成前 generatedBatchesRef 尚未写入，需用 in-flight 集合兜底）
+        if (!options?.force && inFlightBatchesRef.current.has(batchKey)) return false;
+        annotationInFlightRef.current = true;
+        inFlightBatchesRef.current.add(batchKey);
         setGenerating(true);
         setAnnotationError(null);
 
         try {
+            // 历史已有批注仅作为生成参考传入（generateAnnotationBatch 接收 existingAnnotations），
+            // 不用于跳过：重新开启自动批注/重读书籍时，用户期望生成新的批注。
+            // 「本次阅读体验内不重复」由 generatedBatchesRef（内存）保证。
             const existing = await loadExistingAnnotationsForItems(request.items);
-            if (!options?.force && existing.length > 0) {
-                generatedBatchesRef.current.add(batchKey);
-                return;
-            }
 
-            const newAnnotations = await generateAnnotationBatch(
-                book,
-                request.title,
-                request.items.map((item) => ({
-                    chapterIndex: item.chapterIndex,
-                    paragraphIndex: item.paragraphIndex,
-                    text: item.text,
-                })),
-                existing,
-                companionId,
+            const newAnnotations = await withAnnotationRetry(
+                () => generateAnnotationBatch(
+                    book,
+                    request.title,
+                    request.items.map((item) => ({
+                        chapterIndex: item.chapterIndex,
+                        paragraphIndex: item.paragraphIndex,
+                        text: item.text,
+                    })),
+                    existing,
+                    companionId,
+                ),
+                readingConfig.annotationRetryCount > 0 ? readingConfig.annotationRetryCount : 0,
             );
 
             generatedBatchesRef.current.add(batchKey);
@@ -747,13 +870,17 @@ export function ReadingViewer({ book, onBack }: Props) {
             } else {
                 setAnnotationError("AI 没有返回批注（可能返回了[无批注]或API调用失败）");
             }
+            return true;
         } catch (err) {
             console.error("[Reading] Annotation error:", err);
             setAnnotationError(`批注失败: ${err instanceof Error ? err.message : String(err)}`);
+            return false;
         } finally {
+            inFlightBatchesRef.current.delete(batchKey);
+            annotationInFlightRef.current = false;
             setGenerating(false);
         }
-    }, [book, companionId, generating, loadExistingAnnotationsForItems]);
+    }, [book, companionId, loadExistingAnnotationsForItems, readingConfig.annotationRetryCount]);
 
     const openAnnotationDialog = (mode: AnnotationDialogMode) => {
         const nextSize = annotationBatchSize || (isPdf ? 5 : 50);
@@ -775,13 +902,9 @@ export function ReadingViewer({ book, onBack }: Props) {
             }
             setAutoAnnotate(true);
             generatedBatchesRef.current.clear();
-            autoBootstrapInFlightRef.current = true;
-            try {
-                const request = await materializeBatchRequest(size, "auto-current");
-                if (request) await executeBatchAnnotation(request);
-            } finally {
-                autoBootstrapInFlightRef.current = false;
-            }
+            prefetchedBatchStartRef.current = -1; // 新的阅读体验：预生成触发标记一并重置
+            const request = await materializeBatchRequest(size, "auto-current");
+            if (request) await executeBatchAnnotation(request);
             return;
         }
 
@@ -890,6 +1013,27 @@ export function ReadingViewer({ book, onBack }: Props) {
         }
     }, [showChat, chatExpanded]);
 
+    // 共读讨论悬浮窗展开时自动滚动到最新消息。
+    // 仅在「打开」时滚动一次、无持续吸附——用户随后自由滑动即可打断，不会被拉回。
+    useEffect(() => {
+        if (!showChat || !chatExpanded) return;
+        if (readingConfig.chatAutoScrollOnOpen === false) return;
+        const el = chatListRef.current;
+        if (!el) return;
+        let raf1 = 0;
+        let raf2 = 0;
+        // 等展开动画与内容渲染稳定后再滚到底
+        raf1 = window.requestAnimationFrame(() => {
+            raf2 = window.requestAnimationFrame(() => {
+                el.scrollTop = el.scrollHeight;
+            });
+        });
+        return () => {
+            window.cancelAnimationFrame(raf1);
+            window.cancelAnimationFrame(raf2);
+        };
+    }, [showChat, chatExpanded, readingConfig.chatAutoScrollOnOpen]);
+
     const handleDeleteReadingAnnotation = useCallback(async (annotationId: string) => {
         await deleteAnnotation(annotationId);
         setAnnotations((prev) => prev.filter((annotation) => annotation.id !== annotationId));
@@ -921,10 +1065,15 @@ export function ReadingViewer({ book, onBack }: Props) {
             const pageFraction = Math.max(0, Math.min(1, rawPosition - targetChapterIndex));
 
             if (targetChapterIndex === chapterIndex) {
-                pendingTxtPageFractionRef.current = null;
-                setTxtPage(Math.round(pageFraction * Math.max(0, txtTotalPages - 1)));
+                if (isScrollMode) {
+                    scrollToChapterFraction(pageFraction, chapterIndex);
+                } else {
+                    pendingTxtPageFractionRef.current = null;
+                    setTxtPage(Math.round(pageFraction * Math.max(0, txtTotalPages - 1)));
+                }
             } else {
                 pendingTxtPageFractionRef.current = pageFraction;
+                pendingScrollFractionRef.current = pageFraction;
                 setChapterIndex(targetChapterIndex);
                 setTxtPage(0);
             }
@@ -941,7 +1090,7 @@ export function ReadingViewer({ book, onBack }: Props) {
             return;
         }
 
-        if (!isPdf && currentChapter) {
+        if (!isPdf && !isScrollMode && currentChapter) {
             const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
             const x = e.clientX - rect.left;
             const w = rect.width;
@@ -953,13 +1102,66 @@ export function ReadingViewer({ book, onBack }: Props) {
     };
 
     useEffect(() => {
-        if (!autoAnnotate || generating || !companionId || autoBootstrapInFlightRef.current) return;
+        // 自动批注：跟随阅读位置推进，为当前批生成批注。
+        // 与开启时的 bootstrap 并发时由 executeBatchAnnotation 的同步锁去重；
+        // 若 bootstrap 未拿到批次（书刚打开数据未就绪），本 effect 会随阅读位置变化持续兜底触发。
+        if (!autoAnnotate || generating || !companionId) return;
         void (async () => {
             const request = await materializeBatchRequest(annotationBatchSize, "auto");
             if (!request) return;
             await executeBatchAnnotation(request);
         })();
     }, [annotationBatchSize, autoAnnotate, companionId, executeBatchAnnotation, generating, materializeBatchRequest]);
+
+    // 批注预生成：当前批注批读到用户设置的阈值时，提前生成下一批，
+    // 把生成时间差放在用户读上一批批注的时间里，避免用户读到下一批时批注还没生成完。不会重复批注（批次按 key 去重）。
+    const prefetchedBatchStartRef = useRef(-1);
+    useEffect(() => {
+        if (!autoAnnotate) { prefetchedBatchStartRef.current = -1; return; }
+        if (!readingConfig.autoAnnotatePrefetch || isPdf || !companionId || generating) return;
+        if (paragraphRefs.length === 0) return;
+        const size = Math.max(1, annotationBatchSize || 50);
+        const threshold = Math.max(0, Math.min(1, readingConfig.annotationPrefetchThreshold ?? 2 / 3));
+
+        // 当前阅读位置 → 全书记绝对段落索引
+        let currentAbs = -1;
+        if (isScrollMode) {
+            const chapterRefs = paragraphRefs.filter((item) => item.chapterIndex === chapterIndex && item.text.trim());
+            if (chapterRefs.length > 0) {
+                const center = Math.round(Math.max(0, Math.min(1, scrollFraction)) * (chapterRefs.length - 1));
+                currentAbs = chapterRefs[center].absoluteIndex;
+            }
+        } else {
+            const pageItems = txtPages[txtPage] || [];
+            const firstLine = pageItems.find((item): item is Extract<TxtPageItem, { kind: "line" }> => item.kind === "line");
+            if (firstLine) {
+                const ref = paragraphRefs.find((r) => r.chapterIndex === firstLine.chapterIndex && r.paragraphIndex === firstLine.paragraphIndex);
+                if (ref) currentAbs = ref.absoluteIndex;
+            }
+        }
+        if (currentAbs < 0) return;
+
+        const batchStart = Math.floor(currentAbs / size) * size;
+        if (currentAbs - batchStart < Math.ceil(size * threshold)) return; // 本批还没读到用户设置的阈值
+        if (prefetchedBatchStartRef.current === batchStart) return;       // 本批已触发过预生成
+        prefetchedBatchStartRef.current = batchStart;
+
+        const nextStart = batchStart + size;
+        if (nextStart >= paragraphRefs.length) return;
+        const items = paragraphRefs.slice(nextStart, nextStart + size).filter((item) => item.text.trim());
+        if (items.length === 0) return;
+
+        const request: AnnotationBatchRequest = {
+            key: `txt:${nextStart}:${size}`,
+            title: `第${items[0].absoluteIndex + 1}-${items[items.length - 1].absoluteIndex + 1}段`,
+            size,
+            items,
+        };
+        // 若被跳过（自动批注正在生成/该批已生成），重置标记让下一轮滚动再试，避免预生成丢失
+        void executeBatchAnnotation(request).then((started) => {
+            if (!started) prefetchedBatchStartRef.current = -1;
+        });
+    }, [annotationBatchSize, autoAnnotate, chapterIndex, companionId, executeBatchAnnotation, generating, isPdf, isScrollMode, paragraphRefs, readingConfig.autoAnnotatePrefetch, readingConfig.annotationPrefetchThreshold, scrollFraction, txtPage, txtPages]);
 
     useEffect(() => {
         if (!isPdf || pdfCurrentPage <= 0 || chapters.length === 0) return;
@@ -974,9 +1176,11 @@ export function ReadingViewer({ book, onBack }: Props) {
     const goToChapter = (idx: number, startFromEnd = false) => {
         if (idx < 0 || idx >= chapters.length) return;
         pendingTxtPageFractionRef.current = startFromEnd ? 1 : null;
+        // 滚动模式：显式跳章后定位到新章节的起点（0）或终点（1），而非窗口顶部（可能是上一章）
+        // 实际滚动位置由渲染后的 useLayoutEffect 依据章节块度量换算
+        pendingScrollFractionRef.current = startFromEnd ? 1 : 0;
         setChapterIndex(idx);
         setTxtPage(0);
-        scrollRef.current?.scrollTo(0, 0);
     };
 
     const buildDiscussContext = useCallback((sourceChapters: BookChapter[] = chapters): ReadingDiscussContext | null => {
@@ -1010,6 +1214,15 @@ export function ReadingViewer({ book, onBack }: Props) {
                     .filter((item) => item.chapterIndex === focusChapterIndex)
                     .map((item) => item.paragraphIndex),
             )].sort((a, b) => a - b);
+        } else if (isScrollMode) {
+            // 滚动模式没有分页：以当前滚动比例估算正在阅读的段落窗口
+            const chapterRefs0 = sourceParagraphRefs.filter((item) => item.chapterIndex === focusChapterIndex && item.text.trim());
+            if (chapterRefs0.length === 0) return null;
+            const center = Math.round(Math.max(0, Math.min(1, scrollFraction)) * (chapterRefs0.length - 1));
+            const half = Math.max(1, Math.ceil(DISCUSS_MAX_PARAGRAPHS / 3));
+            focusParagraphIndexes = chapterRefs0
+                .slice(Math.max(0, center - half), Math.min(chapterRefs0.length, center + half + 1))
+                .map((item) => item.paragraphIndex);
         } else {
             const pageItems = txtPages[txtPage] || [];
             focusParagraphIndexes = [...new Set(
@@ -1074,7 +1287,7 @@ export function ReadingViewer({ book, onBack }: Props) {
             chapterContent,
             annotations: contextAnnotations,
         };
-    }, [annotations, book.title, chapterIndex, chapters, currentChapter?.title, isPdf, pdfCurrentPage, txtPage, txtPages]);
+    }, [annotations, book.title, chapterIndex, chapters, currentChapter?.title, isPdf, isScrollMode, pdfCurrentPage, scrollFraction, txtPage, txtPages]);
 
     // Chat send — parse AI response like chat-room does
     const handleSend = async () => {
@@ -1212,8 +1425,10 @@ export function ReadingViewer({ book, onBack }: Props) {
 
     const handleChatDragStart = (e: React.PointerEvent<HTMLElement>) => {
         if (e.pointerType === "mouse" && e.button !== 0) return;
-        // Don't hijack the message list scroll or the input — only drag from the chrome.
-        if ((e.target as HTMLElement).closest("button, input, textarea, select, a, .reading-chat-float-body, .reading-char-picker")) return;
+        // 悬浮球自身就是一个 button，点击与拖拽靠 chatMovedRef 区分，必须允许拖拽；
+        // 悬浮条/窗内部的交互元素（按钮/输入框/正文滚动区等）不参与拖拽，避免抢占点击。
+        const target = e.target as HTMLElement;
+        if (!target.closest(".reading-chat-launch") && target.closest("button, input, textarea, select, a, .reading-chat-float-body, .reading-char-picker")) return;
         setIsDragging(true);
         chatDragRef.current = {
             pointerId: e.pointerId,
@@ -1236,9 +1451,78 @@ export function ReadingViewer({ book, onBack }: Props) {
             chatMovedRef.current = true;
         }
         if (chatMovedRef.current) {
-            setChatOffset({ x: nextX, y: nextY });
+            // 拖拽过程中就约束在屏幕内，悬浮元素永不滑出屏幕外
+            setChatOffset(clampChatOffset({ x: nextX, y: nextY }));
         }
     };
+
+    // 悬浮元素尺寸（按当前形态估算，用于边界约束/贴边吸附）
+    const getChatFloatSize = () => {
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        if (!showChat) return { width: 56, height: 56 };                                    // 悬浮球
+        if (!chatExpanded) return { width: Math.min(280, w - CHAT_FLOAT_MARGIN * 2), height: 56 }; // 悬浮条
+        return { width: Math.min(300, w - CHAT_FLOAT_MARGIN * 2), height: Math.min(380, h * 0.55) }; // 悬浮窗
+    };
+
+    // 把偏移量约束在可视范围内。CSS 基础位置为 left:12px / bottom:12px，
+    // 偏移是相对该基础位置的 translate3d，正 Y 向下。
+    const clampChatOffset = (offset: { x: number; y: number }): { x: number; y: number } => {
+        const { width, height } = getChatFloatSize();
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        const maxX = w - CHAT_FLOAT_MARGIN * 2 - width;
+        const maxY = height + CHAT_FLOAT_MARGIN * 2 - h; // 允许向上拖到接近顶边（负值表示可上移）
+        return {
+            x: Math.max(0, Math.min(maxX, offset.x)),
+            y: Math.max(maxY, Math.min(0, offset.y)),
+        };
+    };
+
+    const persistChatFloatPos = (offset: { x: number; y: number }) => {
+        try {
+            localStorage.setItem(CHAT_FLOAT_POS_KEY, JSON.stringify(clampChatOffset(offset)));
+        } catch {
+            // ignore storage errors
+        }
+    };
+
+    // 悬浮形态切换（球→条→窗 / 收起）后把位置约束回可视范围，防止越界丢失
+    useEffect(() => {
+        setChatOffset((prev) => {
+            const clamped = clampChatOffset(prev);
+            return clamped.x === prev.x && clamped.y === prev.y ? prev : clamped;
+        });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [showChat, chatExpanded]);
+
+    // 始终指向最新版本的 clampChatOffset（供一次性挂载的监听器使用）
+    const clampChatOffsetRef = useRef(clampChatOffset);
+    clampChatOffsetRef.current = clampChatOffset;
+
+    // 窗口尺寸变化（旋转/分屏）后把悬浮元素约束回屏幕内；书架设置里的「重置位置」事件
+    useEffect(() => {
+        const onResize = () => {
+            setChatOffset((prev) => {
+                const clamped = clampChatOffsetRef.current(prev);
+                return clamped.x === prev.x && clamped.y === prev.y ? prev : clamped;
+            });
+        };
+        const onResetPos = () => {
+            setChatOffset({ x: 0, y: 0 });
+            try {
+                localStorage.setItem(CHAT_FLOAT_POS_KEY, JSON.stringify({ x: 0, y: 0 }));
+            } catch {
+                // ignore storage errors
+            }
+        };
+        window.addEventListener("resize", onResize);
+        window.addEventListener("reading-chat-float-reset", onResetPos);
+        return () => {
+            window.removeEventListener("resize", onResize);
+            window.removeEventListener("reading-chat-float-reset", onResetPos);
+        };
+    }, []);
 
     const handleChatDragEnd = (e: React.PointerEvent<HTMLElement>) => {
         const drag = chatDragRef.current;
@@ -1247,37 +1531,24 @@ export function ReadingViewer({ book, onBack }: Props) {
         e.currentTarget.releasePointerCapture?.(e.pointerId);
         setIsDragging(false);
 
-        // Snap to edges horizontally if not expanded, or bound within screen
-        const marginX = 12; // left/right margin defined in CSS
-        const marginY = 12; // bottom margin
-        const w = window.innerWidth;
-        const h = window.innerHeight;
-
-        let targetX = chatOffset.x;
-        let targetY = chatOffset.y;
-
-        // Keep inside bounds roughly
-        // If not expanded, we might want to snap to left or right edge.
-        // For simplicity, just bound it inside the screen so it doesn't get lost
-        const elWidth = chatExpanded ? 300 : Math.min(260, w - 64);
-        const elHeight = chatExpanded ? 380 : 56;
-
-        // Original CSS positions it at left: 12px, bottom: 12px
-        // So default position is (0,0) offset from that.
-        // Screen bounds for offset:
-        const minX = -marginX; // touch left edge
-        const maxX = w - elWidth - marginX; // touch right edge
-        const maxY = h - elHeight - marginY - 60; // 60 for safe area approx
-        const minY = -marginY - 120; // Some upper bound
-
-        targetX = Math.max(minX, Math.min(targetX, maxX));
-        // Only apply strict Y bounding if it goes way out of bounds
-        // Since Y is from bottom, positive Y goes up, negative Y goes down
-        // Wait, translate3d positive Y goes DOWN visually.
-        // We'll just do a light bounding to ensure it doesn't disappear.
-        if (targetX !== chatOffset.x || targetY !== chatOffset.y) {
-            setChatOffset({ x: targetX, y: chatOffset.y });
+        // 纯点击（没拖动）不吸附、不改位置
+        if (!chatMovedRef.current) {
+            chatMovedRef.current = false;
+            return;
         }
+        chatMovedRef.current = false;
+
+        let target = clampChatOffset({ x: chatOffset.x, y: chatOffset.y });
+        if (!chatExpanded) {
+            // 悬浮球/悬浮条：横向吸附到最近的边缘（贴左或贴右）
+            const { width } = getChatFloatSize();
+            const maxX = window.innerWidth - CHAT_FLOAT_MARGIN * 2 - width;
+            const leftDist = target.x;
+            const rightDist = maxX - target.x;
+            target = { x: leftDist <= rightDist ? 0 : maxX, y: target.y };
+        }
+        setChatOffset(target);
+        persistChatFloatPos(target);
     };
 
     const handleChatLaunchClick = () => {
@@ -1316,8 +1587,9 @@ export function ReadingViewer({ book, onBack }: Props) {
     }, [annotations, chapterIndex, currentChapter, isPdf]);
 
     // TXT pagination — split by actual rendered width/height so each page fits one screen.
+    // 滚动模式下不参与分页，直接渲染整章内容。
     useEffect(() => {
-        if (isPdf || !currentChapter || !scrollRef.current || !txtMeasureLineRef.current || !txtMeasureGapRef.current || !txtMeasureAnnotationRef.current) {
+        if (isPdf || isScrollMode || !currentChapter || !scrollRef.current || !txtMeasureLineRef.current || !txtMeasureGapRef.current || !txtMeasureAnnotationRef.current) {
             setTxtPages([]);
             return;
         }
@@ -1445,7 +1717,7 @@ export function ReadingViewer({ book, onBack }: Props) {
 
         lastTxtPaginationSignatureRef.current = paginationSignature;
         setTxtPages(pages);
-    }, [annotations, bilingualTranslationEnabled, chapterIndex, currentChapter, isAnnotationTranslationExpanded, isPdf, txtLayoutVersion]);
+    }, [annotations, bilingualTranslationEnabled, chapterIndex, currentChapter, isAnnotationTranslationExpanded, isPdf, isScrollMode, txtLayoutVersion]);
 
     const txtTotalPages = txtPagesReadyForCurrentChapter ? txtPages.length : 1;
 
@@ -1476,48 +1748,187 @@ export function ReadingViewer({ book, onBack }: Props) {
     const txtBookSliderValue = (() => {
         if (chapters.length === 0) return 1;
         const boundedChapterIndex = Math.max(0, Math.min(chapters.length - 1, chapterIndex));
-        const boundedTxtPage = Math.max(0, Math.min(txtPage, txtTotalPages - 1));
-        const pageFraction = txtTotalPages > 1 ? boundedTxtPage / (txtTotalPages - 1) : 0;
+        const pageFraction = isScrollMode
+            ? Math.max(0, Math.min(1, scrollFraction))
+            : (txtTotalPages > 1 ? Math.max(0, Math.min(txtPage, txtTotalPages - 1)) / (txtTotalPages - 1) : 0);
         return Math.max(1, Math.min(txtBookSliderMax, boundedChapterIndex + 1 + pageFraction));
     })();
     useEffect(() => {
-        if (isPdf) return;
+        if (isPdf || isScrollMode) return;
         const pendingFraction = pendingTxtPageFractionRef.current;
         if (pendingFraction === null || txtPagesChapterIndex !== chapterIndex) return;
 
         setTxtPage(Math.round(pendingFraction * Math.max(0, txtTotalPages - 1)));
         pendingTxtPageFractionRef.current = null;
-    }, [chapterIndex, isPdf, txtPagesChapterIndex, txtTotalPages]);
+    }, [chapterIndex, isPdf, isScrollMode, txtPagesChapterIndex, txtTotalPages]);
 
     useEffect(() => {
         if (chapters.length === 0) return;
 
-        const chapterPageCurrent = Math.max(1, txtPage + 1);
-        const chapterPageTotal = Math.max(1, txtTotalPages);
-        const progressFraction = isPdf
-            ? (pdfTotalPages > 0 ? Math.min(1, Math.max(0, pdfCurrentPage / pdfTotalPages)) : 0)
-            : Math.min(1, Math.max(0, (chapterIndex + chapterPageCurrent / chapterPageTotal) / Math.max(1, chapters.length)));
+        let scrollPosition: number;
+        let progressFraction: number;
+        let progressCurrent: number;
+        let progressTotal: number;
+        let progressScope: "book" | "chapter";
+        if (isPdf) {
+            scrollPosition = Math.max(0, pdfCurrentPage - 1);
+            progressFraction = pdfTotalPages > 0 ? Math.min(1, Math.max(0, pdfCurrentPage / pdfTotalPages)) : 0;
+            progressCurrent = Math.max(1, pdfCurrentPage);
+            progressTotal = Math.max(1, pdfTotalPages || 1);
+            progressScope = "book";
+        } else if (isScrollMode) {
+            const fraction = Math.max(0, Math.min(1, scrollFraction));
+            scrollPosition = fraction;
+            progressFraction = Math.min(1, Math.max(0, (chapterIndex + fraction) / Math.max(1, chapters.length)));
+            progressCurrent = Math.max(1, Math.round(fraction * 100));
+            progressTotal = 100;
+            progressScope = "chapter";
+        } else {
+            const chapterPageCurrent = Math.max(1, txtPage + 1);
+            const chapterPageTotal = Math.max(1, txtTotalPages);
+            scrollPosition = txtPage;
+            progressFraction = Math.min(1, Math.max(0, (chapterIndex + chapterPageCurrent / chapterPageTotal) / Math.max(1, chapters.length)));
+            progressCurrent = chapterPageCurrent;
+            progressTotal = chapterPageTotal;
+            progressScope = "chapter";
+        }
 
         const progress: ReadingProgress = {
             bookId: book.id,
             chapterIndex,
-            scrollPosition: isPdf ? Math.max(0, pdfCurrentPage - 1) : txtPage,
+            scrollPosition,
             companionCharacterId: companionId || undefined,
             progressFraction,
-            progressCurrent: isPdf ? Math.max(1, pdfCurrentPage) : chapterPageCurrent,
-            progressTotal: isPdf ? Math.max(1, pdfTotalPages || 1) : chapterPageTotal,
-            progressScope: isPdf ? "book" : "chapter",
+            progressCurrent,
+            progressTotal,
+            progressScope,
+            readingMode: isPdf ? undefined : (isScrollMode ? "scroll" : "page"),
             lastReadAt: new Date().toISOString(),
         };
         saveProgress(progress);
-    }, [book.id, chapterIndex, chapters.length, companionId, isPdf, pdfCurrentPage, pdfTotalPages, txtPage, txtTotalPages]);
+    }, [book.id, chapterIndex, chapters.length, companionId, isPdf, isScrollMode, pdfCurrentPage, pdfTotalPages, scrollFraction, txtPage, txtTotalPages]);
 
     useEffect(() => {
         setTxtPage((prev) => Math.min(prev, Math.max(0, txtTotalPages - 1)));
     }, [txtTotalPages]);
 
-    // Scroll to top when page changes
-    useEffect(() => { scrollRef.current?.scrollTo(0, 0); }, [txtPage]);
+    // Scroll to top when page changes (仅翻页模式；滚动模式的位置由 useLayoutEffect 统一管理)
+    useEffect(() => {
+        if (isScrollMode) return;
+        scrollRef.current?.scrollTo(0, 0);
+    }, [txtPage, isScrollMode]);
+
+    // 滚动模式：监听滚动 —— 更新章节内滚动比例；无缝衔接（多章窗口平移，保持视觉连续）
+    // 前向：当前章内容读完（章底滚到视口顶部/底部）→ 移除顶部章块 + 补偿滚动位置，自然过渡到下一章
+    // 后向：滚到窗口顶部 → 顶部前插上一章块 + 补偿滚动位置，自然回到上一章（无需「上一章」按钮）
+    useEffect(() => {
+        if (!isScrollMode) return;
+        const body = scrollRef.current;
+        if (!body) return;
+        let rafId = 0;
+        const onScroll = () => {
+            if (rafId) return;
+            rafId = window.requestAnimationFrame(() => {
+                rafId = 0;
+                const ci = chapterIndexRef.current;
+                const len = chaptersLenRef.current;
+                const viewport = body.clientHeight;
+                const maxScroll = Math.max(0, body.scrollHeight - viewport);
+                const metrics = chapterMetricsRef.current.get(ci);
+                let fraction = 0;
+                if (metrics) {
+                    const span = Math.max(1, metrics.height - viewport);
+                    fraction = Math.min(1, Math.max(0, (body.scrollTop - metrics.top) / span));
+                } else {
+                    fraction = maxScroll > 0 ? Math.min(1, Math.max(0, body.scrollTop / maxScroll)) : 0;
+                }
+                scrollFractionRef.current = fraction;
+                setScrollFraction(fraction);
+                if (!metrics) return;
+
+                // 离开顶部后解除平移冷却
+                if (body.scrollTop > 2) shiftCooldownRef.current = false;
+
+                const bottom = metrics.top + metrics.height;
+                // 高章节（超一屏）：章底滚到视口底部即衔接下一章，header 同步更新；
+                // 矮章节（不足一屏）：等章底滚到视口顶部再衔接，避免移除顶部章块后滚动位置为负导致跳动
+                const triggerAt = metrics.height >= viewport ? bottom - viewport - 2 : bottom - 2;
+                // 前向：当前章已读完 → 移除顶部章块，窗口后移
+                if (!shiftCooldownRef.current && ci < len - 1 && body.scrollTop >= triggerAt) {
+                    shiftCooldownRef.current = true;
+                    const prevMetrics = chapterMetricsRef.current.get(ci - 1);
+                    pendingScrollActionRef.current = {
+                        kind: "shift-forward",
+                        oldScrollTop: body.scrollTop,
+                        removedHeight: prevMetrics ? prevMetrics.height : 0,
+                    };
+                    setChapterIndex(ci + 1);
+                    return;
+                }
+                // 后向：已滚到窗口顶部 → 顶部前插上一章块，窗口前移
+                if (!shiftCooldownRef.current && ci > 0 && body.scrollTop <= 2) {
+                    shiftCooldownRef.current = true;
+                    pendingScrollActionRef.current = { kind: "shift-backward", oldScrollTop: body.scrollTop };
+                    setChapterIndex(ci - 1);
+                    return;
+                }
+            });
+        };
+        body.addEventListener("scroll", onScroll, { passive: true });
+        return () => {
+            body.removeEventListener("scroll", onScroll);
+            if (rafId) window.cancelAnimationFrame(rafId);
+        };
+    }, [isScrollMode]);
+
+    // 滚动模式：渲染后测量各章块位置，并应用窗口平移补偿 / 显式定位（useLayoutEffect 保证在绘制前执行，无闪跳）
+    useLayoutEffect(() => {
+        if (!isScrollMode || !chaptersLoaded) return;
+        const content = scrollContentRef.current;
+        const body = scrollRef.current;
+        if (!content || !body || windowChapters.length === 0) return;
+
+        // 1. 测量窗口内各章块在滚动坐标系中的位置（top 与 body.scrollTop 同坐标系）
+        const bodyRect = body.getBoundingClientRect();
+        const metrics = new Map<number, { top: number; height: number }>();
+        for (const chunk of content.querySelectorAll<HTMLElement>("[data-chapter-index]")) {
+            const idx = Number(chunk.getAttribute("data-chapter-index"));
+            if (!Number.isFinite(idx)) continue;
+            const rect = chunk.getBoundingClientRect();
+            metrics.set(idx, { top: rect.top - bodyRect.top + body.scrollTop, height: rect.height });
+        }
+        chapterMetricsRef.current = metrics;
+
+        // 2. 窗口平移补偿（保持视觉位置不动，实现无缝衔接）
+        const action = pendingScrollActionRef.current;
+        if (action) {
+            pendingScrollActionRef.current = null;
+            if (action.kind === "shift-forward") {
+                body.scrollTop = Math.max(0, action.oldScrollTop - action.removedHeight);
+            } else {
+                const newPrev = metrics.get(chapterIndex - 1);
+                body.scrollTop = Math.max(0, action.oldScrollTop + (newPrev ? newPrev.height : 0));
+            }
+            return;
+        }
+
+        // 3. 显式跳章 / 打开恢复 / 默认定位到当前章起点
+        const positionKey = `${book.id}:${isScrollMode}`;
+        const pendingFraction = pendingScrollFractionRef.current;
+        const initialFraction = initialScrollFractionRef.current;
+        if (pendingFraction !== null) {
+            pendingScrollFractionRef.current = null;
+            scrollPositionedKeyRef.current = positionKey;
+            scrollToChapterFraction(pendingFraction, chapterIndex);
+        } else if (initialFraction !== null) {
+            initialScrollFractionRef.current = null;
+            scrollPositionedKeyRef.current = positionKey;
+            scrollToChapterFraction(initialFraction, chapterIndex);
+        } else if (scrollPositionedKeyRef.current !== positionKey) {
+            scrollPositionedKeyRef.current = positionKey;
+            scrollToChapterFraction(0, chapterIndex);
+        }
+    }, [isScrollMode, chapterIndex, windowChapters, chaptersLoaded, annotations, txtLayoutVersion, book.id]);
 
     // Swipe handlers for TXT
     const handleTouchStart = (e: React.TouchEvent) => {
@@ -1600,7 +2011,7 @@ export function ReadingViewer({ book, onBack }: Props) {
                             <div
                                 key={c.characterId}
                                 className="chat-contact-item"
-                                onClick={() => { setCompanionId(c.characterId); closeCharPicker(); generatedBatchesRef.current.clear(); }}
+                                onClick={() => { setCompanionId(c.characterId); closeCharPicker(); generatedBatchesRef.current.clear(); prefetchedBatchStartRef.current = -1; }}
                             >
                                 <div className="chat-contact-avatar"
                                     style={companionId === c.characterId ? { outline: "3px solid var(--c-success)", outlineOffset: "2px" } : undefined}
@@ -1617,7 +2028,7 @@ export function ReadingViewer({ book, onBack }: Props) {
             {/* Reading content */}
             <div
                 ref={scrollRef}
-                className={`relative flex-1 min-h-0 px-4 pt-1 pb-3 ${isPdf ? "overflow-auto" : "overflow-hidden"}`}
+                className={`relative flex-1 min-h-0 px-4 pt-1 pb-3 ${(isPdf || isScrollMode) ? "overflow-auto" : "overflow-hidden"}`}
                 data-ui="body"
                 onClick={handleReadingSurfaceClick}
             >
@@ -1657,6 +2068,33 @@ export function ReadingViewer({ book, onBack }: Props) {
                         <div className="reading-debug-line">当前页进度：{txtPage + 1}/{txtTotalPages}</div>
                         <div className="reading-debug-hint">章节数据存在，但当前索引取不到正文。这个状态不是“正在加载”，而是本地章节数据和进度状态不一致。</div>
                     </div>
+                ) : isScrollMode ? (
+                    <div ref={scrollContentRef} className="reading-scroll-content">
+                        {windowChapters.map((chapter) => (
+                            <div key={chapter.id} data-chapter-index={chapter.index}>
+                                {chapter.paragraphs.map((paragraph, pIndex) => {
+                                    const segmentCount = paragraph.split("\n").length;
+                                    const paragraphAnnotations = annotations.filter(
+                                        (annotation) => annotation.chapterIndex === chapter.index && annotation.paragraphIndex === pIndex
+                                    );
+                                    return (
+                                        <div key={pIndex} className="reading-scroll-block">
+                                            {paragraph.split("\n").map((segment, sIndex) => (
+                                                <p
+                                                    key={sIndex}
+                                                    className={`reading-line reading-line-indent${sIndex === segmentCount - 1 ? " reading-line-seg-end" : ""}`}
+                                                >
+                                                    {segment}
+                                                </p>
+                                            ))}
+                                            {paragraphAnnotations.map((annotation) => renderAnnotationItem(annotation))}
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        ))}
+                        <div className="h-[72px]" aria-hidden="true" />
+                    </div>
                 ) : (
                     <>
                         <div
@@ -1689,7 +2127,7 @@ export function ReadingViewer({ book, onBack }: Props) {
 
             {/* Immersive Page Number */}
             <span className={`reading-immersive-page ${immersive ? 'opacity-35' : 'opacity-0'}`}>
-                {isPdf ? `${pdfCurrentPage}/${pdfTotalPages || "?"}` : `${txtDisplayedPage}/${txtTotalPages}`}
+                {isPdf ? `${pdfCurrentPage}/${pdfTotalPages || "?"}` : isScrollMode ? `${Math.round(Math.max(0, Math.min(1, scrollFraction)) * 100)}%` : `${txtDisplayedPage}/${txtTotalPages}`}
             </span>
 
             {/* Bottom bar — mirrors header style */}
@@ -1831,7 +2269,7 @@ export function ReadingViewer({ book, onBack }: Props) {
                                 <button type="button" onClick={() => { if (shouldIgnoreChatAction()) return; setChatExpanded(false); }} className="reading-chat-float-close" aria-label="收起聊天窗口"><ChevronDown size={18} strokeWidth={2} /></button>
                                 <button type="button" onClick={() => { if (shouldIgnoreChatAction()) return; handleCloseChat(); }} className="reading-chat-float-close" aria-label="关闭聊天悬浮窗"><Minus size={18} strokeWidth={2} /></button>
                             </div>
-                            <div className="reading-chat-float-body" onClick={() => {
+                            <div ref={chatListRef} className="reading-chat-float-body" onClick={() => {
                                 if (activeMessageId || readingMessageMenu) closeReadingMessageMenu();
                                 if (activeAnnotationId) setActiveAnnotationId(null);
                             }} onScroll={() => {

--- a/lib/reading-parser.ts
+++ b/lib/reading-parser.ts
@@ -127,12 +127,27 @@ function isChapterHeading(line: string): boolean {
     return CHAPTER_PATTERNS.some(p => p.test(trimmed));
 }
 
+/** 剥离开头/结尾的空行：下载 TXT 常在章节标题前后插入分隔空行，
+ *  它们不是作者段落空行，混入会污染 splitParagraphs 的空行占比检测。 */
+function trimBlankEdges(arr: string[]): string[] {
+    let s = 0;
+    let e = arr.length;
+    while (s < e && arr[s].trim() === "") s += 1;
+    while (e > s && arr[e - 1].trim() === "") e -= 1;
+    return arr.slice(s, e);
+}
+
 /**
  * Parse TXT content into chapters and paragraphs.
  * Splits by chapter headings, then by blank lines for paragraphs.
+ * @param mode 段落划分方式：auto 自动探测 / blank 空行 / indent 段首缩进 / line 每行一段
  */
-export function parseTxtContent(text: string, fileName?: string): ParsedBook {
+export function parseTxtContent(text: string, fileName?: string, mode: TxtParagraphMode = "auto"): ParsedBook {
     const lines = text.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+
+    // auto 模式：对整本书探测一次段落格式，所有章节共用同一结论，
+    // 避免短章节里夹杂的空白行让个别章节误判成别的格式。
+    const resolvedMode = mode === "auto" ? detectParagraphMode(lines) : mode;
 
     // First pass: find chapter boundaries
     const chapterStarts: { lineIdx: number; title: string }[] = [];
@@ -156,7 +171,7 @@ export function parseTxtContent(text: string, fileName?: string): ParsedBook {
             title: bookTitle,
             chapters: [{
                 title: "全文",
-                paragraphs: splitParagraphs(lines),
+                paragraphs: splitParagraphs(trimBlankEdges(lines), resolvedMode),
             }],
         };
     }
@@ -166,8 +181,8 @@ export function parseTxtContent(text: string, fileName?: string): ParsedBook {
     for (let i = 0; i < chapterStarts.length; i++) {
         const start = chapterStarts[i].lineIdx + 1; // skip heading line
         const end = i + 1 < chapterStarts.length ? chapterStarts[i + 1].lineIdx : lines.length;
-        const chapterLines = lines.slice(start, end);
-        const paragraphs = splitParagraphs(chapterLines);
+        const chapterLines = trimBlankEdges(lines.slice(start, end));
+        const paragraphs = splitParagraphs(chapterLines, resolvedMode);
         if (paragraphs.length > 0) {
             chapters.push({ title: chapterStarts[i].title, paragraphs });
         }
@@ -175,8 +190,8 @@ export function parseTxtContent(text: string, fileName?: string): ParsedBook {
 
     // If there's content before the first chapter, add it as a prologue
     if (chapterStarts[0].lineIdx > 1) {
-        const prologueLines = lines.slice(0, chapterStarts[0].lineIdx);
-        const paragraphs = splitParagraphs(prologueLines);
+        const prologueLines = trimBlankEdges(lines.slice(0, chapterStarts[0].lineIdx));
+        const paragraphs = splitParagraphs(prologueLines, resolvedMode);
         if (paragraphs.length > 0) {
             chapters.unshift({ title: "序", paragraphs });
         }
@@ -185,8 +200,62 @@ export function parseTxtContent(text: string, fileName?: string): ParsedBook {
     return { title: bookTitle, chapters };
 }
 
-/** Split lines into paragraphs by blank lines, merging consecutive non-blank lines. */
-function splitParagraphs(lines: string[]): string[] {
+/** 判断一行是否以缩进开头（全角空格 / 2+ 半角空格 / Tab）→ 视为新段落起点。
+ *  很多中文网文 TXT 段落之间没有空行，仅靠段首缩进区分段落；
+ *  若只按空行分割会把整章合并成一段（批注/讨论时整章一起发给模型）。
+ */
+function isIndentedParagraphStart(line: string): boolean {
+    return /^\u3000/.test(line)   // 全角空格缩进（中文网文最常见）
+        || /^ {2,}/.test(line)    // 2+ 半角空格缩进
+        || /^\t/.test(line);      // Tab 缩进
+}
+
+/** 松散标题行检测：比 isChapterHeading 更宽泛，仅用于识别「章节分隔空行」。
+ *  下载 TXT 常在章节标题前后插入分隔空行，这些不是作者段落空行，
+ *  若混进空行占比会污染 splitParagraphs 的格式探测（章节很多但每章很短的小说
+ *  空行占比轻松超过 2%，被误判成空行分段 → 整章变成一段）。 */
+const LENIENT_TITLE_PATTERNS = [
+    /^第[零一二三四五六七八九十百千\d]+[章节回卷集部篇]/,   // 第X章/节/回/卷/部/篇
+    /^[序楔]/,                                            // 序章 / 楔子
+    /^(?:终章|后记|前言|番外|尾声|外传|引子)/,            // 常见非数字标题
+    /^[Cc]hapter\s+\d+/,
+    /^[Pp]art\s+[IVXLCDM\d]+/,
+    /^[零一二三四五六七八九十百千\d]+[、.．:：]/,           // 一、 / 1、 / 1.
+    /^[（(][零一二三四五六七八九十百千\d]+[)）]/,           // （一）/（1）
+    /^《.+》$/,                                            // 《书名》式短行
+    /^[=#*\-]{3,}$/,                                      // 分隔线
+];
+
+function isTitleLikeLine(line: string): boolean {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.length > 40) return false;
+    return LENIENT_TITLE_PATTERNS.some((p) => p.test(trimmed));
+}
+
+/** 统计「作者段落空行」数量：连续空行块紧邻标题行（前或后）的视为章节分隔空行，不计数 */
+function countAuthorBlankLines(lines: string[]): number {
+    const titleLike = new Set<number>();
+    lines.forEach((line, i) => {
+        if (isTitleLikeLine(line)) titleLike.add(i);
+    });
+
+    const isBlank = (i: number) => i >= 0 && i < lines.length && lines[i].trim() === "";
+    let count = 0;
+    let i = 0;
+    while (i < lines.length) {
+        if (!isBlank(i)) { i += 1; continue; }
+        const runStart = i;
+        while (i < lines.length && isBlank(i)) i += 1;
+        const runEnd = i - 1;
+        const beforeTitle = runStart > 0 && titleLike.has(runStart - 1);
+        const afterTitle = runEnd + 1 < lines.length && titleLike.has(runEnd + 1);
+        if (!beforeTitle && !afterTitle) count += runEnd - runStart + 1;
+    }
+    return count;
+}
+
+/** 按空行分段（标准网文导出格式；段内多行保持在同一段） */
+function splitByBlankLines(lines: string[]): string[] {
     const paragraphs: string[] = [];
     let current: string[] = [];
 
@@ -205,6 +274,71 @@ function splitParagraphs(lines: string[]): string[] {
     }
 
     return paragraphs.filter(p => p.length > 0);
+}
+
+/** 按段首缩进分段（无空行的中文网文 TXT） */
+function splitByIndent(lines: string[]): string[] {
+    const paragraphs: string[] = [];
+    let current: string[] = [];
+
+    const flush = () => {
+        if (current.length > 0) {
+            paragraphs.push(current.join("\n").trim());
+            current = [];
+        }
+    };
+
+    for (const line of lines) {
+        if (line.trim() === "") {
+            flush();
+        } else if (isIndentedParagraphStart(line)) {
+            flush();
+            current.push(line);
+        } else {
+            current.push(line);
+        }
+    }
+    flush();
+
+    return paragraphs.filter(p => p.length > 0);
+}
+
+/** 智能分段：先探测本书格式再选策略——
+ *  1) 空行占比 ≥ 15%：空行分段（标准导出格式，段内多行保留）
+ *  2) 缩进行占比 ≥ 20%：段首缩进分段（晋江/起点手排 TXT，无空行）
+ *  3) 空行占比 ≥ 2%：空行分段（段内多行较长、空行稀疏的情况）
+ *  4) 否则：纯换行格式，一行一段（很多网文连开头缩进都省了，纯靠回车换行分段落）
+ *  空行占比统计时已剔除「章节分隔空行」（紧邻标题行的空行块），
+ *  避免下载 TXT 在章节间插入的空行污染探测。
+ *  mode 参数可强制指定划分方式（auto=自动探测）。 */
+export type TxtParagraphMode = "auto" | "blank" | "indent" | "line";
+
+/** 全局探测一本书的段落格式（对整本书的 lines 调用一次，保证各章节结论一致） */
+export function detectParagraphMode(lines: string[]): TxtParagraphMode {
+    const nonEmpty = lines.filter((l) => l.trim() !== "");
+    if (nonEmpty.length === 0) return "line";
+
+    const blankRatio = countAuthorBlankLines(lines) / Math.max(1, lines.length);
+    const indentedRatio = nonEmpty.filter(isIndentedParagraphStart).length / nonEmpty.length;
+
+    if (blankRatio >= 0.15) return "blank";
+    if (indentedRatio >= 0.2) return "indent";
+    if (blankRatio >= 0.02) return "blank";
+    return "line";
+}
+
+function splitParagraphs(lines: string[], mode: TxtParagraphMode = "auto"): string[] {
+    const nonEmpty = lines.filter(l => l.trim() !== "");
+    if (nonEmpty.length === 0) return [];
+
+    if (mode === "blank") return splitByBlankLines(lines);
+    if (mode === "indent") return splitByIndent(lines);
+    if (mode === "line") return nonEmpty.map(l => l.trim()).filter(p => p.length > 0);
+
+    const detected = detectParagraphMode(lines);
+    if (detected === "blank") return splitByBlankLines(lines);
+    if (detected === "indent") return splitByIndent(lines);
+    return nonEmpty.map(l => l.trim()).filter(p => p.length > 0);
 }
 
 // ── EPUB Parsing ──

--- a/lib/reading-storage.ts
+++ b/lib/reading-storage.ts
@@ -52,16 +52,40 @@ registerKvMigration(READING_INTERACTION_CONFIG_KEY);
 const RAW_FILE_DB_NAME = "reading-raw-files";
 const RAW_FILE_STORE_NAME = "files";
 
+/** TXT 导入时的段落划分方式：auto=智能探测（默认）/ blank=空行 / indent=段首缩进 / line=每行一段 */
+export type ReadingParagraphMode = "auto" | "blank" | "indent" | "line";
+
+/** 阅读模式：page=翻页 / scroll=连续滚动 */
+export type ReadingViewMode = "page" | "scroll";
+
 export type ReadingInteractionConfig = {
     bilingualTranslationEnabled: boolean;
     collapseBilingualTranslation: boolean;
     bilingualTranslationPrompt: string;
+    /** 导入 TXT 时如何划分段落（默认自动探测书格式） */
+    paragraphMode: ReadingParagraphMode;
+    /** 阅读模式：翻页 / 连续滚动 */
+    readingMode: ReadingViewMode;
+    /** 自动批注失败时的静默重试次数（0=不重试） */
+    annotationRetryCount: number;
+    /** 上一批自动批注读到该比例时，提前生成下一批批注（避免用户读到下一批时批注还没好）；默认关闭，由用户手动开启 */
+    autoAnnotatePrefetch: boolean;
+    /** 批注预生成触发时机：读到上一批批注的多少比例时提前生成下一批（0-1，默认 2/3） */
+    annotationPrefetchThreshold: number;
+    /** 共读讨论悬浮窗展开时是否自动滚动到最新消息（默认开启；用户可随后自由滑动打断） */
+    chatAutoScrollOnOpen: boolean;
 };
 
 export const DEFAULT_READING_INTERACTION_CONFIG: ReadingInteractionConfig = {
     bilingualTranslationEnabled: true,
     collapseBilingualTranslation: true,
     bilingualTranslationPrompt: DEFAULT_READING_BILINGUAL_PROMPT,
+    paragraphMode: "auto",
+    readingMode: "page",
+    annotationRetryCount: 3,
+    autoAnnotatePrefetch: false,
+    annotationPrefetchThreshold: 2 / 3,
+    chatAutoScrollOnOpen: true,
 };
 
 export async function hydrateReadingStorage(): Promise<void> {

--- a/lib/reading-types.ts
+++ b/lib/reading-types.ts
@@ -34,6 +34,8 @@ export type ReadingProgress = {
     progressCurrent?: number;
     progressTotal?: number;
     progressScope?: "book" | "chapter";
+    /** 保存进度时的阅读模式；滚动模式下 scrollPosition 存的是章节内滚动比例(0-1) */
+    readingMode?: "page" | "scroll";
     lastReadAt: string;
 };
 


### PR DESCRIPTION
贡献者：温铎（@yechen1844）

对阅读 APP 做的一组体验优化（第一批，6 个文件，均为干净的阅读相关改动）：

1. 悬浮球滑动逻辑：共读讨论悬浮球/悬浮条拖动时不被顶栏遮挡（z-index 修正），位置记忆到 localStorage（CHAT_FLOAT_POS_KEY），下次打开恢复上次位置，并提供"重置悬浮球位置"入口。
2. 连续滚动阅读模式：新增"翻页/滚动"两种阅读模式（阅读设置里切换），滚动模式为多章窗口无缝衔接的连续滚动，支持按比例保存/恢复阅读进度（ReadingProgress 新增 readingMode 字段）。
3. 自动批注预生成：读完上一批批注到可配置阈值（1/2、2/3、3/4）时提前生成下一批，避免用户读到下一批时批注还没生成好；同步加"生成中"锁与批次去重，防止同一帧内并发发起多个批注生成任务。
4. 自动批注失败静默重试：新增 annotationRetryCount（0-5，默认 3），生成失败时按逐渐加大的间隔静默重试，全部失败后才提示错误。
5. 共读讨论自动滑到底：展开悬浮窗时自动滚动到最新消息（chatAutoScrollOnOpen，默认开启，用户随后可自由滑动打断）。
6. TXT 导入解析增强：parseTxtContent 支持 auto（整书探测）/空行/段首缩进/每行一段四种段落划分方式，剥离章节标题前后下载站插入的分隔空行（避免污染空行占比检测导致短章误判），章节标题行不在空行占比统计之列；阅读设置里可切换，导入时生效。
7. 阅读设置弹窗（新增 reading-interaction-dialog.tsx）：书架新增"阅读设置"入口，集中配置上述段落划分、阅读模式、重试次数、预生成阈值、自动滑底开关、重置悬浮球位置。

验证：本地构建通过；翻页/滚动两种模式均手工验证章节切换、进度恢复、批注生成与预生成、悬浮球拖动记忆与重置、TXT 四种段落模式的导入效果。

⚠️ 重要说明：本次改动共 7 个文件、是一整套完整功能（前 6 个为功能逻辑，styles/chat.css 为配套样式），因贡献通道单次提交上限 6 个文件，被迫拆成两批提交（本批 + styles/chat.css 单独一批）。两批需合并审阅，单独合入可能因缺少配套样式而出现界面或功能异常。styles/chat.css 那批的提交说明中另有关于该文件内含一处非贡献改动的说明。

---
_经小手机「共同建设」通道提交_