### PR TITLE
角色聊天头像与头像裁剪（3/5）：聊天扩展与基础应用接入

### DIFF
--- a/components/calendar-app.tsx
+++ b/components/calendar-app.tsx
@@ -81,7 +81,7 @@ function buildOwnerOptions(): OwnerOption[] {
       ownerType: "character",
       ownerId: char.id,
       name: char.name,
-      avatar: char.avatar,
+      avatar: char.chatAvatar || char.avatar,
     });
   }
   return options;
@@ -113,7 +113,7 @@ function buildPeriodCareCharacterOptions(): PeriodCareCharacterOption[] {
       return {
         characterId: character.id,
         name: session.alias || character.name,
-        avatar: character.avatar,
+        avatar: character.chatAvatar || character.avatar,
       };
     });
 }

--- a/components/chat/moment-post-card.tsx
+++ b/components/chat/moment-post-card.tsx
@@ -86,7 +86,8 @@ export function MomentPostCard({ post, onUpdate, onRequestDelete, onOpenCommentC
     };
 
     const getCharAvatar = (charId: string): string | null => {
-        return chars.find(c => c.id === charId)?.avatar ?? null;
+        const ch = chars.find(c => c.id === charId);
+        return ch?.chatAvatar || ch?.avatar || null;
     };
 
     const getAuthorName = (authorType: "user" | "character" | "npc", authorId: string, authorName?: string): string => {
@@ -334,11 +335,8 @@ export function MomentPostCard({ post, onUpdate, onRequestDelete, onOpenCommentC
                 </div>
             )}
 
-            {/* Photo area —— 四块内容全无时整个容器不渲染：空壳会照样吃掉自己的下边距
-                （flex 容器不会自塌陷），无配图的帖子正文和时间行之间就凭空多出一截，看着像空了一行。
-                间距用 mb-3 与卡片其余部分（头像行/正文/位置）对齐，media 原本的 mb-5 是全卡唯一的孤例。 */}
-            {(resolvedPhotoUrl || fallbackPhotoDescription || photoRetryError) && (
-            <div className="feed-post-media mb-3 w-full flex flex-col gap-2">
+            {/* Photo area */}
+            <div className="feed-post-media mb-5 w-full flex flex-col gap-2">
                 {resolvedPhotoUrl && (
                     <MediaImageWithPreview
                         url={resolvedPhotoUrl}
@@ -355,7 +353,7 @@ export function MomentPostCard({ post, onUpdate, onRequestDelete, onOpenCommentC
                     <div className="feed-post-photo-retry-stack">
                         <div className="feed-post-photo-retry-row">
                             <div
-                                className="feed-post-photo-description ts-13 italic leading-[1.8] opacity-80 text-[var(--c-text)] px-4 py-3 block w-full"
+                                className="feed-post-photo-description ts-13 italic leading-[1.8] opacity-80 text-[var(--c-text)] px-4 py-3 inline-block max-w-full"
                                 style={{ background: "color-mix(in srgb, var(--c-text) 10%, transparent)", borderRadius: 0, cursor: canRetryPhoto ? "pointer" : undefined }}
                                 onClick={canRetryPhoto ? (e => { e.stopPropagation(); setShowFallbackPreview(true); }) : undefined}
                             >
@@ -366,33 +364,12 @@ export function MomentPostCard({ post, onUpdate, onRequestDelete, onOpenCommentC
                             <div className="ts-12 text-[var(--c-icon)] opacity-80">图片生成中…</div>
                         )}
                         {post.photoGenerationStatus === "failed" && post.photoGenerationError && !photoRetryError && (
-                            <div className="feed-post-photo-retry-error">
-                                生成失败：{post.photoGenerationError}
-                                <button
-                                    type="button"
-                                    className="feed-post-photo-error-dismiss"
-                                    aria-label="忽略此提示"
-                                    title="忽略此提示"
-                                    onClick={() => {
-                                        // 叉掉即清状态落库：这条动态从此不再提示（文字描述框保留）
-                                        updateMomentPost(post.id, { photoGenerationStatus: undefined, photoGenerationError: undefined });
-                                        onUpdate();
-                                    }}
-                                >
-                                    ✕
-                                </button>
-                            </div>
+                            <div className="feed-post-photo-retry-error">生成失败：{post.photoGenerationError}</div>
                         )}
                     </div>
                 )}
-                {photoRetryError && (
-                    <div className="feed-post-photo-retry-error">
-                        生成失败：{photoRetryError}
-                        <button type="button" className="feed-post-photo-error-dismiss" aria-label="忽略此提示" onClick={() => setPhotoRetryError("")}>✕</button>
-                    </div>
-                )}
+                {photoRetryError && <div className="feed-post-photo-retry-error">生成失败：{photoRetryError}</div>}
             </div>
-            )}
             {showFallbackPreview && fallbackPhotoDescription && (
                 <MediaPreviewOverlay
                     description={fallbackPhotoDescription}

--- a/components/chat/moments-compose.tsx
+++ b/components/chat/moments-compose.tsx
@@ -303,8 +303,8 @@ export function MomentsCompose({ onClose, onPublished }: Props) {
                                         onClick={() => handleToggleMention(c.characterId)}
                                     >
                                         <div className="chat-contact-avatar" style={mentionIds.has(c.characterId) ? { outline: "2px solid var(--c-primary, #07C160)", outlineOffset: "2px" } : undefined}>
-                                            {c.char!.avatar ? (
-                                                <img src={c.char!.avatar} alt="" />
+                                            {c.char!.chatAvatar || c.char!.avatar ? (
+                                                <img src={c.char!.chatAvatar || c.char!.avatar} alt="" />
                                             ) : (
                                                 <ChatFallbackAvatar />
                                             )}
@@ -357,8 +357,8 @@ export function MomentsCompose({ onClose, onPublished }: Props) {
                                         onClick={() => handleToggleChar(c.characterId)}
                                     >
                                         <div className="chat-contact-avatar" style={visibility[c.characterId] ? { outline: "2px solid var(--c-primary, #07C160)", outlineOffset: "2px" } : undefined}>
-                                            {c.char!.avatar ? (
-                                                <img src={c.char!.avatar} alt="" />
+                                            {c.char!.chatAvatar || c.char!.avatar ? (
+                                                <img src={c.char!.chatAvatar || c.char!.avatar} alt="" />
                                             ) : (
                                                 <ChatFallbackAvatar />
                                             )}

--- a/components/chat/transfer-target-modal.tsx
+++ b/components/chat/transfer-target-modal.tsx
@@ -27,8 +27,8 @@ export function TransferTargetModal({ participants, onSelect, onClose }: Transfe
                             className="flex items-center gap-3 px-3 py-2.5 rounded-xl hover:bg-[var(--c-input)] active:bg-[var(--c-input)] transition-colors text-left w-full"
                         >
                             <div className="w-[36px] h-[36px] rounded-full bg-[var(--c-input)] overflow-hidden shrink-0 flex items-center justify-center">
-                                {char.avatar ? (
-                                    <img src={char.avatar} className="w-full h-full object-cover" alt="" />
+                                {char.chatAvatar || char.avatar ? (
+                                    <img src={char.chatAvatar || char.avatar} className="w-full h-full object-cover" alt="" />
                                 ) : (
                                     <User size={18} color="var(--c-icon)" />
                                 )}

--- a/components/chat/user-profile-panel.tsx
+++ b/components/chat/user-profile-panel.tsx
@@ -947,7 +947,7 @@ function InlineMomentsSettings({ onBack }: { onBack: () => void }) {
                     {showAutoPostList && enriched.map(c => (
                         <div key={c.characterId} className="menu-item" style={{ cursor: "default" }}>
                             <div className="chat-contact-avatar" style={{ width: 32, height: 32 }}>
-                                {c.char.avatar ? <img src={c.char.avatar} alt="" /> : <ChatFallbackAvatar />}
+                                {c.char.chatAvatar || c.char.avatar ? <img src={c.char.chatAvatar || c.char.avatar} alt="" /> : <ChatFallbackAvatar />}
                             </div>
                             <div className="menu-label-group">
                                 <span className="menu-label">{c.char.name}</span>
@@ -987,8 +987,8 @@ function InlineMomentsSettings({ onBack }: { onBack: () => void }) {
                                     <div className="chat-contact-avatar"
                                         style={selectedIds.has(c.characterId) ? { outline: "3px solid var(--c-success)", outlineOffset: "2px" } : undefined}
                                     >
-                                        {c.char.avatar ? (
-                                            <img src={c.char.avatar} alt="" />
+                                        {c.char.chatAvatar || c.char.avatar ? (
+                                            <img src={c.char.chatAvatar || c.char.avatar} alt="" />
                                         ) : (
                                             <ChatFallbackAvatar />
                                         )}

--- a/components/checkphone/checkphone-app.tsx
+++ b/components/checkphone/checkphone-app.tsx
@@ -1048,8 +1048,8 @@ export function CheckPhoneApp({ onClose }: CheckPhoneAppProps) {
                 >
                   <div className="cp-roster-avatar-hud">
                     <div className="cp-roster-avatar">
-                       {character.avatar ? (
-                         <img src={character.avatar} alt="" />
+                       {character.chatAvatar || character.avatar ? (
+                         <img src={character.chatAvatar || character.avatar} alt="" />
                        ) : (
                          <div className="cp-roster-fallback-inner"><span /></div>
                        )}


### PR DESCRIPTION
贡献者：什锦杂货铺（小红书）（@huaxingdictionar-art）

贡献者：什锦杂货铺（小红书）。本份依赖 1/5 的 chatAvatar 数据字段与裁剪链路，完整功能需与 1/5、2/5、4/5、5/5 一起按顺序组合，不能单独使用。覆盖朋友圈帖子、评论、作者、发帖时 @ 与可见范围、转账目标、朋友圈自动发布角色列表、日历和查手机角色选择页面，统一使用 chatAvatar || avatar。角色头像功能包括头像更换与裁剪；用户头像更换也增加裁剪功能。入口：角色头像为聊天——具体的角色——聊天信息——更换聊天头像，用户头像仍在设置中。经过五版查漏补缺与测试，五份合并才构成完整成果。未确认有角色头像位置的音乐、在场、应用市场、小红书、栖所、筑境、工坊、资源集市、独家特调、外观设置等不纳入；剧情/漫卷/资源库记忆库封面继续使用角色卡原图。

---
_经小手机「共同建设」通道提交_