### PR TITLE
feat(chat): 支持表情包组改名与备注

### DIFF
--- a/components/chat/sticker-manager.tsx
+++ b/components/chat/sticker-manager.tsx
@@ -13,6 +13,8 @@ import {
     addStickersToPack,
     addStickerByUrlToPack,
     checkStickerBlob,
+    renameStickerPack,
+    updateStickerPackNote,
     renameStickerInPack,
     removeStickerFromPack,
     getPackAssignments,
@@ -85,6 +87,9 @@ export function StickerManager({ onBack }: { onBack: () => void }) {
                                 <div className="flex flex-col w-full gap-0.5">
                                     <span className="ts-16 text-[var(--c-text-title)] font-bold truncate max-w-full leading-tight">{pack.name}</span>
                                     <span className="ts-12 text-[var(--c-text)] opacity-70">{pack.stickers.length === 0 ? "空相册" : `${pack.stickers.length} 个表情`}</span>
+                                    {pack.note?.trim() && (
+                                        <span className="ts-11 text-[var(--c-text)] opacity-50 truncate mt-1">{pack.note}</span>
+                                    )}
                                 </div>
 
                                 {assignedNames.length > 0 && (
@@ -161,6 +166,7 @@ function CreatePackDialog({
     onCancel: () => void;
 }) {
     const [name, setName] = useState("");
+    const [note, setNote] = useState("");
     const [selectedCharIds, setSelectedCharIds] = useState<string[]>([]);
 
     const handleToggle = (charId: string) => {
@@ -172,7 +178,7 @@ function CreatePackDialog({
     const handleCreate = () => {
         const trimmed = name.trim();
         if (!trimmed) return;
-        const pack = createStickerPack(trimmed);
+        const pack = createStickerPack(trimmed, note.trim());
         for (const charId of selectedCharIds) {
             togglePackAssignment(pack.id, charId);
         }
@@ -196,6 +202,17 @@ function CreatePackDialog({
                                 onChange={e => setName(e.target.value)}
                                 placeholder="例如：可爱猫猫"
                                 className="ui-input"
+                            />
+                        </div>
+
+                        <div className="flex flex-col gap-1">
+                            <label className="menu-desc ml-1">备注（可选）</label>
+                            <textarea
+                                value={note}
+                                onChange={e => setNote(e.target.value)}
+                                placeholder="例如：由某某老师整理分享，目前还差 20 个表情待整理"
+                                className="ui-input min-h-[88px] resize-y"
+                                rows={3}
                             />
                         </div>
 
@@ -329,6 +346,8 @@ function PackEditor({ pack, onBack }: { pack: StickerPack; onBack: () => void })
     const [assignedCharIds, setAssignedCharIds] = useState<string[]>([]);
     const [showAddDialog, setShowAddDialog] = useState(false);
     const [showBatchDialog, setShowBatchDialog] = useState(false);
+    const [packNameDraft, setPackNameDraft] = useState(pack.name);
+    const [packNoteDraft, setPackNoteDraft] = useState(pack.note ?? "");
 
     const refreshPack = useCallback(() => {
         const fresh = loadStickerPacks().find(p => p.id === pack.id);
@@ -399,11 +418,51 @@ function PackEditor({ pack, onBack }: { pack: StickerPack; onBack: () => void })
         refreshAssignments();
     };
 
+    const handleSavePackInfo = () => {
+        const trimmedName = packNameDraft.trim();
+        if (!trimmedName) return;
+        renameStickerPack(pack.id, trimmedName);
+        updateStickerPackNote(pack.id, packNoteDraft.trim());
+        setPackNameDraft(trimmedName);
+        setPackNoteDraft(packNoteDraft.trim());
+        refreshPack();
+    };
+
+    const packInfoChanged = packNameDraft.trim() !== currentPack.name
+        || packNoteDraft.trim() !== (currentPack.note ?? "");
+
     return (
         <PageShell title={currentPack.name} onBack={onBack} className="absolute inset-0 z-[100]">
             <div className="flex flex-col h-full bg-[var(--c-page-body-bg)]">
-                {/* Character assignment section */}
+                {/* Pack metadata section */}
                 <div className="px-6 pt-5 pb-2 shrink-0">
+                    <div className="text-[calc(12px*var(--app-text-scale,1))] font-bold text-[var(--c-text)] opacity-60 uppercase mb-3 px-1 tracking-[0.1em]">图集信息</div>
+                    <div className="flex flex-col gap-3">
+                        <input
+                            type="text"
+                            value={packNameDraft}
+                            onChange={e => setPackNameDraft(e.target.value)}
+                            placeholder="图集名称"
+                            className="ui-input"
+                        />
+                        <textarea
+                            value={packNoteDraft}
+                            onChange={e => setPackNoteDraft(e.target.value)}
+                            placeholder="备注这套表情包的来源、整理进度等（可选）"
+                            className="ui-input min-h-[72px] resize-y"
+                            rows={2}
+                        />
+                        <button
+                            type="button"
+                            onClick={handleSavePackInfo}
+                            disabled={!packNameDraft.trim() || !packInfoChanged}
+                            className="ui-btn ui-btn-primary self-end"
+                        >保存图集信息</button>
+                    </div>
+                </div>
+
+                {/* Character assignment section */}
+                <div className="px-6 pt-4 pb-2 shrink-0">
                     <div className="text-[calc(12px*var(--app-text-scale,1))] font-bold text-[var(--c-text)] opacity-60 uppercase mb-3 px-1 tracking-[0.1em]">智能角色绑定</div>
                     <div className="flex flex-wrap gap-2.5 px-1">
                         {characters.map(c => {

--- a/lib/custom-sticker-storage.ts
+++ b/lib/custom-sticker-storage.ts
@@ -31,6 +31,8 @@ export interface StickerItem {
 export interface StickerPack {
     id: string;
     name: string;
+    /** Optional note for the whole pack. Missing on legacy data. */
+    note?: string;
     stickers: StickerItem[];
     createdAt: string;
 }
@@ -72,10 +74,11 @@ export function loadStickerPacks(): StickerPack[] {
     return readPacks();
 }
 
-export function createStickerPack(name: string): StickerPack {
+export function createStickerPack(name: string, note = ""): StickerPack {
     const pack: StickerPack = {
         id: `pack_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         name,
+        note,
         stickers: [],
         createdAt: new Date().toISOString(),
     };
@@ -106,6 +109,14 @@ export function renameStickerPack(packId: string, newName: string): void {
     const pack = packs.find(p => p.id === packId);
     if (!pack) return;
     pack.name = newName;
+    writePacks(packs);
+}
+
+export function updateStickerPackNote(packId: string, note: string): void {
+    const packs = readPacks();
+    const pack = packs.find(p => p.id === packId);
+    if (!pack) return;
+    pack.note = note;
     writePacks(packs);
 }
 


### PR DESCRIPTION
贡献者：什锦杂货铺（小红书）（@huaxingdictionar-art）

这是一个微小贡献，功能入口位于「聊天 → 主页 → 表情包仓储」。本改动支持创建后修改表情包组名称、添加可选备注，并在表情包仓储列表中展示备注；存储层兼容没有 note 字段的旧数据。仅包含 components/chat/sticker-manager.tsx 与 lib/custom-sticker-storage.ts 的相关改动。

---
_经小手机「共同建设」通道提交_