### PR TITLE
角色聊天头像与头像裁剪（2/5）：聊天主链路展示

### DIFF
--- a/components/chat/chat-contacts-list.tsx
+++ b/components/chat/chat-contacts-list.tsx
@@ -281,8 +281,8 @@ export function ChatContactsList({ onCloseApp, onSelectSession, onSelectMascot, 
                                             className="minimal-list-item"
                                         >
                                             <div className="minimal-avatar-wrapper">
-                                                {char.avatar ? (
-                                                    <img src={char.avatar} className="w-full h-full object-cover rounded-full" alt="" />
+                                                {char.chatAvatar || char.avatar ? (
+                                                    <img src={char.chatAvatar || char.avatar || ""} className="w-full h-full object-cover rounded-full" alt="" />
                                                 ) : (
                                                     <ChatFallbackAvatar className="rounded-full" />
                                                 )}
@@ -343,8 +343,8 @@ export function ChatContactsList({ onCloseApp, onSelectSession, onSelectMascot, 
                                             onClick={() => setSelectedRequest(req)}
                                         >
                                             <div className="freq-avatar">
-                                                {char?.avatar ? (
-                                                    <img src={char.avatar} alt="" />
+                                                {char?.chatAvatar || char?.avatar ? (
+                                                    <img src={char?.chatAvatar || char?.avatar || ""} alt="" />
                                                 ) : (
                                                     <div className="freq-avatar-fallback">
                                                         {(char?.name || "?")[0]}
@@ -382,8 +382,8 @@ export function ChatContactsList({ onCloseApp, onSelectSession, onSelectMascot, 
                         <div className="modal-dialog freq-dialog" onClick={e => e.stopPropagation()}>
                             {/* Avatar */}
                             <div className="freq-detail-avatar">
-                                {char?.avatar ? (
-                                    <img src={char.avatar} alt="" />
+                                {char?.chatAvatar || char?.avatar ? (
+                                    <img src={char?.chatAvatar || char?.avatar || ""} alt="" />
                                 ) : (
                                     <div className="freq-avatar-fallback" style={{ fontSize: "calc(28px*var(--app-text-scale,1))" }}>
                                         {(char?.name || "?")[0]}

--- a/components/chat/chat-message-list.tsx
+++ b/components/chat/chat-message-list.tsx
@@ -615,8 +615,8 @@ function ContactPicker({ onClose, onSelect }: { onClose: () => void; onSelect: (
                                 onClick={() => onSelect(c.characterId)}
                             >
                                 <div className="chat-contact-avatar">
-                                    {c.char.avatar ? (
-                                        <img src={c.char.avatar} alt="" />
+                                    {c.char.chatAvatar || c.char.avatar ? (
+                                        <img src={c.char.chatAvatar || c.char.avatar || ""} alt="" />
                                     ) : (
                                         <ChatFallbackAvatar />
                                     )}
@@ -647,7 +647,7 @@ function SessionItem({ session, onSelect, isPinned }: { session: ChatSession, on
             ...((session.participantIds || [])
                 .map(id => chars.find(c => c.id === id))
                 .filter(Boolean) as Character[])
-                .map(c => ({ id: c.id, name: c.name, avatar: c.avatar || "" })),
+                .map(c => ({ id: c.id, name: c.name, avatar: c.chatAvatar || c.avatar || "" })),
         ].slice(0, 4)
         : [];
 
@@ -673,8 +673,8 @@ function SessionItem({ session, onSelect, isPinned }: { session: ChatSession, on
                 </div>
             ) : (
                 <div className="minimal-avatar-wrapper">
-                    {character?.avatar ? (
-                        <img src={character.avatar} className="w-full h-full object-cover pointer-events-none rounded-full" alt="" />
+                    {character?.chatAvatar || character?.avatar ? (
+                        <img src={character?.chatAvatar || character?.avatar || ""} className="w-full h-full object-cover pointer-events-none rounded-full" alt="" />
                     ) : (
                         <ChatFallbackAvatar className="pointer-events-none rounded-full" />
                     )}

--- a/components/chat/group-call-screen.tsx
+++ b/components/chat/group-call-screen.tsx
@@ -673,8 +673,8 @@ export function GroupCallScreen({ type, session, characters, onEnd, initiator = 
                         return (
                             <div key={char.id} className="gcall-tile" {...(isSpeaking ? { "data-speaking": "" } : {})}>
                                 <div className="gcall-tile-avatar">
-                                    {char.avatar ? (
-                                        <img src={char.avatar} alt={char.name} />
+                                    {char.chatAvatar || char.avatar ? (
+                                        <img src={char.chatAvatar || char.avatar} alt={char.name} />
                                     ) : (
                                         <span className="gcall-tile-initial">{char.name?.[0] || "?"}</span>
                                     )}

--- a/components/chat/group-create-modal.tsx
+++ b/components/chat/group-create-modal.tsx
@@ -62,8 +62,8 @@ export function GroupCreateModal({ onClose, onCreate }: GroupCreateModalProps) {
                                             onClick={() => toggle(c.characterId)}
                                         >
                                             <div className="chat-contact-avatar" style={isSelected ? { outline: "3px solid var(--c-success)", outlineOffset: "2px" } : undefined}>
-                                                {c.char.avatar ? (
-                                                    <img src={c.char.avatar} alt="" />
+                                                {c.char.chatAvatar || c.char.avatar ? (
+                                                    <img src={c.char.chatAvatar || c.char.avatar} alt="" />
                                                 ) : (
                                                     <ChatFallbackAvatar />
                                                 )}
@@ -102,8 +102,8 @@ export function GroupCreateModal({ onClose, onCreate }: GroupCreateModalProps) {
                             {selectedChars.map(c => (
                                 <div key={c.id} className="chat-contact-item">
                                     <div className="chat-contact-avatar">
-                                        {c.avatar ? (
-                                            <img src={c.avatar} alt="" />
+                                        {c.chatAvatar || c.avatar ? (
+                                            <img src={c.chatAvatar || c.avatar} alt="" />
                                         ) : (
                                             <ChatFallbackAvatar />
                                         )}

--- a/components/chat/message-bubble.tsx
+++ b/components/chat/message-bubble.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef, useMemo, memo } from "react";
 import { findCustomStickerByName, resolveCustomStickerUrl } from "@/lib/custom-sticker-storage";
 import { isMediaStoreRef, loadMediaObjectUrl } from "@/lib/media-cache-storage";
 import { getChatImageFromIndexedDB } from "@/lib/chat-asset-storage";
-import { ChatMessage, createOrGetSession, updateMessageMediaStatus, updateMessageMediaData } from "@/lib/chat-storage";
+import { ChatMessage, createOrGetSession, updateMessageMediaStatus, updateMessageMediaData, updateMessageMediaUrl } from "@/lib/chat-storage";
 import { resolveContactCard } from "@/lib/contact-card";
 import { loadCharacters } from "@/lib/character-storage";
 import { CHAT_OPEN_SESSION_EVENT, dispatchOpenAddContact } from "@/lib/chat-notification-events";
@@ -1047,8 +1047,8 @@ function ContactCardBubble({ msg, characterId }: { msg: ChatMessage; characterId
             <div className="chat-contact-card" onClick={handleClick} role="button">
                 <div className="chat-contact-card-main">
                     <div className="chat-contact-card-avatar">
-                        {resolved.character?.avatar
-                            ? <img src={resolved.character.avatar} alt="" />
+                        {resolved.character?.chatAvatar || resolved.character?.avatar
+                            ? <img src={resolved.character?.chatAvatar || resolved.character?.avatar} alt="" />
                             : <CharAvatarFallbackInline name={contactName} />}
                     </div>
                     <div className="chat-contact-card-info">
@@ -2164,44 +2164,10 @@ function XiaohongshuShareBubble({ msg }: { msg: ChatMessage }) {
 }
 
 // ── Voice Message ───────────────────────────────
-
-// 模块级在途表：同一条消息全局只允许一个合成请求。组件重渲染/卸载重挂都
-// 复用同一个 Promise——之前"挂载即合成 + 取消竞态"会把同一条语音反复送去
-// 计费还留下点不动的死气泡（用户实报），点击触发 + 全局去重从根上断掉。
-const _voiceSynthInFlight = new Map<string, Promise<string>>();
-
-function synthesizeVoiceForMessage(msgId: string, characterId: string, speechText: string): Promise<string> {
-    const existing = _voiceSynthInFlight.get(msgId);
-    if (existing) return existing;
-    const task = (async () => {
-        const { resolveVoiceConfig, synthesizeSpeech } = await import("@/lib/tts-service");
-        const vc = resolveVoiceConfig(characterId);
-        if (!vc) throw new Error("未绑定语音配置");
-        const blob = await synthesizeSpeech(speechText, vc);
-        if (!blob) throw new Error("合成失败");
-        const dataUrl = await new Promise<string>((resolve, reject) => {
-            const reader = new FileReader();
-            reader.onload = () => resolve(reader.result as string);
-            reader.onerror = () => reject(new Error("音频编码失败"));
-            reader.readAsDataURL(blob);
-        });
-        // 直接落库（不依赖会话缓存）——合成一次的音频永久保存，绝不重复计费
-        const { persistMessageVoiceAudio } = await import("@/lib/chat-storage");
-        await persistMessageVoiceAudio(msgId, dataUrl, speechText);
-        return dataUrl;
-    })();
-    _voiceSynthInFlight.set(msgId, task);
-    task.catch(() => {}).then(() => { _voiceSynthInFlight.delete(msgId); });
-    return task;
-}
-
 function VoiceMessageBubble({ msg, characterId, onUpdate, defaultTranslationExpanded = false }: { msg: ChatMessage; characterId?: string; onUpdate?: (m: ChatMessage) => void; defaultTranslationExpanded?: boolean }) {
     const [playing, setPlaying] = useState(false);
     const [synthesizing, setSynthesizing] = useState(false);
-    const [synthFailed, setSynthFailed] = useState(false);
     const audioRef = useRef<HTMLAudioElement | null>(null);
-    const mountedRef = useRef(true);
-    useEffect(() => { mountedRef.current = true; return () => { mountedRef.current = false; }; }, []);
     const text = msg.mediaData?.label || "语音消息";
     const bilingual = splitBilingualText(text);
     const speechText = bilingual?.original || text;
@@ -2209,7 +2175,48 @@ function VoiceMessageBubble({ msg, characterId, onUpdate, defaultTranslationExpa
     const needsResynthesis = msg.role !== "user" && synthesizedFromText !== speechText;
     const duration = msg.mediaData?.voiceDuration || Math.max(2, Math.ceil(speechText.length / 4));
 
-    const playSrc = (src: string) => {
+    // Auto-synthesize on mount if no audio yet (AI messages)
+    useEffect(() => {
+        if ((msg.mediaUrl && !needsResynthesis) || msg.role === "user" || synthesizing) return;
+        if (!characterId) return;
+        let cancelled = false;
+        setSynthesizing(true);
+        (async () => {
+            try {
+                const { resolveVoiceConfig, synthesizeSpeech } = await import("@/lib/tts-service");
+                const vc = resolveVoiceConfig(characterId);
+                if (!vc || cancelled) { setSynthesizing(false); return; }
+                const blob = await synthesizeSpeech(speechText, vc);
+                if (cancelled || !blob) { setSynthesizing(false); return; }
+                // Convert to base64 data URL and persist
+                const reader = new FileReader();
+                reader.onload = () => {
+                    if (cancelled) return;
+                    const dataUrl = reader.result as string;
+                    const nextMediaData = { ...msg.mediaData, synthesizedFromText: speechText };
+                    updateMessageMediaData(msg.id, nextMediaData);
+                    updateMessageMediaUrl(msg.id, dataUrl);
+                    if (onUpdate) onUpdate({ ...msg, mediaUrl: dataUrl, mediaData: nextMediaData });
+                    setSynthesizing(false);
+                };
+                reader.readAsDataURL(blob);
+            } catch { if (!cancelled) setSynthesizing(false); }
+        })();
+        return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [msg.id, msg.mediaUrl, msg.mediaData, characterId, needsResynthesis, speechText]);
+
+    const handlePlay = () => {
+        if (synthesizing || needsResynthesis) return;
+        if (playing && audioRef.current) {
+            const active = audioRef.current;
+            audioRef.current = null;
+            try { active.pause(); active.removeAttribute("src"); active.load(); } catch { /* ignore */ }
+            setPlaying(false);
+            return;
+        }
+        const src = msg.mediaUrl;
+        if (!src) return;
         // 必须用 <audio> 元素:iOS 静音拨键会掐掉 Web Audio 的输出(表现为全线
         // 无声),媒体元素不受影响。元素属于宿主页面,锁屏媒体卡片指向站点本身,
         // 点了只会回到 App;播完清 src 让卡片立即撤下。
@@ -2224,41 +2231,6 @@ function VoiceMessageBubble({ msg, characterId, onUpdate, defaultTranslationExpa
         audio.onended = finalize;
         audio.onerror = finalize;
         audio.play().catch(finalize);
-    };
-
-    // 点击才合成（不再挂载即合成）：已有音频直接播；没有就现场合成一次，
-    // 合成结果已在任务内落库，之后任何时候点都是直接播放，不再消耗额度。
-    const handlePlay = () => {
-        if (synthesizing) return;
-        if (playing && audioRef.current) {
-            const active = audioRef.current;
-            audioRef.current = null;
-            try { active.pause(); active.removeAttribute("src"); active.load(); } catch { /* ignore */ }
-            setPlaying(false);
-            return;
-        }
-        if (msg.mediaUrl && !needsResynthesis) {
-            playSrc(msg.mediaUrl);
-            return;
-        }
-        if (msg.role === "user" || !characterId) {
-            if (msg.mediaUrl) playSrc(msg.mediaUrl);
-            return;
-        }
-        setSynthesizing(true);
-        setSynthFailed(false);
-        synthesizeVoiceForMessage(msg.id, characterId, speechText)
-            .then((dataUrl) => {
-                if (onUpdate) onUpdate({ ...msg, mediaUrl: dataUrl, mediaData: { ...msg.mediaData, synthesizedFromText: speechText } });
-                if (!mountedRef.current) return;
-                setSynthesizing(false);
-                playSrc(dataUrl);
-            })
-            .catch(() => {
-                if (!mountedRef.current) return;
-                setSynthesizing(false);
-                setSynthFailed(true);
-            });
     };
 
     useEffect(() => () => { audioRef.current?.pause(); }, []);
@@ -2295,7 +2267,7 @@ function VoiceMessageBubble({ msg, characterId, onUpdate, defaultTranslationExpa
                     />
                 ))}
             </div>
-            <span className="voice-msg-dur">{synthFailed ? "合成失败·点击重试" : `${duration}"`}</span>
+            <span className="voice-msg-dur">{duration}&quot;</span>
         </div>
     );
 }

--- a/components/chat/voice-call-screen.tsx
+++ b/components/chat/voice-call-screen.tsx
@@ -566,9 +566,9 @@ export function VoiceCallScreen({ session, character, onEnd, onConnect, initiato
                             className="voicecall-avatar"
                             {...(callState === "AI_SPEAKING" ? { "data-speaking": "" } : {})}
                         >
-                            {character.avatar ? (
+                            {character.chatAvatar || character.avatar ? (
                                 <img
-                                    src={character.avatar}
+                                    src={character.chatAvatar || character.avatar}
                                     alt={character.name}
                                     className="w-full h-full object-cover"
                                 />


### PR DESCRIPTION
贡献者：什锦杂货铺（小红书）（@huaxingdictionar-art）

贡献者：什锦杂货铺（小红书）。本份依赖 1/5 的 chatAvatar 数据字段与更换/裁剪链路，不能脱离 1/5 单独使用；完整功能必须按 1/5 → 2/5 → 3/5 → 4/5 → 5/5 组合。将聊天主链路中的联系人、好友申请与详情、会话列表、联系人选择、群聊组合、群聊创建、群通话、单人语音通话和联系人卡片统一改为优先展示 chatAvatar || avatar。功能范围为角色头像更换并支持裁剪，用户头像更换同样支持裁剪；入口分别为聊天——具体的角色——聊天信息——更换聊天头像，以及设置中的原用户头像入口。五份合并才是经过五版查漏补缺与测试的完整成果。

---
_经小手机「共同建设」通道提交_