### PR TITLE
D: feat(chat) 记忆总结来源标签 + 表情搜索联想 UI 优化

### DIFF
--- a/components/chat/sticker-search-suggest.tsx
+++ b/components/chat/sticker-search-suggest.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 // 表情包搜索联想：输入时按名称模糊匹配本地表情包，横向列表浮在输入框正上方，
-// 点击直接发送（复用 onSendSticker 的 sticker 消息通道）。
+// 点击直接发送（复用 onSendSticker 的 sticker 消息通道），发送后由父组件清空输入。
 // 数据源 = 内置表情包（sticker-data，emoji 兜底）+ 当前会话角色绑定的自定义贴纸包（IndexedDB 解析出 url）。
 
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -115,7 +115,7 @@ export function StickerSearchSuggest({ query, characterIds, onSend, onClose }: S
       onMouseDown={(event) => event.preventDefault()}
     >
       <div
-        className="flex items-stretch gap-1.5 overflow-x-auto px-2.5 py-2 rounded-2xl hide-scrollbar"
+        className="flex items-stretch gap-2 overflow-x-auto px-3 py-2.5 rounded-2xl hide-scrollbar"
         style={{
           background: "color-mix(in srgb, var(--c-card) 96%, transparent)",
           border: "1px solid var(--c-card-border)",
@@ -133,20 +133,20 @@ export function StickerSearchSuggest({ query, characterIds, onSend, onClose }: S
               onSend(item.name, item.url);
               onClose();
             }}
-            className="shrink-0 flex flex-col items-center gap-1 px-2 py-1.5 rounded-xl bg-transparent border-none cursor-pointer transition-transform active:scale-95"
-            style={{ minWidth: 52 }}
+            className="shrink-0 flex flex-col items-center gap-1 px-2.5 py-2 rounded-xl bg-transparent border-none cursor-pointer transition-transform active:scale-95"
+            style={{ minWidth: 64 }}
             title={item.name}
           >
-            <span className="w-10 h-10 flex items-center justify-center overflow-hidden">
+            <span className="w-14 h-14 flex items-center justify-center overflow-hidden">
               {item.url ? (
-                <img src={item.url} alt={item.name} className="w-10 h-10 object-contain" draggable={false} />
+                <img src={item.url} alt={item.name} className="w-14 h-14 object-contain" draggable={false} />
               ) : item.emoji ? (
-                <span className="text-[26px] leading-none">{item.emoji}</span>
+                <span className="text-[32px] leading-none">{item.emoji}</span>
               ) : (
-                <span className="ts-10 text-[var(--c-text)] w-full text-center truncate">{item.name}</span>
+                <span className="ts-11 text-[var(--c-text)] w-full text-center truncate">{item.name}</span>
               )}
             </span>
-            <span className="ts-10 text-[var(--c-text)] opacity-75 max-w-[56px] truncate leading-tight">{item.name}</span>
+            <span className="ts-11 text-[var(--c-text)] opacity-75 max-w-[64px] truncate leading-tight">{item.name}</span>
           </button>
         ))}
       </div>

--- a/lib/memory-summarizer.ts
+++ b/lib/memory-summarizer.ts
@@ -102,10 +102,11 @@ export async function runSummarizationPipeline(
         .replace(/\{\{events\}\}/gi, eventsText);
 
     // Call LLM for summarization — compatible with all providers
+    // label 用于在「底层调用大模型日志」中标识这是记忆总结调用
     const result = await simpleLLMCall(
         apiConfig,
         [{ role: "user", content: summaryPrompt }],
-        { temperature: 0.3 },
+        { temperature: 0.3, label: `记忆总结·${characterName}` },
     );
 
     if (!result.content) {


### PR DESCRIPTION
贡献者：温铎（@yechen1844）

【请结合 A/B/C 一起审阅】本组与 A（核心 bug + 日志底层）、B（日志/工坊 UI）、C（流式生成）相互关联，属于同一批「线下模式思维链输出经常不按格式」引发的修复与配套，建议合并审阅。

本组（D）为两个小配套改动：

1. lib/memory-summarizer.ts：给记忆总结的 simpleLLMCall 增加请求来源标签 label:「记忆总结·角色名」——配合 A 组 api-helpers 新增的 label 参数与 B 组日志的来源过滤，让「底层调用大模型日志」能区分出记忆总结类调用（来源标签显示为「记忆总结·角色名」）。
2. components/chat/sticker-search-suggest.tsx：表情搜索联想列表的 UI 微调（贴纸/表情尺寸加大）+ 注释说明，与 C 组 chat-room 的「表情联动搜索后清空搜索框」优化相配套。

本组 2 个文件均为干净贡献内容，无任何非贡献的个人改动。

---
_经小手机「共同建设」通道提交_