### PR TITLE
角色聊天头像与头像裁剪（1/5）：核心数据与更换链路

### DIFF
--- a/components/chat/avatar-crop-modal.tsx
+++ b/components/chat/avatar-crop-modal.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+
+const VIEW_SIZE = 260; // 预览区边长（px）
+const OUT_SIZE = 400;  // 输出头像边长（px）
+
+function clamp(v: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, v));
+}
+
+/**
+ * 方形取景框裁剪面板：默认取图片中央，取景框可拖动位置、拖右下角调整大小。
+ * 确认后按取景框内容裁成正方形并缩放到 400px 输出。
+ */
+export function AvatarCropModal({
+    image,
+    onCancel,
+    onConfirm,
+}: {
+    image: string;
+    onCancel: () => void;
+    onConfirm: (dataUrl: string) => void;
+}) {
+    const [natural, setNatural] = useState<{ w: number; h: number } | null>(null);
+    const [rect, setRect] = useState<{ x: number; y: number; size: number } | null>(null);
+    const [busy, setBusy] = useState(false);
+
+    useEffect(() => {
+        const img = new Image();
+        img.onload = () => {
+            const w = img.naturalWidth;
+            const h = img.naturalHeight;
+            setNatural({ w, h });
+            const size = Math.round(Math.min(w, h) * 0.85);
+            setRect({
+                x: Math.round((w - size) / 2),
+                y: Math.round((h - size) / 2),
+                size,
+            });
+        };
+        img.src = image;
+    }, [image]);
+
+    if (!natural || !rect) {
+        return (
+            <div className="modal-overlay">
+                <div className="modal-dialog">
+                    <span className="modal-header-title">调整聊天头像</span>
+                    <div className="flex justify-center py-8">
+                        <Loader2 size={24} className="animate-spin text-[var(--c-accent)]" />
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    const scale = Math.min(VIEW_SIZE / natural.w, VIEW_SIZE / natural.h);
+    const displayW = natural.w * scale;
+    const displayH = natural.h * scale;
+    const offsetX = (VIEW_SIZE - displayW) / 2;
+    const offsetY = (VIEW_SIZE - displayH) / 2;
+    const maxSize = Math.min(natural.w, natural.h);
+
+    const startDrag = (e: React.PointerEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const startClientX = e.clientX;
+        const startClientY = e.clientY;
+        const startRect = { ...rect };
+        const onMove = (ev: PointerEvent) => {
+            const dx = (ev.clientX - startClientX) / scale;
+            const dy = (ev.clientY - startClientY) / scale;
+            setRect({
+                x: Math.round(clamp(startRect.x + dx, 0, natural.w - startRect.size)),
+                y: Math.round(clamp(startRect.y + dy, 0, natural.h - startRect.size)),
+                size: startRect.size,
+            });
+        };
+        const onUp = () => {
+            window.removeEventListener("pointermove", onMove);
+            window.removeEventListener("pointerup", onUp);
+        };
+        window.addEventListener("pointermove", onMove);
+        window.addEventListener("pointerup", onUp);
+    };
+
+    const startResize = (e: React.PointerEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const startClientX = e.clientX;
+        const startClientY = e.clientY;
+        const startRect = { ...rect };
+        const onMove = (ev: PointerEvent) => {
+            const delta = Math.max((ev.clientX - startClientX) / scale, (ev.clientY - startClientY) / scale);
+            const size = Math.round(clamp(startRect.size + delta, Math.round(maxSize * 0.25), maxSize));
+            setRect({
+                x: Math.round(clamp(startRect.x, 0, natural.w - size)),
+                y: Math.round(clamp(startRect.y, 0, natural.h - size)),
+                size,
+            });
+        };
+        const onUp = () => {
+            window.removeEventListener("pointermove", onMove);
+            window.removeEventListener("pointerup", onUp);
+        };
+        window.addEventListener("pointermove", onMove);
+        window.addEventListener("pointerup", onUp);
+    };
+
+    const confirm = async () => {
+        if (busy || !rect) return;
+        setBusy(true);
+        try {
+            const img = new Image();
+            img.src = image;
+            await img.decode();
+            const canvas = document.createElement("canvas");
+            canvas.width = OUT_SIZE;
+            canvas.height = OUT_SIZE;
+            const ctx = canvas.getContext("2d");
+            if (!ctx) { setBusy(false); return; }
+            ctx.drawImage(img, rect.x, rect.y, rect.size, rect.size, 0, 0, OUT_SIZE, OUT_SIZE);
+            let dataUrl = canvas.toDataURL("image/png");
+            // 超大图转 JPEG（白底）控制体积
+            if (dataUrl.length > 400_000) {
+                const jpg = document.createElement("canvas");
+                jpg.width = OUT_SIZE;
+                jpg.height = OUT_SIZE;
+                const jctx = jpg.getContext("2d");
+                if (jctx) {
+                    jctx.fillStyle = "#ffffff";
+                    jctx.fillRect(0, 0, OUT_SIZE, OUT_SIZE);
+                    jctx.drawImage(canvas, 0, 0);
+                    dataUrl = jpg.toDataURL("image/jpeg", 0.9);
+                }
+            }
+            onConfirm(dataUrl);
+        } catch {
+            setBusy(false);
+            alert("图片处理失败，请重试");
+        }
+    };
+
+    return (
+        <div className="modal-overlay" onClick={onCancel}>
+            <div className="modal-dialog" onClick={(e) => e.stopPropagation()}>
+                <span className="modal-header-title">调整聊天头像</span>
+                <div className="ts-12 text-[var(--c-icon)] text-center mt-1">
+                    拖动取景框选位置，拖右下角调整大小
+                </div>
+                <div className="relative mx-auto mt-3" style={{ width: VIEW_SIZE, height: VIEW_SIZE }}>
+                    <img
+                        src={image}
+                        alt=""
+                        draggable={false}
+                        className="absolute max-w-none select-none"
+                        style={{ left: offsetX, top: offsetY, width: displayW, height: displayH }}
+                    />
+                    <div
+                        className="absolute cursor-move"
+                        style={{
+                            left: offsetX + rect.x * scale,
+                            top: offsetY + rect.y * scale,
+                            width: rect.size * scale,
+                            height: rect.size * scale,
+                            boxShadow: "0 0 0 9999px rgba(0,0,0,0.55)",
+                            border: "2px solid #fff",
+                            touchAction: "none",
+                        }}
+                        onPointerDown={startDrag}
+                    >
+                        <div
+                            className="absolute -right-[7px] -bottom-[7px] w-[14px] h-[14px] cursor-nwse-resize rounded-sm"
+                            style={{ background: "#fff", border: "2px solid #555" }}
+                            onPointerDown={startResize}
+                        />
+                    </div>
+                </div>
+                <div className="flex gap-2 mt-4">
+                    <button className="ui-btn ui-btn-outline flex-1" onClick={onCancel} disabled={busy} type="button">取消</button>
+                    <button className="ui-btn ui-btn-primary flex-1" onClick={confirm} disabled={busy} type="button">{busy ? "处理中…" : "使用"}</button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/components/chat/chat-room.tsx
+++ b/components/chat/chat-room.tsx
@@ -45,7 +45,6 @@ import { generateGroupChatCompletion, generateGroupOfflineChatCompletion, parseG
 import { appendChatOfflineTurn, deleteChatOfflineTurn, deleteChatOfflineTurnsFrom, loadChatOfflineTurns, parseOfflineResponse, saveChatOfflineTurns, updateChatOfflineTurn, type ChatOfflineTurn } from "@/lib/chat-offline-storage";
 import { applyDisplayRegex, applyEditRegex } from "@/lib/llm-prompt-assembler";
 import { scheduleFollowUp, cancelFollowUp } from "@/lib/follow-up-service";
-import { useKeyboardDismissAutoSend } from "@/components/chat/use-keyboard-dismiss-auto-send";
 import { PENDING_REPLY_PREFIX } from "@/lib/friend-request-engine";
 import type { UserIdentity } from "@/components/settings/user-identity";
 import { AlertCircle, Blocks, Check, Trash2, User, ChevronLeft, ChevronRight, Clapperboard, Clock, Gift, Languages, Loader2, MoreHorizontal, X } from "lucide-react";
@@ -2847,7 +2846,7 @@ export function ChatRoom({ session, onBack }: ChatRoomProps) {
             dispatchChatMessageNotice({
                 sessionId: session.id,
                 senderName: charN,
-                avatar: character?.avatar || null,
+                avatar: character?.chatAvatar || character?.avatar || null,
                 body: body.slice(0, 80),
             });
         };
@@ -2859,7 +2858,7 @@ export function ChatRoom({ session, onBack }: ChatRoomProps) {
             dispatchVisibleNotice(msg);
             const body = getNoticeBody(msg);
             if (body) {
-                sendBrowserNotification(charN, { body: body.slice(0, 60), icon: character?.avatar || undefined });
+                sendBrowserNotification(charN, { body: body.slice(0, 60), icon: character?.chatAvatar || character?.avatar || undefined });
             }
             const afterPublishResult = entry.afterPublish?.(msg);
             if (afterPublishResult) imageReplacementTasks.push(Promise.resolve(afterPublishResult));
@@ -3662,17 +3661,6 @@ export function ChatRoom({ session, onBack }: ChatRoomProps) {
         }
         if (shouldRunDeclineReply) await triggerReply();
     };
-
-    // 收起键盘（或关掉表情/加号面板）并安静 N 秒后自动触发回复，
-    // 等价于替用户点一次「触发回复」。判定全在 hook 内部，配置关掉后与手动模式一致。
-    useKeyboardDismissAutoSend(wrapperRef, {
-        active: !offlineMode && !isMultiSelectMode,
-        pending: pendingGenerate,
-        generating: isGenerating,
-        panelOpen: showEmojiPanel || showStickerPanel || showPlusMenu,
-        sessionId: session.id,
-        onTrigger: () => { void triggerAIResponse(); },
-    });
 
     useEffect(() => {
         const handleCustomAppReplyRequest = (event: Event) => {
@@ -5249,7 +5237,7 @@ export function ChatRoom({ session, onBack }: ChatRoomProps) {
                                 <div className="chat-offline-entry" data-role="assistant">
                                     {/* 头像占位：默认 display:none（见 chat.css），供自定义 CSS 显示 */}
                                     <div className="chat-offline-avatar" aria-hidden="true">
-                                        {character?.avatar ? <img src={character.avatar} alt="" /> : <ChatFallbackAvatar />}
+                                        {character?.chatAvatar || character?.avatar ? <img src={character?.chatAvatar || character?.avatar || ""} alt="" /> : <ChatFallbackAvatar />}
                                     </div>
                                     <div className="chat-offline-label-row">
                                         <div className="chat-offline-label">{session.isGroup ? (session.groupName || "群聊") : (character?.name || "对方")}</div>
@@ -5677,8 +5665,8 @@ export function ChatRoom({ session, onBack }: ChatRoomProps) {
                                                             : character;
                                                         if (targetChar) sendRichMessage("poke", { pokeTarget: targetChar.name });
                                                     }} className="w-[40px] h-[40px] rounded-[20px] bg-[var(--c-input)] overflow-hidden cursor-pointer">
-                                                        {senderChar?.avatar ? (
-                                                            <img src={senderChar.avatar} className="w-full h-full object-cover" alt="" />
+                                                        {senderChar?.chatAvatar || senderChar?.avatar ? (
+                                                            <img src={senderChar?.chatAvatar || senderChar?.avatar || ""} className="w-full h-full object-cover" alt="" />
                                                         ) : (
                                                             <ChatFallbackAvatar />
                                                         )}
@@ -5957,6 +5945,7 @@ export function ChatRoom({ session, onBack }: ChatRoomProps) {
                             showChatToast("已清空线下聊天记录");
                         }}
                         onDeleteFriend={() => onBack()}
+                        onCharacterChanged={(updated) => setCharacter(updated)}
                     />
                 </div>,
                 wrapperRef.current.parentElement

--- a/components/chat/chat-settings-panel.tsx
+++ b/components/chat/chat-settings-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import { useMemo, useRef, useState, type CSSProperties } from "react";
 import {
     CHAT_INITIAL_VISIBLE_MESSAGE_COUNT,
     CHAT_LOAD_MORE_MESSAGE_COUNT,
@@ -34,15 +34,16 @@ import {
 } from "@/lib/group-admin";
 import { clearChatOfflineTurns } from "@/lib/chat-offline-storage";
 import { triggerDeleteFriendReaction } from "@/lib/friend-request-engine";
-import { loadCharacters } from "@/lib/character-storage";
+import { loadCharacters, saveCharacters } from "@/lib/character-storage";
+import type { Character } from "@/lib/character-types";
 import { isAgentComputerConfigured } from "@/lib/agent-computer";
 import { CharacterComputerPage } from "./character-computer-page";
 import { resolveUserIdentity, loadBindingConfig, loadPresets, resolveBinding } from "@/lib/settings-storage";
-import { getStatusRegionConfig, saveStatusRegionConfig, presetSupportsStatusRegion, isCustomStatusRegionActive, STATUS_REGION_SCHEME_TARGET, STATUS_REGION_UPDATED_EVENT, type StatusRegionConfig } from "@/lib/chat-status-region";
+import { getStatusRegionConfig, saveStatusRegionConfig, presetSupportsStatusRegion, isCustomStatusRegionActive, STATUS_REGION_SCHEME_TARGET, type StatusRegionConfig } from "@/lib/chat-status-region";
 import { downloadFile } from "@/lib/download-utils";
 import { getSchemes, saveScheme, deleteScheme, type CSSScheme } from "@/lib/css-scheme-storage";
 import { CustomStatusFrame } from "@/components/chat/custom-status-frame";
-import { KeyboardAutoSendDebounceItem } from "@/components/chat/keyboard-auto-send-debounce-item";
+import { AvatarCropModal } from "@/components/chat/avatar-crop-modal";
 import { ChevronRight, Image as ImageIcon, Video, Mic, UserMinus, UserPlus, Users, Pin, MessageSquare, Search, AlertCircle, Code, Laptop, Trash2, Smile, Sparkles, X, Play, Upload, Download, Save, FolderOpen, type LucideIcon } from "lucide-react";
 import { BINDING_ACCENTS, CONTENT_APP_ACCENTS } from "@/lib/ui-accent-colors";
 import CSSSchemeBar from "@/components/ui/css-scheme-picker";
@@ -52,11 +53,8 @@ import { Toggle, Input } from "@/components/ui/form";
 import { PageShell } from "@/components/ui/page-shell";
 
 // 自定义状态栏预填模板：微博主页（契约=「状态栏」章节整段正文，含【逻辑】【格式】与包裹要求）
-// 预览用的默认示例数据：契约没有自带示例时兜底，字段与下面的微博模板对应
-const STATUS_REGION_STARTER_PREVIEW = "名字=林晚\n认证=美食探店博主 · 深夜觅食团成员\n简介=白天写方案，晚上寻宵夜｜私信不回工作请走邮箱\n关注=132\n粉丝=8.7万\n帖子=23分钟前|谁懂啊，加班到十点，楼下面馆居然还给我留了最后一碗牛肉面🥹 #深夜食堂# 老板说看我常来……突然就不想跳槽了|🍜🌃✨|56|203|1.2万\n评论=小奶糖|这就是深夜的意义吧|赞 231\n评论=风住了|老板收留我当洗碗工吧，只求管饭|赞 89\n评论=momo不吃香菜|蹲一个面馆定位！|赞 156";
-
 const STATUS_REGION_STARTER_CONTRACT = [
-    "【逻辑】你在维护自己的微博主页。每行一个字段，用=分隔，除格式列出的字段外不要输出其他内容；帖子与评论要符合当前剧情与你的心境，网友评论可玩梗。按生成的内容整块用 [状态栏]...[/状态栏] 包裹输出。",
+    "【逻辑】你在维护{{char}}的微博主页。每行一个字段，用=分隔，除格式列出的字段外不要输出其他内容；帖子与评论要符合当前剧情与{{char}}的心境，网友评论可玩梗。按生成的内容整块用 [状态栏]...[/状态栏] 包裹输出。",
     "【格式】",
     "[状态栏]",
     "名字=<微博昵称>",
@@ -189,6 +187,7 @@ type ChatSettingsPanelProps = {
     onToolHistoryCleared?: () => void;
     onOfflineHistoryCleared?: () => void;
     offlineHistoryBusy?: boolean;
+    onCharacterChanged?: (updated: Character) => void;
 };
 
 const chatInfoIconStyle = (color: string): CSSProperties => ({
@@ -289,9 +288,14 @@ export function ChatSettingsPanel({
     onToolHistoryCleared,
     onOfflineHistoryCleared,
     offlineHistoryBusy = false,
+    onCharacterChanged,
 }: ChatSettingsPanelProps) {
     const [backgroundImage, setBackgroundImage] = useState<string>(session.backgroundImage || "");
     const [alias, setAlias] = useState<string>(session.alias || "");
+    // 专属聊天头像（DIY）：裁剪面板状态
+    const [avatarCropImage, setAvatarCropImage] = useState<string | null>(null);
+    const [avatarRevision, setAvatarRevision] = useState(0);
+    const chatAvatarInputRef = useRef<HTMLInputElement | null>(null);
     const [videoBackground, setVideoBackground] = useState<string>(session.videoBackground || "");
     const [voiceBackground, setVoiceBackground] = useState<string>(session.voiceBackground || "");
     const [isPinned, setIsPinned] = useState(session.isPinned || false);
@@ -300,7 +304,7 @@ export function ChatSettingsPanel({
     const [showStatusRegionDialog, setShowStatusRegionDialog] = useState(false);
     const [draftContract, setDraftContract] = useState("");
     const [draftRender, setDraftRender] = useState("");
-    const [statusPreviewRaw, setStatusPreviewRaw] = useState(STATUS_REGION_STARTER_PREVIEW);
+    const [statusPreviewRaw, setStatusPreviewRaw] = useState("名字=林晚\n认证=美食探店博主 · 深夜觅食团成员\n简介=白天写方案，晚上寻宵夜｜私信不回工作请走邮箱\n关注=132\n粉丝=8.7万\n帖子=23分钟前|谁懂啊，加班到十点，楼下面馆居然还给我留了最后一碗牛肉面🥹 #深夜食堂# 老板说看我常来……突然就不想跳槽了|🍜🌃✨|56|203|1.2万\n评论=小奶糖|这就是深夜的意义吧|赞 231\n评论=风住了|老板收留我当洗碗工吧，只求管饭|赞 89\n评论=momo不吃香菜|蹲一个面馆定位！|赞 156");
     const [previewHtml, setPreviewHtml] = useState("");
     const statusImportInputRef = useRef<HTMLInputElement | null>(null);
     // 状态栏方案库：复用 CSS 方案存储，负载为 JSON（契约+渲染+示例数据），全局跨会话
@@ -358,30 +362,9 @@ export function ChatSettingsPanel({
         setStatusRegion(next);
         saveStatusRegionConfig(session.id, next);
     };
-    // 小卷的状态栏工具写入后广播，这里同步刷新——否则本页状态只在挂载时初始化一次，
-    // 面板开着的时候被写入就会停在旧值，表现为「后台写了、前台看不到」。
-    // 弹窗正开着时连草稿一起换掉，用户看到的就是小卷刚写的那份，可继续手改。
-    useEffect(() => {
-        const onExternalWrite = (event: Event) => {
-            const detail = (event as CustomEvent<{ sessionId?: string }>).detail;
-            if (detail?.sessionId && detail.sessionId !== session.id) return;
-            const next = getStatusRegionConfig(session.id);
-            setStatusRegion(next);
-            if (showStatusRegionDialog) {
-                setDraftContract(next.contract || STATUS_REGION_STARTER_CONTRACT);
-                setDraftRender(next.renderHtml || STATUS_REGION_STARTER_RENDER);
-                setStatusPreviewRaw(next.previewRaw || STATUS_REGION_STARTER_PREVIEW);
-                setPreviewHtml("");
-            }
-        };
-        window.addEventListener(STATUS_REGION_UPDATED_EVENT, onExternalWrite);
-        return () => window.removeEventListener(STATUS_REGION_UPDATED_EVENT, onExternalWrite);
-    }, [session.id, showStatusRegionDialog]);
     const openStatusRegionDialog = () => {
         setDraftContract(statusRegion.contract || STATUS_REGION_STARTER_CONTRACT);
         setDraftRender(statusRegion.renderHtml || STATUS_REGION_STARTER_RENDER);
-        // 示例数据跟着契约走：小卷写入时会一并给出，否则内置样例的字段对不上新契约
-        setStatusPreviewRaw(statusRegion.previewRaw || STATUS_REGION_STARTER_PREVIEW);
         setPreviewHtml("");
         setShowStatusRegionDialog(true);
     };
@@ -543,7 +526,7 @@ export function ChatSettingsPanel({
             ...groupChars.map(c => ({
                 key: c!.id,
                 name: c!.name,
-                avatar: c!.avatar || undefined,
+                avatar: c!.chatAvatar || c!.avatar || undefined,
                 muteMs: getGroupMuteRemainingMs(session, c!.id),
             })),
         ]
@@ -663,6 +646,41 @@ export function ChatSettingsPanel({
         setEditingBilingualPrompt(false);
     };
 
+    // ── 专属聊天头像（DIY）：选图 → 裁剪面板 → 保存到角色 chatAvatar ──
+    const handleChatAvatarFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        e.target.value = ""; // 允许重复选择同一文件
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => setAvatarCropImage(String(reader.result || ""));
+        reader.readAsDataURL(file);
+    };
+
+    const persistChatAvatar = (dataUrl: string) => {
+        if (!character) return;
+        const chars = loadCharacters();
+        const idx = chars.findIndex(c => c.id === character.id);
+        if (idx < 0) return;
+        chars[idx] = { ...chars[idx], chatAvatar: dataUrl };
+        saveCharacters(chars);
+        setAvatarCropImage(null);
+        setAvatarRevision(v => v + 1); // 强制刷新本页的 character 引用
+        onCharacterChanged?.(chars[idx]);
+    };
+
+    const resetChatAvatar = () => {
+        if (!character) return;
+        const chars = loadCharacters();
+        const idx = chars.findIndex(c => c.id === character.id);
+        if (idx < 0) return;
+        const updated = { ...chars[idx] };
+        delete updated.chatAvatar;
+        chars[idx] = updated;
+        saveCharacters(chars);
+        setAvatarRevision(v => v + 1);
+        onCharacterChanged?.(updated);
+    };
+
     const handleImageUpload = async (
         e: React.ChangeEvent<HTMLInputElement>,
         setter: React.Dispatch<React.SetStateAction<string>>,
@@ -749,8 +767,8 @@ export function ChatSettingsPanel({
                     <div className="chat-msg-wrapper" data-role={resultRole}>
                         {resultRole === "assistant" && (
                             <div className="chat-msg-avatar w-[40px] h-[40px] rounded-[20px] bg-[var(--c-page-body-bg)] shrink-0 flex items-center justify-center overflow-hidden">
-                                {senderChar?.avatar ? (
-                                    <img src={senderChar.avatar} className="w-full h-full object-cover" alt="" />
+                                {(senderChar?.chatAvatar || senderChar?.avatar) ? (
+                                    <img src={senderChar?.chatAvatar || senderChar?.avatar || ""} className="w-full h-full object-cover" alt="" />
                                 ) : (
                                     <ChatFallbackAvatar />
                                 )}
@@ -823,6 +841,29 @@ export function ChatSettingsPanel({
                             <ChevronRight size={16} />
                         </div>
                     </button>
+                    {!session.isGroup && (
+                        <button className="menu-item" onClick={() => chatAvatarInputRef.current?.click()}>
+                            {character?.chatAvatar ? (
+                                <div className="w-[36px] h-[36px] rounded-full overflow-hidden bg-[var(--c-input)] shrink-0 flex items-center justify-center">
+                                    <img src={character.chatAvatar} className="w-full h-full object-cover" alt="" />
+                                </div>
+                            ) : (
+                                <ChatInfoIcon icon={ImageIcon} color={CONTENT_APP_ACCENTS.chat} />
+                            )}
+                            <div className="menu-label-group">
+                                <span className="menu-label">更换聊天头像</span>
+                                <span className="menu-desc">{character?.chatAvatar ? "已设置专属圆形头像，点此更换" : "从角色卡裁出正脸，聊天/列表/朋友圈通用"}</span>
+                            </div>
+                            <div className="menu-right">
+                                {character?.chatAvatar ? (
+                                    <span className="menu-desc mr-1 cursor-pointer" onClick={(e) => { e.stopPropagation(); resetChatAvatar(); }}>恢复默认</span>
+                                ) : (
+                                    <ChevronRight size={16} />
+                                )}
+                            </div>
+                        </button>
+                    )}
+                    <input ref={chatAvatarInputRef} type="file" accept="image/*" className="hidden" onChange={handleChatAvatarFile} />
                     <button className="menu-item" onClick={openSearchPanel}>
                         <ChatInfoIcon icon={Search} color={BINDING_ACCENTS.api} />
                         <div className="menu-label-group"><span className="menu-label">查找聊天记录</span></div>
@@ -916,10 +957,8 @@ export function ChatSettingsPanel({
                     </div>
                 )}
 
-                {/* 状态栏（状态区）：原生开关 + 自定义契约/渲染。
-                    群聊同样支持：群回复按 [角色名]: 切段后每段各自解析，
-                    一份契约 + 一份渲染，群里每个角色各出一条状态栏。 */}
-                {(
+                {/* 状态栏（状态区）：原生开关 + 自定义契约/渲染 */}
+                {!session.isGroup && (
                     <div className="menu-group">
                         <div className="menu-item">
                             <ChatInfoIcon icon={Code} color={BINDING_ACCENTS.preset} />
@@ -1160,7 +1199,6 @@ export function ChatSettingsPanel({
 
                 {/* Advanced */}
                 <div className="menu-group">
-                    <KeyboardAutoSendDebounceItem sessionId={session.id} />
                     <button className="menu-item" onClick={() => setEditingCSS(true)}>
                         <ChatInfoIcon icon={Code} color={BINDING_ACCENTS.embedding} />
                         <div className="menu-label-group"><span className="menu-label">自定义 CSS 样式</span></div>
@@ -1385,6 +1423,15 @@ export function ChatSettingsPanel({
                         </div>
                     </div>
                 </div>
+            )}
+
+            {/* Modal: Chat Avatar Crop */}
+            {avatarCropImage && (
+                <AvatarCropModal
+                    image={avatarCropImage}
+                    onCancel={() => setAvatarCropImage(null)}
+                    onConfirm={persistChatAvatar}
+                />
             )}
 
             {/* Modal: Screen Effects */}
@@ -1659,7 +1706,7 @@ export function ChatSettingsPanel({
                                 onClick={() => {
                                     const contract = draftContract.trim();
                                     const renderHtml = draftRender.trim();
-                                    saveStatusRegion({ mode: contract && renderHtml ? "custom" : "off", contract, renderHtml, previewRaw: statusPreviewRaw });
+                                    saveStatusRegion({ mode: contract && renderHtml ? "custom" : "off", contract, renderHtml });
                                     setShowStatusRegionDialog(false);
                                 }}
                             >
@@ -1668,6 +1715,13 @@ export function ChatSettingsPanel({
                         </div>
                     </div>
                 </div>
+            )}
+            {avatarCropImage && (
+                <AvatarCropModal
+                    image={avatarCropImage}
+                    onCancel={() => setAvatarCropImage(null)}
+                    onConfirm={persistChatAvatar}
+                />
             )}
         </PageShell>
     );

--- a/components/settings/user-identity.tsx
+++ b/components/settings/user-identity.tsx
@@ -6,6 +6,7 @@ import { SettingsContext } from "../phone-settings-app";
 import { loadUserIdentities, saveUserIdentities } from "@/lib/settings-storage";
 import { Input } from "@/components/ui/form";
 import { ConfirmDialog } from "@/components/ui/modal";
+import { AvatarCropModal } from "@/components/chat/avatar-crop-modal";
 
 export type UserIdentity = {
     id: string;
@@ -67,6 +68,7 @@ export function UserIdentitySettings() {
     const [editingId, setEditingId] = useState<string | null>(null);
     const [isNewIdentity, setIsNewIdentity] = useState(false);
     const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+    const [avatarCropImage, setAvatarCropImage] = useState<string | null>(null);
 
     useEffect(() => {
         const saved = loadUserIdentities();
@@ -232,7 +234,7 @@ export function UserIdentitySettings() {
                                                         if (!file) return;
                                                         try {
                                                             const dataUrl = await fileToDataUrl(file);
-                                                            updateIdentity(identity.id, { avatarUrl: dataUrl });
+                                                            setAvatarCropImage(dataUrl);
                                                         } catch { /* ignore */ }
                                                     };
                                                     input.click();
@@ -341,6 +343,17 @@ export function UserIdentitySettings() {
                         </div>
                     </div>
                 </div>
+            )}
+
+            {avatarCropImage && (
+                <AvatarCropModal
+                    image={avatarCropImage}
+                    onCancel={() => setAvatarCropImage(null)}
+                    onConfirm={(dataUrl) => {
+                        if (editingId) updateIdentity(editingId, { avatarUrl: dataUrl });
+                        setAvatarCropImage(null);
+                    }}
+                />
             )}
 
             {confirmDeleteId && (

--- a/lib/character-storage.ts
+++ b/lib/character-storage.ts
@@ -64,6 +64,11 @@ export function loadCharacters(): Character[] {
         char.avatar = null;
         needsSave = true;
       }
+      // Sanitize chatAvatar the same way
+      if (char.chatAvatar && !char.chatAvatar.startsWith("data:") && !char.chatAvatar.startsWith("http://") && !char.chatAvatar.startsWith("https://")) {
+        char.chatAvatar = null;
+        needsSave = true;
+      }
       return char as Character;
     });
 
@@ -145,6 +150,7 @@ export function exportCharacterAsJson(char: Character): void {
     description: char.persona,
     personality: char.personality || "",
     avatar: char.avatar ?? "none",
+    chatAvatar: char.chatAvatar ?? "none",
     tags: char.tags || [],
     wechatID: char.wechatID || "",
     timeZone: char.timeZone || "",
@@ -187,6 +193,7 @@ export function parseCharacterFromJson(
       name: String(src.name ?? ""),
       persona: String(src.description ?? src.persona ?? ""),
       avatar: validAvatar(src.avatar),
+      chatAvatar: validAvatar(src.chatAvatar),
       personality: typeof src.personality === "string" && src.personality.trim() ? src.personality : undefined,
       tags: Array.isArray(src.tags) ? src.tags.map(String) : [],
       wechatID: typeof src.wechatID === "string" && src.wechatID.trim() ? src.wechatID : undefined,
@@ -405,6 +412,7 @@ export async function exportCharacterAsPng(char: Character): Promise<void> {
     description: char.persona,
     personality: char.personality || "",
     avatar: "none",
+    chatAvatar: char.chatAvatar ?? "none",
     tags: char.tags || [],
     wechatID: char.wechatID || "",
     timeZone: char.timeZone || "",

--- a/lib/character-types.ts
+++ b/lib/character-types.ts
@@ -2,6 +2,7 @@ export type Character = {
   id: string;
   name: string;
   avatar: string | null; // data URL 或外部 URL
+  chatAvatar?: string | null; // 专属聊天头像（data URL 或外部 URL）；所有圆形头像展示点优先用它，未设置回退 avatar
   persona: string;       // 人设
   briefPersona?: string; // 简量版人设：注入到同世界有关系角色的「角色关系」marker，供对方了解 TA（防 OOC）
   briefPersonaUpdatedAt?: string; // 简介生成时间；早于 updatedAt 时编辑器提示「设定已更新，建议重新生成」


### PR DESCRIPTION
贡献者：什锦杂货铺（小红书）（@huaxingdictionar-art）

贡献者：什锦杂货铺（小红书）。本份是完整功能的前置基础，必须与 2/5、3/5、4/5、5/5 组合使用。功能包括角色头像更换并支持裁剪；用户头像更换也增加裁剪功能。角色头像入口：聊天——具体的角色——聊天信息——更换聊天头像。用户头像入口仍在设置中。本份实现 chatAvatar 独立字段、存储校验与 JSON/PNG 导入导出、统一头像裁剪组件、角色和用户更换入口及当前聊天即时刷新。完整功能按 1/5 → 2/5 → 3/5 → 4/5 → 5/5 合并，五份合并才是经过五版查漏补缺与测试的完整成果。角色头像覆盖聊天、手记、日历、查手机、购物、阅读、共创、游戏、剧情、冒险和设置中的绑定角色选择；音乐、在场、应用市场、小红书、栖所、筑境、工坊、资源集市、独家特调、外观设置、漫卷/剧情/资源库记忆库封面等未确认的头像位置不纳入，封面继续使用角色卡原图。

---
_经小手机「共同建设」通道提交_