### PR TITLE
阅读器优化（二）：配套样式 styles/chat.css（内含一处非贡献的菜单美化，可直接删除）

### DIFF
--- a/styles/chat.css
+++ b/styles/chat.css
@@ -1024,12 +1024,9 @@
 
 /* ── Context menu ── */
 .ctx-menu {
-  background: rgba(25, 25, 25, 0.8);
-  -webkit-backdrop-filter: blur(16px) saturate(180%);
-  backdrop-filter: blur(16px) saturate(180%);
-  border: 0.5px solid rgba(255, 255, 255, 0.15);
-  border-radius: 14px;
-  box-shadow: 0 10px 30px rgba(0,0,0,0.25), 0 4px 12px rgba(0,0,0,0.15);
+  background: var(--ctx-menu-bg, #2c2c2c);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
   z-index: 50;
   white-space: nowrap;
 }
@@ -1060,24 +1057,19 @@
   border: none;
   color: #fff;
   padding: 0 12px;
-  font-size: calc(14px*var(--app-text-scale,1));
-  font-weight: 500;
-  line-height: 1.2;
-  border-radius: 999px;
+  font-size: calc(12.6px*var(--app-text-scale,1));
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-.ctx-menu-btn:active {
-  background: rgba(255, 255, 255, 0.15);
-  transform: scale(0.96);
 }
 .ctx-menu-btn-danger {
   color: var(--c-danger);
 }
-/* 胶囊化后按钮间用留白区分，不再画竖分隔线 */
-/* 悬浮胶囊卡片：隐藏指向箭头 */
+.ctx-menu-btn:not(:last-of-type) {
+  border-right: 1px solid rgba(255,255,255,0.1);
+}
 .ctx-menu-triangle {
-  display: none;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-bottom: 6px solid var(--ctx-menu-bg, #2c2c2c);
 }
 
 /* ══════════════════════════════════════════

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -1024,9 +1024,12 @@
 
 /* ── Context menu ── */
 .ctx-menu {
-  background: var(--ctx-menu-bg, #2c2c2c);
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  background: rgba(25, 25, 25, 0.8);
+  -webkit-backdrop-filter: blur(16px) saturate(180%);
+  backdrop-filter: blur(16px) saturate(180%);
+  border: 0.5px solid rgba(255, 255, 255, 0.15);
+  border-radius: 14px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.25), 0 4px 12px rgba(0,0,0,0.15);
   z-index: 50;
   white-space: nowrap;
 }
@@ -1057,19 +1060,24 @@
   border: none;
   color: #fff;
   padding: 0 12px;
-  font-size: calc(12.6px*var(--app-text-scale,1));
+  font-size: calc(14px*var(--app-text-scale,1));
+  font-weight: 500;
+  line-height: 1.2;
+  border-radius: 999px;
   cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+.ctx-menu-btn:active {
+  background: rgba(255, 255, 255, 0.15);
+  transform: scale(0.96);
 }
 .ctx-menu-btn-danger {
   color: var(--c-danger);
 }
-.ctx-menu-btn:not(:last-of-type) {
-  border-right: 1px solid rgba(255,255,255,0.1);
-}
+/* 胶囊化后按钮间用留白区分，不再画竖分隔线 */
+/* 悬浮胶囊卡片：隐藏指向箭头 */
 .ctx-menu-triangle {
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
-  border-bottom: 6px solid var(--ctx-menu-bg, #2c2c2c);
+  display: none;
 }
 
 /* ══════════════════════════════════════════
@@ -4041,7 +4049,8 @@
   position: absolute;
   left: 12px;
   bottom: max(12px, env(safe-area-inset-bottom));
-  z-index: 45;
+  /* 高于顶栏(46)/底栏(35)，避免拖到顶部时被顶栏遮挡、无法继续拖动 */
+  z-index: 48;
   width: 56px;
   height: 56px;
   border-radius: 28px;
@@ -4066,7 +4075,8 @@
   position: absolute;
   left: 12px;
   bottom: max(12px, env(safe-area-inset-bottom));
-  z-index: 45;
+  /* 高于顶栏(46)/底栏(35)，拖到顶部时不被顶栏遮挡 */
+  z-index: 48;
   width: min(280px, calc(100% - 24px));
   border-radius: 14px;
   border: 1px solid #e2d5be;
@@ -4607,6 +4617,17 @@
   font-size: calc(9.9px*var(--app-text-scale,1));
   color: var(--reading-warm-ink-tertiary, #999);
 }
+.reading-settings-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.reading-settings-toggle-label {
+  font-size: calc(10.8px*var(--app-text-scale,1));
+  color: var(--reading-warm-ink, #111);
+  line-height: 1.5;
+}
 .reading-settings-prompt {
   display: flex;
   flex-direction: column;
@@ -4669,6 +4690,119 @@
   align-items: center;
   justify-content: center;
   gap: 6px;
+}
+
+/* 阅读设置：选项卡片 */
+.reading-option-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.reading-option-grid--two {
+  grid-template-columns: 1fr;
+}
+.reading-option-grid--three {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+.reading-option-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--reading-warm-card-border, #f0e8da);
+  background: rgba(255, 255, 255, 0.55);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
+}
+.reading-option-card.is-active {
+  border-color: var(--reading-warm-brown, #8a5a2b);
+  background: rgba(237, 227, 207, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(138, 90, 43, 0.25);
+}
+.reading-option-card-label {
+  font-size: calc(11.7px*var(--app-text-scale,1));
+  font-weight: 600;
+  color: var(--reading-warm-ink, #111);
+}
+.reading-option-card-desc {
+  font-size: calc(9.9px*var(--app-text-scale,1));
+  line-height: 1.45;
+  color: var(--reading-warm-ink-tertiary, #999);
+}
+
+/* 阅读设置：批注重试次数步进器 */
+.reading-retry-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+}
+.reading-retry-btn {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid var(--reading-warm-card-border, #f0e8da);
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--reading-warm-brown, #8a5a2b);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+.reading-retry-btn:active:not(:disabled) {
+  background: rgba(237, 227, 207, 0.6);
+}
+.reading-retry-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.reading-retry-value {
+  min-width: 64px;
+  text-align: center;
+  font-size: calc(15.3px*var(--app-text-scale,1));
+  font-weight: 700;
+  color: var(--reading-warm-ink, #111);
+}
+.reading-retry-value em {
+  font-style: normal;
+  font-size: calc(9.9px*var(--app-text-scale,1));
+  font-weight: 400;
+  color: var(--reading-warm-ink-tertiary, #999);
+  margin-left: 2px;
+}
+
+/* 阅读设置：重置悬浮球位置 */
+.reading-reset-float-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 9px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--reading-warm-card-border, #f0e8da);
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--reading-warm-brown, #8a5a2b);
+  font-size: calc(10.8px*var(--app-text-scale,1));
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.reading-reset-float-btn:active {
+  background: rgba(237, 227, 207, 0.6);
+}
+
+/* 滚动阅读模式 */
+.reading-scroll-content {
+  min-height: 100%;
+  padding: 6px 0 12px;
+  touch-action: pan-y;
+}
+.reading-scroll-block {
+  margin-bottom: 14px;
 }
 
 .chat-bilingual-prompt-dialog {


### PR DESCRIPTION
贡献者：温铎（@yechen1844）

阅读器优化（二）：配套样式文件 styles/chat.css。

本文件与 PR #117（阅读器优化第一批）是一整套完整改动的一部分：前 6 个文件是功能逻辑，本文件是它们的配套样式，包括：
- 悬浮球/悬浮条 z-index 修正（45→48，拖动到顶部时不被顶栏遮挡）
- 阅读设置面板样式（选项卡片 .reading-option-grid/card、批注重试步进器 .reading-retry-*、开关行、重置悬浮球按钮 .reading-reset-float-btn）
- 连续滚动阅读模式样式（.reading-scroll-content/block）

⚠️ 重要说明（两条）：
1. 本次改动共 7 个文件、是一整套完整功能，因贡献通道单次提交上限 6 个文件，被迫拆成两批提交（PR #117 + 本 PR）。两批需合并审阅，单独合入本文件可能导致阅读器新功能缺少配套样式而界面异常。
2. 贡献通道按文件整体提交、无法拆分单个文件内的无关改动，本文件一并带上了一处独立的聊天右键菜单样式美化（.ctx-menu 毛玻璃背景/胶囊按钮/隐藏小箭头，约 40 行，位于文件中部）。该部分不是本贡献的内容，可直接删除或忽略；其余新增样式为本次阅读优化所需。

验证：本地构建通过；阅读设置面板、滚动模式、悬浮球拖拽修复均手工验证。

---
_经小手机「共同建设」通道提交_