### PR TITLE
feat(reading) 阅读体验优化：PDF 渲染防闪烁/性能优化 + TXT 导入乱码编码优化

### DIFF
--- a/components/reading/reading-interaction-dialog.tsx
+++ b/components/reading/reading-interaction-dialog.tsx
@@ -19,6 +19,16 @@ const PARAGRAPH_MODE_OPTIONS: { value: ReadingParagraphMode; label: string; desc
     { value: "line", label: "每行一段", desc: "纯回车换行分段落（无空行无缩进）" },
 ];
 
+const TXT_ENCODING_OPTIONS: { value: NonNullable<ReadingInteractionConfig["txtEncoding"]>; label: string; desc: string }[] = [
+    { value: "auto", label: "自动", desc: "自动识别文件的编码（推荐）" },
+    { value: "utf-8", label: "UTF-8", desc: "现代标准编码，多数文件默认" },
+    { value: "gb18030", label: "GB18030", desc: "中文国标全集（含 GBK/GB2312）" },
+    { value: "gbk", label: "GBK", desc: "简体中文常用编码" },
+    { value: "big5", label: "Big5", desc: "繁体中文常用编码" },
+    { value: "utf-16le", label: "UTF-16LE", desc: "Windows 记事本可存此编码" },
+    { value: "utf-16be", label: "UTF-16BE", desc: "大端 UTF-16" },
+];
+
 const VIEW_MODE_OPTIONS: { value: ReadingViewMode; label: string; desc: string }[] = [
     { value: "page", label: "翻页", desc: "一屏一页，左右点击/滑动翻页" },
     { value: "scroll", label: "滚动", desc: "连续滚动阅读，上下滑动翻读" },
@@ -26,18 +36,6 @@ const VIEW_MODE_OPTIONS: { value: ReadingViewMode; label: string; desc: string }
 
 const RETRY_MIN = 0;
 const RETRY_MAX = 5;
-
-/** 批注预生成触发时机：读到上一批批注的比例 */
-const PREFETCH_THRESHOLD_OPTIONS: { value: number; label: string; desc: string }[] = [
-    { value: 1 / 2, label: "读到一半", desc: "预留生成时间更充足" },
-    { value: 2 / 3, label: "读到 2/3", desc: "默认推荐" },
-    { value: 3 / 4, label: "读到 3/4", desc: "接近读完才生成" },
-];
-
-/** 浮点档位比较容差 */
-function prefetchThresholdMatches(a: number, b: number): boolean {
-    return Math.abs(a - b) < 0.01;
-}
 
 type Props = {
     onClose: () => void;
@@ -90,6 +88,29 @@ export function ReadingInteractionDialog({ onClose }: Props) {
                                 type="button"
                                 className={`reading-option-card ${config.paragraphMode === opt.value ? "is-active" : ""}`}
                                 onClick={() => setConfig((prev) => ({ ...prev, paragraphMode: opt.value }))}
+                            >
+                                <span className="reading-option-card-label">{opt.label}</span>
+                                <span className="reading-option-card-desc">{opt.desc}</span>
+                            </button>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="reading-settings-group">
+                    <div className="reading-settings-heading">
+                        <Settings size={15} />
+                        <span>导入 TXT 编码</span>
+                    </div>
+                    <p className="reading-settings-inline-note">
+                        <span>导入 TXT 小说时按哪种编码解析。自动识别一般够用；个别 TXT 自动识别出错导致乱码时，可手动指定其真实编码后重新导入。</span>
+                    </p>
+                    <div className="reading-option-grid">
+                        {TXT_ENCODING_OPTIONS.map((opt) => (
+                            <button
+                                key={opt.value}
+                                type="button"
+                                className={`reading-option-card ${config.txtEncoding === opt.value ? "is-active" : ""}`}
+                                onClick={() => setConfig((prev) => ({ ...prev, txtEncoding: opt.value }))}
                             >
                                 <span className="reading-option-card-label">{opt.label}</span>
                                 <span className="reading-option-card-desc">{opt.desc}</span>
@@ -162,35 +183,44 @@ export function ReadingInteractionDialog({ onClose }: Props) {
                     </div>
                     <div className="reading-settings-toggle-row">
                         <span className="reading-settings-toggle-label">
-                            提前生成下一批批注
+                            TXT 预批注
                         </span>
                         <Toggle
                             checked={config.autoAnnotatePrefetch === true}
                             onChange={(next) => setConfig((prev) => ({ ...prev, autoAnnotatePrefetch: next }))}
                         />
                     </div>
-                    {config.autoAnnotatePrefetch && (
+                    <div className="reading-settings-toggle-row">
+                        <span className="reading-settings-toggle-label">
+                            PDF 预批注
+                        </span>
+                        <Toggle
+                            checked={config.autoAnnotatePrefetchPdf === true}
+                            onChange={(next) => setConfig((prev) => ({ ...prev, autoAnnotatePrefetchPdf: next }))}
+                        />
+                    </div>
+                    {(config.autoAnnotatePrefetch || config.autoAnnotatePrefetchPdf) && (
                         <>
-                            <p className="reading-settings-inline-note">
-                                <span>读到上一批批注的多少时开始生成下一批：</span>
-                            </p>
-                            <div className="reading-option-grid reading-option-grid--three">
-                                {PREFETCH_THRESHOLD_OPTIONS.map((opt) => (
-                                    <button
-                                        key={opt.value}
-                                        type="button"
-                                        className={`reading-option-card ${prefetchThresholdMatches(config.annotationPrefetchThreshold ?? 2 / 3, opt.value) ? "is-active" : ""}`}
-                                        onClick={() => setConfig((prev) => ({ ...prev, annotationPrefetchThreshold: opt.value }))}
-                                    >
-                                        <span className="reading-option-card-label">{opt.label}</span>
-                                        <span className="reading-option-card-desc">{opt.desc}</span>
-                                    </button>
-                                ))}
+                            <div className="reading-settings-inline-note">
+                                <span>读到当前批的多少时预生成下一批</span>
+                                <span>{Math.round((config.annotationPrefetchThreshold ?? 2 / 3) * 100)}%</span>
                             </div>
+                            <input
+                                type="range"
+                                className="w-full my-1"
+                                min={0.05}
+                                max={0.95}
+                                step={0.05}
+                                value={config.annotationPrefetchThreshold ?? 2 / 3}
+                                onChange={(e) => setConfig((prev) => ({ ...prev, annotationPrefetchThreshold: Number(e.target.value) }))}
+                            />
+                            <p className="reading-settings-inline-note">
+                                <span>百分比越低，越早开始预生成下一批——设得很低（如 5%）时，刚开始读当前批，下一批批注就已经在生成/已生成，阅读不等待。默认 2/3。</span>
+                            </p>
                         </>
                     )}
                     <p className="reading-settings-inline-note">
-                        <span>利用读上一批批注的时间生成下一批，避免你读到时批注还没生成完。不会重复批注。</span>
+                        <span>TXT 预批注按段落分批，PDF 预批注按页分批，批次大小与自动批注一致（可在批注对话框里调整）。利用读上一批批注的时间生成下一批，不会重复批注。</span>
                     </p>
                 </section>
 
@@ -226,6 +256,52 @@ export function ReadingInteractionDialog({ onClose }: Props) {
                         <RotateCcw size={15} strokeWidth={2} />
                         重置悬浮球位置
                     </button>
+                </section>
+
+                <section className="reading-settings-group">
+                    <div className="reading-settings-heading">
+                        <Settings size={15} />
+                        <span>PDF 渲染</span>
+                    </div>
+                    <div className="reading-settings-toggle-row">
+                        <span className="reading-settings-toggle-label">预加载后续页</span>
+                        <Toggle
+                            checked={config.pdfPreloadEnabled !== false}
+                            onChange={(next) => setConfig((prev) => ({ ...prev, pdfPreloadEnabled: next }))}
+                        />
+                    </div>
+                    <p className="reading-settings-inline-note">
+                        <span>开启后阅读 PDF 时会提前渲染当前页之后的页面，滚动更平滑；关闭则只渲染屏幕内的页。</span>
+                    </p>
+                    <div className="reading-settings-inline-note">
+                        <span>页面缩放率</span>
+                        <span>{Math.round((config.pdfZoom ?? 1) * 100)}%</span>
+                    </div>
+                    <input
+                        type="range"
+                        className="w-full my-1"
+                        min={0.5}
+                        max={2}
+                        step={0.05}
+                        value={config.pdfZoom ?? 1}
+                        onChange={(e) => setConfig((prev) => ({ ...prev, pdfZoom: Number(e.target.value) }))}
+                    />
+                    <div className="reading-settings-inline-note">
+                        <span>一次渲染页数（当前页前后各几页）</span>
+                        <span>{config.pdfPreloadRadius ?? 3} 页</span>
+                    </div>
+                    <input
+                        type="range"
+                        className="w-full my-1"
+                        min={1}
+                        max={8}
+                        step={1}
+                        value={config.pdfPreloadRadius ?? 3}
+                        onChange={(e) => setConfig((prev) => ({ ...prev, pdfPreloadRadius: Number(e.target.value) }))}
+                    />
+                    <p className="reading-settings-inline-note">
+                        <span>提示：一次渲染页数过少时，滑动到未渲染的页会反复渲染，造成闪烁卡顿；调大并开启预加载可缓解。缩放率调大后一页更接近一屏。</span>
+                    </p>
                 </section>
             </div>
         </ContentDialog>

--- a/components/reading/reading-pdf-viewer.tsx
+++ b/components/reading/reading-pdf-viewer.tsx
@@ -16,6 +16,7 @@ type Props = {
     onTotalPages?: (n: number) => void;
     onCurrentPage?: (page: number) => void;
     jumpToPage?: number;
+    onJumpComplete?: () => void;
     onCopyAnnotation?: (text: string) => void;
     onDeleteAnnotation?: (annotationId: string) => void;
     /** 页面缩放率：1=按容器宽度原样，>1 放大（如 1.5 一页近似一屏） */
@@ -62,6 +63,7 @@ export function PdfPageRenderer({
     onTotalPages,
     onCurrentPage,
     jumpToPage,
+    onJumpComplete,
     onCopyAnnotation,
     onDeleteAnnotation,
     zoom = 1,
@@ -108,7 +110,7 @@ export function PdfPageRenderer({
         return { cssWidth, effectiveWidth, scrollParent, renderDpr };
     };
 
-    /** 渲染完成版本号：渲染 effect 每完成一轮全量渲染 +1，驱动批注钉同步 effect 重放 */
+    /** 渲染完成版本号：渲染 effect 每完成一轮全量渲染 +1，驱动待处理的跳页定位 */
     const [renderDone, setRenderDone] = useState(0);
 
     /**
@@ -233,6 +235,13 @@ export function PdfPageRenderer({
         }
         return elements;
     }, [annotations, bilingualTranslationEnabled, chapter, collapseBilingualTranslation, onCopyAnnotation, onDeleteAnnotation]);
+
+    // 懒加载页可能在批注同步 effect 之后才完成渲染；始终从 ref 读取最新的批注工厂，
+    // 避免 canvas 替换占位内容时把已经生成的批注钉永久丢掉。
+    const annotationPinFactoryRef = useRef(createAnnotationPin);
+    useEffect(() => {
+        annotationPinFactoryRef.current = createAnnotationPin;
+    }, [createAnnotationPin]);
 
     // Load PDF document once per book.
     useEffect(() => {
@@ -380,7 +389,7 @@ export function PdfPageRenderer({
 
                         renderedPagesRef.current.add(pageNum);
                         pageWrapper.style.height = `${cssHeight}px`;
-                        pageWrapper.replaceChildren(canvas);
+                        pageWrapper.replaceChildren(canvas, ...annotationPinFactoryRef.current(pageNum));
                         } finally {
                             activeRendersRef.current -= 1;
                         }
@@ -407,7 +416,7 @@ export function PdfPageRenderer({
                     const reused = reusableCanvases.get(i);
                     if (reused && Math.abs(parseFloat(reused.style.width || "0") - effectiveWidth) < 1) {
                         pageWrapper.style.height = reused.style.height || `${defaultCssHeight}px`;
-                        pageWrapper.replaceChildren(reused);
+                        pageWrapper.replaceChildren(reused, ...annotationPinFactoryRef.current(i));
                         renderedPagesRef.current.add(i);
                     } else {
                         const placeholder = document.createElement("div");
@@ -484,9 +493,12 @@ export function PdfPageRenderer({
                 preloadNeighborhood(initialPage);
                 // 恢复进度：渲染完目标页后把滚动容器滚到目标页，确保打开即停在上次读的页（而非开头）
                 if (jumpToPage) {
-                    const targetEl = pageWrappers.get(jumpToPage);
+                    const targetEl = pageWrappers.get(initialPage);
                     const sc = canvasContainerRef.current?.closest("[data-ui='body']") as HTMLElement | null;
-                    if (targetEl) scrollElementWithinContainer(sc || wrapperRef.current, targetEl, { block: "start" });
+                    if (targetEl) {
+                        scrollElementWithinContainer(sc || wrapperRef.current, targetEl, { block: "start" });
+                        onJumpComplete?.();
+                    }
                 }
                 scheduleCurrentPageReport();
 
@@ -526,7 +538,7 @@ export function PdfPageRenderer({
             cleanupRef.current = null;
         };
     // 渲染 effect 只依赖文档与渲染参数；chapter（文本层数据）/annotations（批注）变化不再触发整本重建。
-    }, [docVersion, onCurrentPage, preloadEnabled, preloadRadius, scale, zoom]);
+    }, [docVersion, onCurrentPage, onJumpComplete, preloadEnabled, preloadRadius, scale, zoom]);
 
     // 批注钉同步：文本层更新（chapter 变化）/批注增删/双语开关变化时，只重放批注钉，不重建页面。
     // 与渲染 effect 解耦——渲染 effect 不再依赖 chapter/annotations，开自动批注/生成批注也不闪烁。
@@ -535,12 +547,12 @@ export function PdfPageRenderer({
         if (!container) return;
         for (const child of Array.from(container.children)) {
             const pageNum = Number((child as HTMLElement).dataset.page);
-            if (!pageNum) continue;
+            if (!pageNum || !child.querySelector("canvas[data-page]")) continue;
             child.querySelectorAll(".reading-ann-pin").forEach((pin) => pin.remove());
             const pins = createAnnotationPin(pageNum);
             if (pins.length) child.append(...pins);
         }
-    }, [createAnnotationPin, renderDone]);
+    }, [createAnnotationPin]);
 
     useEffect(() => {
         if (!jumpToPage || !canvasContainerRef.current || !wrapperRef.current) return;
@@ -548,7 +560,8 @@ export function PdfPageRenderer({
         if (!target) return;
         const scrollParent = canvasContainerRef.current.closest("[data-ui='body']") as HTMLElement | null;
         scrollElementWithinContainer(scrollParent || wrapperRef.current, target, { block: "start", behavior: "smooth" });
-    }, [docVersion, jumpToPage, renderDone]);
+        onJumpComplete?.();
+    }, [docVersion, jumpToPage, onJumpComplete, renderDone]);
 
     // Pinch-to-zoom
     useEffect(() => {

--- a/components/reading/reading-pdf-viewer.tsx
+++ b/components/reading/reading-pdf-viewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { loadRawFileBlob } from "@/lib/reading-storage";
 import { splitBilingualText } from "@/lib/bilingual-text";
 import { scrollElementWithinContainer } from "@/lib/dom-scroll";
@@ -18,12 +18,19 @@ type Props = {
     jumpToPage?: number;
     onCopyAnnotation?: (text: string) => void;
     onDeleteAnnotation?: (annotationId: string) => void;
+    /** 页面缩放率：1=按容器宽度原样，>1 放大（如 1.5 一页近似一屏） */
+    zoom?: number;
+    /** 当前页前后各预渲染几页（懒加载粒度） */
+    preloadRadius?: number;
+    /** 是否预加载后续页（阅读时提前渲染视口之外的页，滚动更平滑） */
+    preloadEnabled?: boolean;
 };
 
 const PDFJS_VERSION = "3.11.174";
 const PDFJS_CDN = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${PDFJS_VERSION}`;
-const PRELOAD_RADIUS = 3;
 const PRELOAD_ROOT_MARGIN = "1800px 0px";
+/** 渲染并发上限：预加载页多时限制同时光栅化的页数，避免一次把主线程塞满导致卡顿 */
+const MAX_CONCURRENT_RENDERS = 2;
 let _pdfjsPromise: Promise<any> | null = null;
 
 function loadPdfjs(): Promise<any> {
@@ -57,15 +64,22 @@ export function PdfPageRenderer({
     jumpToPage,
     onCopyAnnotation,
     onDeleteAnnotation,
+    zoom = 1,
+    preloadRadius = 3,
+    preloadEnabled = true,
 }: Props) {
     const canvasContainerRef = useRef<HTMLDivElement>(null);
     const wrapperRef = useRef<HTMLDivElement>(null);
     const pdfDocRef = useRef<any | null>(null);
     const observerRef = useRef<IntersectionObserver | null>(null);
     const renderSeqRef = useRef(0);
+    /** 正在光栅化的页数（并发限流用） */
+    const activeRendersRef = useRef(0);
     const [error, setError] = useState<string | null>(null);
     const [loading, setLoading] = useState(true);
     const [docVersion, setDocVersion] = useState(0);
+    /** 上一次完成渲染的 pdf 文档对象：换书（docVersion 变化）时旧 canvas 一律不复用，防止串书 */
+    const renderedPdfRef = useRef<any | null>(null);
     const scaleRef = useRef(1);
     const [scale, setScale] = useState(1);
     const renderedPagesRef = useRef(new Set<number>());
@@ -85,9 +99,140 @@ export function PdfPageRenderer({
     const getRenderMetrics = () => {
         const scrollParent = canvasContainerRef.current?.closest("[data-ui='body']") as HTMLElement | null;
         const cssWidth = wrapperRef.current?.clientWidth || scrollParent?.clientWidth || 350;
-        const renderDpr = Math.max(window.devicePixelRatio || 1, 2);
-        return { cssWidth, scrollParent, renderDpr };
+        // 页面有效宽度 = 容器宽度 × 用户缩放率（zoom 可调，放大后一页接近一屏）
+        const effectiveWidth = Math.max(1, cssWidth * zoom);
+        // 渲染分辨率封顶 2 倍：@3x 设备上 3 倍 canvas 像素量是 2 倍的 2.25 倍，
+        // PDF.js 光栅化与 canvas 上传都明显变慢，是滚动卡顿的重要放大器；
+        // 手机上 2x 已足够清晰（4 倍像素），降到 2x 渲染速度大幅提升。
+        const renderDpr = Math.min(Math.max(window.devicePixelRatio || 1, 1), 2);
+        return { cssWidth, effectiveWidth, scrollParent, renderDpr };
     };
+
+    /** 渲染完成版本号：渲染 effect 每完成一轮全量渲染 +1，驱动批注钉同步 effect 重放 */
+    const [renderDone, setRenderDone] = useState(0);
+
+    /**
+     * 批注钉与页面渲染解耦：页面 canvas 渲染只依赖文档与渲染参数；
+     * 文本层解析（chapter 变化）或批注增删时，仅通过本函数局部重建批注钉，
+     * 不再触发整本页面重建（开自动批注/生成批注也不闪烁）。
+     */
+    const createAnnotationPin = useCallback((pageNum: number) => {
+        if (!chapter?.paragraphPages || !annotations?.length) return [] as HTMLDivElement[];
+        const elements: HTMLDivElement[] = [];
+        for (const ann of annotations) {
+            const pIdx = ann.paragraphIndex;
+            if (pIdx < 0 || pIdx >= (chapter.paragraphPages?.length || 0)) continue;
+            if (chapter.paragraphPages[pIdx] !== pageNum) continue;
+            const yRatio = chapter.paragraphYPositions?.[pIdx] ?? 0.5;
+
+            const annEl = document.createElement("div");
+            annEl.className = "reading-ann-pin";
+            annEl.style.top = `${yRatio * 100}%`;
+            annEl.dataset.expanded = "false";
+            annEl.dataset.noNav = "true";
+            const tagEl = document.createElement("span");
+            tagEl.className = "reading-ann-pin-tag";
+            tagEl.textContent = `💬 ${ann.characterName}`;
+
+            const bodyEl = document.createElement("div");
+            bodyEl.className = "reading-ann-pin-body";
+
+            const nameEl = document.createElement("span");
+            nameEl.className = "reading-annotation-name";
+            nameEl.textContent = ann.characterName;
+
+            const textEl = document.createElement("div");
+            textEl.className = "reading-annotation-text";
+
+            const bilingual = bilingualTranslationEnabled ? splitBilingualText(ann.content) : null;
+            if (!bilingual) {
+                textEl.textContent = ann.content;
+            } else {
+                const originalEl = document.createElement("div");
+                originalEl.textContent = bilingual.original;
+
+                const toggleBtn = document.createElement("button");
+                toggleBtn.type = "button";
+                toggleBtn.className = "chat-bilingual-toggle reading-annotation-bilingual-toggle";
+                toggleBtn.textContent = collapseBilingualTranslation ? "中文" : "收起中文";
+
+                const translationEl = document.createElement("div");
+                translationEl.className = "reading-annotation-translation";
+                translationEl.textContent = bilingual.translated;
+                translationEl.style.display = collapseBilingualTranslation ? "none" : "block";
+
+                toggleBtn.onclick = (e) => {
+                    e.stopPropagation();
+                    const expanded = translationEl.style.display !== "none";
+                    translationEl.style.display = expanded ? "none" : "block";
+                    toggleBtn.textContent = expanded ? "中文" : "收起中文";
+                };
+
+                textEl.append(originalEl, toggleBtn, translationEl);
+            }
+
+            const menuEl = document.createElement("div");
+            menuEl.className = "ctx-menu reading-annotation-menu";
+
+            const copyBtn = document.createElement("button");
+            copyBtn.className = "ctx-menu-btn";
+            copyBtn.textContent = "复制";
+            copyBtn.onclick = (e) => {
+                e.stopPropagation();
+                onCopyAnnotation?.(ann.content);
+                menuEl.dataset.open = "false";
+            };
+
+            const deleteBtn = document.createElement("button");
+            deleteBtn.className = "ctx-menu-btn ctx-menu-btn-danger";
+            deleteBtn.textContent = "删除";
+            deleteBtn.onclick = (e) => {
+                e.stopPropagation();
+                onDeleteAnnotation?.(ann.id);
+                menuEl.dataset.open = "false";
+            };
+
+            menuEl.dataset.open = "false";
+            menuEl.append(copyBtn, deleteBtn);
+            bodyEl.append(nameEl, textEl, menuEl);
+            annEl.append(tagEl, bodyEl);
+
+            let longPressTimer: number | null = null;
+            let didLongPress = false;
+            const clearLongPress = () => {
+                if (longPressTimer !== null) {
+                    window.clearTimeout(longPressTimer);
+                    longPressTimer = null;
+                }
+            };
+            const openMenu = () => {
+                annEl.dataset.expanded = "true";
+                menuEl.dataset.open = "true";
+                didLongPress = true;
+            };
+            bodyEl.onpointerdown = (e) => {
+                e.stopPropagation();
+                clearLongPress();
+                longPressTimer = window.setTimeout(openMenu, 500);
+            };
+            bodyEl.onpointerup = clearLongPress;
+            bodyEl.onpointercancel = clearLongPress;
+            bodyEl.onpointerleave = clearLongPress;
+            annEl.onclick = (e) => {
+                e.stopPropagation();
+                clearLongPress();
+                if (didLongPress) {
+                    didLongPress = false;
+                    return;
+                }
+                const isExpanded = annEl.dataset.expanded === "true";
+                annEl.dataset.expanded = isExpanded ? "false" : "true";
+                if (isExpanded) menuEl.dataset.open = "false";
+            };
+            elements.push(annEl);
+        }
+        return elements;
+    }, [annotations, bilingualTranslationEnabled, chapter, collapseBilingualTranslation, onCopyAnnotation, onDeleteAnnotation]);
 
     // Load PDF document once per book.
     useEffect(() => {
@@ -143,142 +288,40 @@ export function PdfPageRenderer({
 
         (async () => {
             try {
+                // 记录重建前正在看的页：缩放率/预渲染设置变化导致重建后仍停留在该页，避免跳位
+                const prevReportedPage = reportedPageRef.current;
                 observerRef.current?.disconnect();
                 renderedPagesRef.current.clear();
                 renderingPagesRef.current.clear();
                 reportedPageRef.current = 0;
 
-                const { cssWidth, scrollParent, renderDpr } = getRenderMetrics();
+                const { effectiveWidth, scrollParent, renderDpr } = getRenderMetrics();
                 const pageRoot = scrollParent || wrapperRef.current;
                 const firstPage = await pdf.getPage(1);
                 const firstViewport = firstPage.getViewport({ scale: 1 });
-                const defaultCssHeight = cssWidth * (firstViewport.height / firstViewport.width);
+                const defaultCssHeight = effectiveWidth * (firstViewport.height / firstViewport.width);
                 firstPage.cleanup?.();
+
+                // 换书（pdf 对象变化）时旧 canvas 一律丢弃重渲；同书重建（缩放/预渲染设置变化）时尽量复用已渲染的 canvas，
+                // 避免整本闪回米黄色占位块。
+                const isNewPdf = renderedPdfRef.current !== pdf;
+                if (isNewPdf) renderedPdfRef.current = pdf;
+                const reusableCanvases = new Map<number, HTMLCanvasElement>();
+                if (!isNewPdf) {
+                    for (const child of Array.from(container.children)) {
+                        const n = Number((child as HTMLElement).dataset.page);
+                        const canvas = (child as HTMLElement).querySelector("canvas[data-page]") as HTMLCanvasElement | null;
+                        if (n && canvas) reusableCanvases.set(n, canvas);
+                    }
+                }
 
                 const fragment = document.createDocumentFragment();
                 const pageWrappers = new Map<number, HTMLDivElement>();
 
-                const createAnnotationPin = (pageNum: number) => {
-                    if (!chapter?.paragraphPages || !annotations?.length) return [] as HTMLDivElement[];
-                    const elements: HTMLDivElement[] = [];
-                    for (const ann of annotations) {
-                        const pIdx = ann.paragraphIndex;
-                        if (pIdx < 0 || pIdx >= (chapter.paragraphPages?.length || 0)) continue;
-                        if (chapter.paragraphPages[pIdx] !== pageNum) continue;
-                        const yRatio = chapter.paragraphYPositions?.[pIdx] ?? 0.5;
-
-                        const annEl = document.createElement("div");
-                        annEl.className = "reading-ann-pin";
-                        annEl.style.top = `${yRatio * 100}%`;
-                        annEl.dataset.expanded = "false";
-                        annEl.dataset.noNav = "true";
-                        const tagEl = document.createElement("span");
-                        tagEl.className = "reading-ann-pin-tag";
-                        tagEl.textContent = `💬 ${ann.characterName}`;
-
-                        const bodyEl = document.createElement("div");
-                        bodyEl.className = "reading-ann-pin-body";
-
-                        const nameEl = document.createElement("span");
-                        nameEl.className = "reading-annotation-name";
-                        nameEl.textContent = ann.characterName;
-
-                        const textEl = document.createElement("div");
-                        textEl.className = "reading-annotation-text";
-
-                        const bilingual = bilingualTranslationEnabled ? splitBilingualText(ann.content) : null;
-                        if (!bilingual) {
-                            textEl.textContent = ann.content;
-                        } else {
-                            const originalEl = document.createElement("div");
-                            originalEl.textContent = bilingual.original;
-
-                            const toggleBtn = document.createElement("button");
-                            toggleBtn.type = "button";
-                            toggleBtn.className = "chat-bilingual-toggle reading-annotation-bilingual-toggle";
-                            toggleBtn.textContent = collapseBilingualTranslation ? "中文" : "收起中文";
-
-                            const translationEl = document.createElement("div");
-                            translationEl.className = "reading-annotation-translation";
-                            translationEl.textContent = bilingual.translated;
-                            translationEl.style.display = collapseBilingualTranslation ? "none" : "block";
-
-                            toggleBtn.onclick = (e) => {
-                                e.stopPropagation();
-                                const expanded = translationEl.style.display !== "none";
-                                translationEl.style.display = expanded ? "none" : "block";
-                                toggleBtn.textContent = expanded ? "中文" : "收起中文";
-                            };
-
-                            textEl.append(originalEl, toggleBtn, translationEl);
-                        }
-
-                        const menuEl = document.createElement("div");
-                        menuEl.className = "ctx-menu reading-annotation-menu";
-
-                        const copyBtn = document.createElement("button");
-                        copyBtn.className = "ctx-menu-btn";
-                        copyBtn.textContent = "复制";
-                        copyBtn.onclick = (e) => {
-                            e.stopPropagation();
-                            onCopyAnnotation?.(ann.content);
-                            menuEl.dataset.open = "false";
-                        };
-
-                        const deleteBtn = document.createElement("button");
-                        deleteBtn.className = "ctx-menu-btn ctx-menu-btn-danger";
-                        deleteBtn.textContent = "删除";
-                        deleteBtn.onclick = (e) => {
-                            e.stopPropagation();
-                            onDeleteAnnotation?.(ann.id);
-                            menuEl.dataset.open = "false";
-                        };
-
-                        menuEl.dataset.open = "false";
-                        menuEl.append(copyBtn, deleteBtn);
-                        bodyEl.append(nameEl, textEl, menuEl);
-                        annEl.append(tagEl, bodyEl);
-
-                        let longPressTimer: number | null = null;
-                        let didLongPress = false;
-                        const clearLongPress = () => {
-                            if (longPressTimer !== null) {
-                                window.clearTimeout(longPressTimer);
-                                longPressTimer = null;
-                            }
-                        };
-                        const openMenu = () => {
-                            annEl.dataset.expanded = "true";
-                            menuEl.dataset.open = "true";
-                            didLongPress = true;
-                        };
-                        bodyEl.onpointerdown = (e) => {
-                            e.stopPropagation();
-                            clearLongPress();
-                            longPressTimer = window.setTimeout(openMenu, 500);
-                        };
-                        bodyEl.onpointerup = clearLongPress;
-                        bodyEl.onpointercancel = clearLongPress;
-                        bodyEl.onpointerleave = clearLongPress;
-                        annEl.onclick = (e) => {
-                            e.stopPropagation();
-                            clearLongPress();
-                            if (didLongPress) {
-                                didLongPress = false;
-                                return;
-                            }
-                            const isExpanded = annEl.dataset.expanded === "true";
-                            annEl.dataset.expanded = isExpanded ? "false" : "true";
-                            if (isExpanded) menuEl.dataset.open = "false";
-                        };
-                        elements.push(annEl);
-                    }
-                    return elements;
-                };
-
+                const renderRadius = Math.max(0, Math.min(8, Math.round(preloadRadius) || 0));
                 const buildRenderOrder = (centerPage: number) => {
                     const ordered = [centerPage];
-                    for (let offset = 1; offset <= PRELOAD_RADIUS; offset += 1) {
+                    for (let offset = 1; offset <= renderRadius; offset += 1) {
                         ordered.push(centerPage + offset);
                         ordered.push(centerPage - offset);
                     }
@@ -286,6 +329,7 @@ export function PdfPageRenderer({
                 };
 
                 const preloadNeighborhood = (centerPage: number) => {
+                    if (!preloadEnabled) return; // 关闭预加载：只渲染进入视口的页
                     for (const pageNum of buildRenderOrder(centerPage)) {
                         void renderPage(pageNum);
                     }
@@ -303,10 +347,18 @@ export function PdfPageRenderer({
                     const pageWrapper = pageWrappers.get(pageNum);
                     if (!pageWrapper) return;
                     const renderTask = (async () => {
+                        // 并发限流：同时最多光栅化 MAX_CONCURRENT_RENDERS 页，
+                        // 预加载页多时不把主线程一次性塞满（轮询等待，16ms 一拍）
+                        while (activeRendersRef.current >= MAX_CONCURRENT_RENDERS) {
+                            if (cancelled || renderSeq !== renderSeqRef.current) return;
+                            await new Promise<void>((resolve) => setTimeout(resolve, 16));
+                        }
+                        activeRendersRef.current += 1;
+                        try {
                         const page = await pdf.getPage(pageNum);
                         const viewport = page.getViewport({ scale: 1 });
-                        const cssHeight = cssWidth * (viewport.height / viewport.width);
-                        const bufferWidth = Math.round(cssWidth * renderDpr * scale);
+                        const cssHeight = effectiveWidth * (viewport.height / viewport.width);
+                        const bufferWidth = Math.round(effectiveWidth * renderDpr * scale);
                         const bufferHeight = Math.round(cssHeight * renderDpr * scale);
                         const renderScale = bufferWidth / viewport.width;
                         const scaledViewport = page.getViewport({ scale: renderScale });
@@ -314,7 +366,7 @@ export function PdfPageRenderer({
                         const canvas = document.createElement("canvas");
                         canvas.width = bufferWidth;
                         canvas.height = bufferHeight;
-                        canvas.style.width = `${cssWidth}px`;
+                        canvas.style.width = `${effectiveWidth}px`;
                         canvas.style.height = `${cssHeight}px`;
                         canvas.style.display = "block";
                         canvas.dataset.page = String(pageNum);
@@ -328,7 +380,10 @@ export function PdfPageRenderer({
 
                         renderedPagesRef.current.add(pageNum);
                         pageWrapper.style.height = `${cssHeight}px`;
-                        pageWrapper.replaceChildren(canvas, ...createAnnotationPin(pageNum));
+                        pageWrapper.replaceChildren(canvas);
+                        } finally {
+                            activeRendersRef.current -= 1;
+                        }
                     })();
 
                     renderingPagesRef.current.set(pageNum, renderTask);
@@ -342,17 +397,26 @@ export function PdfPageRenderer({
                 for (let i = 1; i <= pdf.numPages; i++) {
                     const pageWrapper = document.createElement("div");
                     pageWrapper.style.position = "relative";
-                    pageWrapper.style.width = `${cssWidth}px`;
+                    pageWrapper.style.width = `${effectiveWidth}px`;
                     pageWrapper.style.height = `${defaultCssHeight}px`;
                     pageWrapper.dataset.page = String(i);
-                    pageWrapper.dataset.noNav = "true";
+                    // 注意：页面容器不能标 data-no-nav，否则点击页面唤不出沉浸菜单
+                    // （底部翻页/批注/设置按钮）。批注钉与「点击恢复原始大小」自身仍保留 noNav。
 
-                    const placeholder = document.createElement("div");
-                    placeholder.style.width = "100%";
-                    placeholder.style.height = "100%";
-                    placeholder.style.borderRadius = "12px";
-                    placeholder.style.background = "rgba(255, 252, 237, 0.5)";
-                    pageWrapper.appendChild(placeholder);
+                    // 同书重建且缩放率未变：复用已渲染的 canvas，不闪回米黄占位
+                    const reused = reusableCanvases.get(i);
+                    if (reused && Math.abs(parseFloat(reused.style.width || "0") - effectiveWidth) < 1) {
+                        pageWrapper.style.height = reused.style.height || `${defaultCssHeight}px`;
+                        pageWrapper.replaceChildren(reused);
+                        renderedPagesRef.current.add(i);
+                    } else {
+                        const placeholder = document.createElement("div");
+                        placeholder.style.width = "100%";
+                        placeholder.style.height = "100%";
+                        placeholder.style.borderRadius = "12px";
+                        placeholder.style.background = "rgba(255, 252, 237, 0.5)";
+                        pageWrapper.appendChild(placeholder);
+                    }
 
                     pageWrappers.set(i, pageWrapper);
                     fragment.appendChild(pageWrapper);
@@ -414,9 +478,16 @@ export function PdfPageRenderer({
                     observerRef.current.observe(child);
                 }
 
-                const initialPage = Math.min(Math.max(jumpToPage || 1, 1), pdf.numPages);
+                // 优先跳转目标页；没有跳转目标时停留在重建前正在读的页（缩放/预渲染设置调整后不跳位）
+                const initialPage = Math.min(Math.max(jumpToPage || prevReportedPage || 1, 1), pdf.numPages);
                 await renderPage(initialPage);
                 preloadNeighborhood(initialPage);
+                // 恢复进度：渲染完目标页后把滚动容器滚到目标页，确保打开即停在上次读的页（而非开头）
+                if (jumpToPage) {
+                    const targetEl = pageWrappers.get(jumpToPage);
+                    const sc = canvasContainerRef.current?.closest("[data-ui='body']") as HTMLElement | null;
+                    if (targetEl) scrollElementWithinContainer(sc || wrapperRef.current, targetEl, { block: "start" });
+                }
                 scheduleCurrentPageReport();
 
                 pageRoot?.addEventListener("scroll", scheduleCurrentPageReport, { passive: true });
@@ -425,6 +496,8 @@ export function PdfPageRenderer({
 
                 if (!cancelled && renderSeq === renderSeqRef.current) {
                     setLoading(false);
+                    // 通知批注钉同步 effect：整页渲染完成，可以重放批注钉
+                    setRenderDone((v) => v + 1);
                 }
 
                 return () => {
@@ -452,7 +525,22 @@ export function PdfPageRenderer({
             cleanupRef.current?.();
             cleanupRef.current = null;
         };
-    }, [bilingualTranslationEnabled, chapter, collapseBilingualTranslation, docVersion, onCurrentPage, annotations, scale]);
+    // 渲染 effect 只依赖文档与渲染参数；chapter（文本层数据）/annotations（批注）变化不再触发整本重建。
+    }, [docVersion, onCurrentPage, preloadEnabled, preloadRadius, scale, zoom]);
+
+    // 批注钉同步：文本层更新（chapter 变化）/批注增删/双语开关变化时，只重放批注钉，不重建页面。
+    // 与渲染 effect 解耦——渲染 effect 不再依赖 chapter/annotations，开自动批注/生成批注也不闪烁。
+    useEffect(() => {
+        const container = canvasContainerRef.current;
+        if (!container) return;
+        for (const child of Array.from(container.children)) {
+            const pageNum = Number((child as HTMLElement).dataset.page);
+            if (!pageNum) continue;
+            child.querySelectorAll(".reading-ann-pin").forEach((pin) => pin.remove());
+            const pins = createAnnotationPin(pageNum);
+            if (pins.length) child.append(...pins);
+        }
+    }, [createAnnotationPin, renderDone]);
 
     useEffect(() => {
         if (!jumpToPage || !canvasContainerRef.current || !wrapperRef.current) return;
@@ -460,7 +548,7 @@ export function PdfPageRenderer({
         if (!target) return;
         const scrollParent = canvasContainerRef.current.closest("[data-ui='body']") as HTMLElement | null;
         scrollElementWithinContainer(scrollParent || wrapperRef.current, target, { block: "start", behavior: "smooth" });
-    }, [docVersion, jumpToPage]);
+    }, [docVersion, jumpToPage, renderDone]);
 
     // Pinch-to-zoom
     useEffect(() => {

--- a/components/reading/reading-shelf.tsx
+++ b/components/reading/reading-shelf.tsx
@@ -201,8 +201,9 @@ export function ReadingShelf({ onOpenBook, onClose, appearance, backgroundUrl, o
                     format: "txt",
                     updatedAt: new Date().toISOString(),
                 });
-                const { text } = decodeTxtArrayBuffer(await file.arrayBuffer());
-                parsed = parseTxtContent(text, file.name, loadReadingInteractionConfig().paragraphMode);
+                const readingConfig = loadReadingInteractionConfig();
+                const { text } = decodeTxtArrayBuffer(await file.arrayBuffer(), readingConfig.txtEncoding);
+                parsed = parseTxtContent(text, file.name, readingConfig.paragraphMode);
                 format = "txt";
             } else if (ext === "epub") {
                 importStage = "读取 EPUB 文件";

--- a/components/reading/reading-viewer.tsx
+++ b/components/reading/reading-viewer.tsx
@@ -59,6 +59,7 @@ const DISCUSS_TARGET_CHARS = 1000;
 const DISCUSS_MIN_CHARS = 700;
 const DISCUSS_MAX_CHARS = 1600;
 const DISCUSS_MAX_PARAGRAPHS = 16;
+const MAX_MANUAL_PDF_PREFETCH_PAGES = 30;
 
 /** 聊天悬浮球/悬浮条/悬浮窗的位置记忆键 */
 const CHAT_FLOAT_POS_KEY = "reading-chat-float-pos-v1";
@@ -279,6 +280,11 @@ export function ReadingViewer({ book, onBack }: Props) {
     const [annotationBatchInput, setAnnotationBatchInput] = useState(String(isPdf ? 5 : 50));
     const [annotationDialogMode, setAnnotationDialogMode] = useState<AnnotationDialogMode | null>(null);
     const [showReadingSettings, setShowReadingSettings] = useState(false);
+    const [pdfRenderDraft, setPdfRenderDraft] = useState(() => ({
+        pdfZoom: readingConfig.pdfZoom ?? 1,
+        pdfPreloadRadius: readingConfig.pdfPreloadRadius ?? 3,
+        pdfPreloadEnabled: readingConfig.pdfPreloadEnabled !== false,
+    }));
     const [showNavigationDialog, setShowNavigationDialog] = useState(false);
     const [pdfJumpPage, setPdfJumpPage] = useState<number | undefined>(undefined);
     /** PDF 手动预批注对话框：自定义起始页/结束页，确认后立即预解析并预生成该范围批注 */
@@ -929,6 +935,7 @@ export function ReadingViewer({ book, onBack }: Props) {
         const start = Math.max(1, pdfCurrentPage || 1);
         const batch = Math.max(1, annotationBatchSize || 5);
         const end = Math.min(pdfTotalPages || (start + batch - 1), start + batch - 1);
+        setAnnotationError(null);
         setPdfPrefetchStartInput(String(start));
         setPdfPrefetchEndInput(String(end));
         setPdfPrefetchDialogOpen(true);
@@ -936,11 +943,19 @@ export function ReadingViewer({ book, onBack }: Props) {
 
     /** 手动预批注：按用户自定义的页码范围，预解析文本层并立即生成批注 */
     const handlePdfManualPrefetch = async () => {
-        setPdfPrefetchDialogOpen(false);
-        if (!companionId) return;
+        if (!companionId) {
+            setAnnotationError("请先选择共读角色");
+            return;
+        }
         const total = Math.max(1, pdfTotalPages || 1);
         const start = Math.max(1, Math.min(total, Math.round(Number(pdfPrefetchStartInput) || 1)));
         const end = Math.max(start, Math.min(total, Math.round(Number(pdfPrefetchEndInput) || start)));
+        if (end - start + 1 > MAX_MANUAL_PDF_PREFETCH_PAGES) {
+            setAnnotationError(`一次最多预批注 ${MAX_MANUAL_PDF_PREFETCH_PAGES} 页，请缩小页码范围`);
+            return;
+        }
+        setAnnotationError(null);
+        setPdfPrefetchDialogOpen(false);
         try {
             // 预解析指定范围的文本层（渲染已解耦，不会重建页面）
             const merged = await ensurePdfPageRangeParsed(start, end);
@@ -1088,6 +1103,10 @@ export function ReadingViewer({ book, onBack }: Props) {
         setActiveAnnotationId(null);
     }, []);
 
+    const handlePdfJumpComplete = useCallback(() => {
+        setPdfJumpPage(undefined);
+    }, []);
+
     const handleNavChapterClick = (index: number) => {
         if (isPdf) {
             const chapter = chapters[index];
@@ -1179,7 +1198,7 @@ export function ReadingViewer({ book, onBack }: Props) {
             if (pdfTotalPages <= 0) return;
             const batchStartPage = Math.floor((pdfCurrentPage - 1) / size) * size + 1;
             const offsetInBatch = pdfCurrentPage - batchStartPage; // 0-based
-            if (offsetInBatch < Math.ceil(size * threshold)) return; // 本批还没读到阈值
+            if ((offsetInBatch + 1) / size < threshold) return; // 本批还没读到阈值
             if (prefetchedBatchStartRef.current === batchStartPage) return;
             prefetchedBatchStartRef.current = batchStartPage;
 
@@ -1234,7 +1253,7 @@ export function ReadingViewer({ book, onBack }: Props) {
         if (currentAbs < 0) return;
 
         const batchStart = Math.floor(currentAbs / size) * size;
-        if (currentAbs - batchStart < Math.ceil(size * threshold)) return; // 本批还没读到用户设置的阈值
+        if ((currentAbs - batchStart + 1) / size < threshold) return; // 本批还没读到用户设置的阈值
         if (prefetchedBatchStartRef.current === batchStart) return;       // 本批已触发过预生成
         prefetchedBatchStartRef.current = batchStart;
 
@@ -1858,7 +1877,7 @@ export function ReadingViewer({ book, onBack }: Props) {
     }, [chapterIndex, isPdf, isScrollMode, txtPagesChapterIndex, txtTotalPages]);
 
     useEffect(() => {
-        if (chapters.length === 0) return;
+        if (!chaptersLoaded || chapters.length === 0) return;
 
         let scrollPosition: number;
         let progressFraction: number;
@@ -1901,7 +1920,7 @@ export function ReadingViewer({ book, onBack }: Props) {
             lastReadAt: new Date().toISOString(),
         };
         saveProgress(progress);
-    }, [book.id, chapterIndex, chapters.length, companionId, isPdf, isScrollMode, pdfCurrentPage, pdfTotalPages, scrollFraction, txtPage, txtTotalPages]);
+    }, [book.id, chapterIndex, chapters.length, chaptersLoaded, companionId, isPdf, isScrollMode, pdfCurrentPage, pdfTotalPages, scrollFraction, txtPage, txtTotalPages]);
 
     useEffect(() => {
         setTxtPage((prev) => Math.min(prev, Math.max(0, txtTotalPages - 1)));
@@ -2042,13 +2061,25 @@ export function ReadingViewer({ book, onBack }: Props) {
         ? chatMessages.find((msg) => msg.id === readingMessageMenu.messageId) || null
         : null;
 
-    /** 更新 PDF 渲染配置（缩放率/预渲染页数/预加载开关），改动即时生效并持久化 */
-    const updatePdfRenderConfig = (patch: { pdfZoom?: number; pdfPreloadRadius?: number; pdfPreloadEnabled?: boolean }) => {
-        setReadingConfig((prev) => {
-            const next = { ...prev, ...patch };
-            saveReadingInteractionConfig(next);
-            return next;
+    /** PDF 渲染设置先在弹窗内暂存，确认时只重建一次，避免拖动滑块期间连续重渲染整本 PDF。 */
+    const openReadingSettings = () => {
+        setPdfRenderDraft({
+            pdfZoom: readingConfig.pdfZoom ?? 1,
+            pdfPreloadRadius: readingConfig.pdfPreloadRadius ?? 3,
+            pdfPreloadEnabled: readingConfig.pdfPreloadEnabled !== false,
         });
+        setShowReadingSettings(true);
+    };
+
+    const handleReadingSettingsConfirm = () => {
+        if (isPdf) {
+            setReadingConfig((prev) => {
+                const next = { ...prev, ...pdfRenderDraft };
+                saveReadingInteractionConfig(next);
+                return next;
+            });
+        }
+        setShowReadingSettings(false);
     };
 
     return (
@@ -2148,8 +2179,9 @@ export function ReadingViewer({ book, onBack }: Props) {
                             onTotalPages={setPdfTotalPages}
                             onCurrentPage={setPdfCurrentPage}
                             jumpToPage={pdfJumpPage}
+                            onJumpComplete={handlePdfJumpComplete}
                             onCopyAnnotation={copyToClipboard}
-                            onDeleteAnnotation={(annotationId) => { void handleDeleteReadingAnnotation(annotationId); }}
+                            onDeleteAnnotation={handleDeleteReadingAnnotation}
                             zoom={readingConfig.pdfZoom ?? 1}
                             preloadRadius={readingConfig.pdfPreloadRadius ?? 3}
                             preloadEnabled={readingConfig.pdfPreloadEnabled !== false}
@@ -2308,7 +2340,7 @@ export function ReadingViewer({ book, onBack }: Props) {
                         <button
                             type="button"
                             className="reading-footer-icon-btn"
-                            onClick={() => setShowReadingSettings(true)}
+                            onClick={openReadingSettings}
                         >
                             <Languages size={22} strokeWidth={1.7} />
                             <span>设置</span>
@@ -2587,8 +2619,13 @@ export function ReadingViewer({ book, onBack }: Props) {
                             />
                         </div>
                         <p className="reading-settings-inline-note">
-                            <span>当前第 {Math.max(1, pdfCurrentPage)} / {Math.max(1, pdfTotalPages)} 页。页码范围越大，批注生成越久。</span>
+                            <span>当前第 {Math.max(1, pdfCurrentPage)} / {Math.max(1, pdfTotalPages)} 页。一次最多 {MAX_MANUAL_PDF_PREFETCH_PAGES} 页。</span>
                         </p>
+                        {annotationError && (
+                            <p className="reading-settings-inline-note" style={{ color: "var(--c-danger)" }}>
+                                <span>{annotationError}</span>
+                            </p>
+                        )}
                     </div>
                 </ContentDialog>
             )}
@@ -2597,7 +2634,7 @@ export function ReadingViewer({ book, onBack }: Props) {
                     title="阅读设置"
                     confirmLabel="完成"
                     cancelLabel="关闭"
-                    onConfirm={() => setShowReadingSettings(false)}
+                    onConfirm={handleReadingSettingsConfirm}
                     onCancel={() => setShowReadingSettings(false)}
                 >
                     <div className="reading-settings-grid">
@@ -2667,8 +2704,8 @@ export function ReadingViewer({ book, onBack }: Props) {
                                 <div className="reading-settings-toggle-row">
                                     <span className="reading-settings-toggle-label">预加载后续页</span>
                                     <Toggle
-                                        checked={readingConfig.pdfPreloadEnabled !== false}
-                                        onChange={(next) => updatePdfRenderConfig({ pdfPreloadEnabled: next })}
+                                        checked={pdfRenderDraft.pdfPreloadEnabled}
+                                        onChange={(next) => setPdfRenderDraft((prev) => ({ ...prev, pdfPreloadEnabled: next }))}
                                     />
                                 </div>
                                 <p className="reading-settings-inline-note">
@@ -2676,7 +2713,7 @@ export function ReadingViewer({ book, onBack }: Props) {
                                 </p>
                                 <div className="reading-settings-inline-note">
                                     <span>页面缩放率</span>
-                                    <span>{Math.round((readingConfig.pdfZoom ?? 1) * 100)}%</span>
+                                    <span>{Math.round(pdfRenderDraft.pdfZoom * 100)}%</span>
                                 </div>
                                 <input
                                     type="range"
@@ -2684,12 +2721,12 @@ export function ReadingViewer({ book, onBack }: Props) {
                                     min={0.5}
                                     max={2}
                                     step={0.05}
-                                    value={readingConfig.pdfZoom ?? 1}
-                                    onChange={(e) => updatePdfRenderConfig({ pdfZoom: Number(e.target.value) })}
+                                    value={pdfRenderDraft.pdfZoom}
+                                    onChange={(e) => setPdfRenderDraft((prev) => ({ ...prev, pdfZoom: Number(e.target.value) }))}
                                 />
                                 <div className="reading-settings-inline-note">
                                     <span>一次渲染页数（当前页前后各几页）</span>
-                                    <span>{readingConfig.pdfPreloadRadius ?? 3} 页</span>
+                                    <span>{pdfRenderDraft.pdfPreloadRadius} 页</span>
                                 </div>
                                 <input
                                     type="range"
@@ -2697,8 +2734,8 @@ export function ReadingViewer({ book, onBack }: Props) {
                                     min={1}
                                     max={8}
                                     step={1}
-                                    value={readingConfig.pdfPreloadRadius ?? 3}
-                                    onChange={(e) => updatePdfRenderConfig({ pdfPreloadRadius: Number(e.target.value) })}
+                                    value={pdfRenderDraft.pdfPreloadRadius}
+                                    onChange={(e) => setPdfRenderDraft((prev) => ({ ...prev, pdfPreloadRadius: Number(e.target.value) }))}
                                 />
                                 <p className="reading-settings-inline-note">
                                     <span>提示：一次渲染页数过少时，滑动到未渲染的页会反复渲染，造成闪烁卡顿；调大并开启预加载可缓解。缩放率调大后一页更接近一屏。</span>

--- a/components/reading/reading-viewer.tsx
+++ b/components/reading/reading-viewer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect } from "react";
-import { Bot, ChevronDown, ChevronRight, Languages, Menu, Minus, PenLine, SendHorizontal, X } from "lucide-react";
+import { Bot, ChevronDown, ChevronRight, Languages, Menu, Minus, PenLine, Rocket, SendHorizontal, X, ZoomIn } from "lucide-react";
 import {
     loadChapters,
     loadProgress,
@@ -281,6 +281,10 @@ export function ReadingViewer({ book, onBack }: Props) {
     const [showReadingSettings, setShowReadingSettings] = useState(false);
     const [showNavigationDialog, setShowNavigationDialog] = useState(false);
     const [pdfJumpPage, setPdfJumpPage] = useState<number | undefined>(undefined);
+    /** PDF 手动预批注对话框：自定义起始页/结束页，确认后立即预解析并预生成该范围批注 */
+    const [pdfPrefetchDialogOpen, setPdfPrefetchDialogOpen] = useState(false);
+    const [pdfPrefetchStartInput, setPdfPrefetchStartInput] = useState("");
+    const [pdfPrefetchEndInput, setPdfPrefetchEndInput] = useState("");
     const [chaptersLoaded, setChaptersLoaded] = useState(false);
     const touchStartRef = useRef({ x: 0, y: 0 });
     const [activeMessageId, setActiveMessageId] = useState<string | null>(null);
@@ -544,7 +548,7 @@ export function ReadingViewer({ book, onBack }: Props) {
                 if (rawFile && rawFile.size > 0) {
                     try {
                         const parsed = book.format === "txt"
-                            ? parseTxtContent(decodeTxtArrayBuffer(await rawFile.arrayBuffer()).text, book.title)
+                            ? parseTxtContent(decodeTxtArrayBuffer(await rawFile.arrayBuffer(), loadReadingInteractionConfig().txtEncoding).text, book.title)
                             : await parseEpubFile(await rawFile.arrayBuffer(), book.title);
                         const rebuiltChapters: BookChapter[] = parsed.chapters.map((chapter, index) => ({
                             id: `${book.id}_ch${index}`,
@@ -576,13 +580,18 @@ export function ReadingViewer({ book, onBack }: Props) {
                     : 0;
                 setChapterIndex(safeChapterIndex);
                 setCompanionId(progress.companionCharacterId || null);
-                if (!isPdf) {
-                    if (progress.readingMode === "scroll") {
-                        // 滚动模式：scrollPosition 存的是章节内滚动比例(0-1)
-                        initialScrollFractionRef.current = Math.max(0, Math.min(1, progress.scrollPosition || 0));
-                    } else {
-                        setTxtPage(Math.max(0, progress.scrollPosition || 0));
-                    }
+                if (isPdf) {
+                    // PDF 恢复：scrollPosition 存的是「当前页 - 1」。
+                    // 同时设置 pdfCurrentPage（避免跳转前保存逻辑把它覆盖回第 1 页）
+                    // 与 pdfJumpPage（让 PdfPageRenderer 渲染完成后滚到该页）。
+                    const restoredPage = Math.max(1, Math.round((progress.scrollPosition ?? 0) + 1));
+                    setPdfCurrentPage(restoredPage);
+                    setPdfJumpPage(restoredPage);
+                } else if (progress.readingMode === "scroll") {
+                    // 滚动模式：scrollPosition 存的是章节内滚动比例(0-1)
+                    initialScrollFractionRef.current = Math.max(0, Math.min(1, progress.scrollPosition || 0));
+                } else {
+                    setTxtPage(Math.max(0, progress.scrollPosition || 0));
                 }
             }
             // Default companion: first contact
@@ -915,6 +924,45 @@ export function ReadingViewer({ book, onBack }: Props) {
         await executeBatchAnnotation(request, { force: true });
     };
 
+    /** 打开手动预批注对话框：默认预生成「当前页起一个批次」的范围 */
+    const openPdfPrefetchDialog = () => {
+        const start = Math.max(1, pdfCurrentPage || 1);
+        const batch = Math.max(1, annotationBatchSize || 5);
+        const end = Math.min(pdfTotalPages || (start + batch - 1), start + batch - 1);
+        setPdfPrefetchStartInput(String(start));
+        setPdfPrefetchEndInput(String(end));
+        setPdfPrefetchDialogOpen(true);
+    };
+
+    /** 手动预批注：按用户自定义的页码范围，预解析文本层并立即生成批注 */
+    const handlePdfManualPrefetch = async () => {
+        setPdfPrefetchDialogOpen(false);
+        if (!companionId) return;
+        const total = Math.max(1, pdfTotalPages || 1);
+        const start = Math.max(1, Math.min(total, Math.round(Number(pdfPrefetchStartInput) || 1)));
+        const end = Math.max(start, Math.min(total, Math.round(Number(pdfPrefetchEndInput) || start)));
+        try {
+            // 预解析指定范围的文本层（渲染已解耦，不会重建页面）
+            const merged = await ensurePdfPageRangeParsed(start, end);
+            const refs = buildParagraphRefsFromChapters(merged);
+            const items = refs.filter((item) => (item.pageNum || 0) >= start && (item.pageNum || 0) <= end && item.text.trim());
+            if (items.length === 0) {
+                setAnnotationError("所选范围没有可批注的文本");
+                return;
+            }
+            const request: AnnotationBatchRequest = {
+                key: `pdf:${start}:${end}:manual`,
+                title: `第${start}-${end}页`,
+                size: end - start + 1,
+                items,
+            };
+            await executeBatchAnnotation(request, { force: true });
+        } catch (err) {
+            console.error("[Reading] PDF manual prefetch error:", err);
+            setAnnotationError(`预批注失败: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    };
+
     const openNavigationDialog = () => {
         setShowNavigationDialog(true);
     };
@@ -1115,15 +1163,59 @@ export function ReadingViewer({ book, onBack }: Props) {
 
     // 批注预生成：当前批注批读到用户设置的阈值时，提前生成下一批，
     // 把生成时间差放在用户读上一批批注的时间里，避免用户读到下一批时批注还没生成完。不会重复批注（批次按 key 去重）。
+    // TXT 按「段落」分批次（autoAnnotatePrefetch 控制）；PDF 按「页数」分批次（autoAnnotatePrefetchPdf 控制），
+    // 两者各自独立开关，批次大小统一跟随自动批注的 annotationBatchSize。
     const prefetchedBatchStartRef = useRef(-1);
     useEffect(() => {
         if (!autoAnnotate) { prefetchedBatchStartRef.current = -1; return; }
-        if (!readingConfig.autoAnnotatePrefetch || isPdf || !companionId || generating) return;
-        if (paragraphRefs.length === 0) return;
-        const size = Math.max(1, annotationBatchSize || 50);
+        if (!companionId || generating) return;
+        const size = Math.max(1, annotationBatchSize || (isPdf ? 5 : 50));
         const threshold = Math.max(0, Math.min(1, readingConfig.annotationPrefetchThreshold ?? 2 / 3));
 
-        // 当前阅读位置 → 全书记绝对段落索引
+        if (isPdf) {
+            // PDF 预批注开关：关闭时不预生成
+            if (!readingConfig.autoAnnotatePrefetchPdf) { prefetchedBatchStartRef.current = -1; return; }
+            // PDF：按页分批次。当前页所在批次读到阈值时，预解析并预生成下一批批注。
+            if (pdfTotalPages <= 0) return;
+            const batchStartPage = Math.floor((pdfCurrentPage - 1) / size) * size + 1;
+            const offsetInBatch = pdfCurrentPage - batchStartPage; // 0-based
+            if (offsetInBatch < Math.ceil(size * threshold)) return; // 本批还没读到阈值
+            if (prefetchedBatchStartRef.current === batchStartPage) return;
+            prefetchedBatchStartRef.current = batchStartPage;
+
+            const nextStartPage = batchStartPage + size;
+            if (nextStartPage > pdfTotalPages) return;
+            const nextEndPage = Math.min(nextStartPage + size - 1, pdfTotalPages);
+            void (async () => {
+                try {
+                    // 预解析下一批文本层（解析后 setChapters，但渲染已与文本层解耦，不会重建页面）
+                    const merged = await ensurePdfPageRangeParsed(nextStartPage, nextEndPage);
+                    const refs = buildParagraphRefsFromChapters(merged);
+                    const items = refs.filter((item) => (item.pageNum || 0) >= nextStartPage && (item.pageNum || 0) <= nextEndPage && item.text.trim());
+                    if (items.length === 0) { prefetchedBatchStartRef.current = -1; return; }
+                    const request: AnnotationBatchRequest = {
+                        key: `pdf:${nextStartPage}:${size}`,
+                        title: `第${nextStartPage}-${nextEndPage}页`,
+                        size,
+                        items,
+                    };
+                    // 若被跳过，重置标记让下一轮滚动再试，避免预生成丢失
+                    void executeBatchAnnotation(request).then((started) => {
+                        if (!started) prefetchedBatchStartRef.current = -1;
+                    });
+                } catch (err) {
+                    console.error("[Reading] PDF prefetch error:", err);
+                    prefetchedBatchStartRef.current = -1;
+                }
+            })();
+            return;
+        }
+
+        // TXT 预批注开关：关闭时不预生成
+        if (!readingConfig.autoAnnotatePrefetch) { prefetchedBatchStartRef.current = -1; return; }
+
+        // TXT：当前阅读位置 → 全书记绝对段落索引
+        if (paragraphRefs.length === 0) return;
         let currentAbs = -1;
         if (isScrollMode) {
             const chapterRefs = paragraphRefs.filter((item) => item.chapterIndex === chapterIndex && item.text.trim());
@@ -1161,16 +1253,19 @@ export function ReadingViewer({ book, onBack }: Props) {
         void executeBatchAnnotation(request).then((started) => {
             if (!started) prefetchedBatchStartRef.current = -1;
         });
-    }, [annotationBatchSize, autoAnnotate, chapterIndex, companionId, executeBatchAnnotation, generating, isPdf, isScrollMode, paragraphRefs, readingConfig.autoAnnotatePrefetch, readingConfig.annotationPrefetchThreshold, scrollFraction, txtPage, txtPages]);
+    }, [annotationBatchSize, autoAnnotate, chapterIndex, companionId, ensurePdfPageRangeParsed, executeBatchAnnotation, generating, isPdf, isScrollMode, paragraphRefs, pdfCurrentPage, pdfTotalPages, readingConfig.autoAnnotatePrefetch, readingConfig.autoAnnotatePrefetchPdf, readingConfig.annotationPrefetchThreshold, scrollFraction, txtPage, txtPages]);
 
     useEffect(() => {
-        if (!isPdf || pdfCurrentPage <= 0 || chapters.length === 0) return;
+        // 自动批注开启时，随滚动把当前 5 页的文本层预先解析好，让批注生成请求不用临时等待解析。
+        // 手动写批注 / 共读讨论内部会自行 ensurePdfPageRangeParsed，关闭自动批注时纯阅读不预解析。
+        // 渲染已与文本层解耦：此处 setChapters 只会触发批注钉局部更新，不会重建页面，无闪烁。
+        if (!isPdf || !autoAnnotate || pdfCurrentPage <= 0 || chapters.length === 0) return;
         const chunkStart = Math.floor((pdfCurrentPage - 1) / PDF_PAGES_PER_CHAPTER) * PDF_PAGES_PER_CHAPTER + 1;
         const chunkEnd = Math.min(chunkStart + PDF_PAGES_PER_CHAPTER - 1, pdfTotalPages || chunkStart + PDF_PAGES_PER_CHAPTER - 1);
         void ensurePdfPageRangeParsed(chunkStart, chunkEnd).catch((err) => {
             console.error("[Reading] PDF lazy parse error:", err);
         });
-    }, [chapters.length, ensurePdfPageRangeParsed, isPdf, pdfCurrentPage, pdfTotalPages]);
+    }, [autoAnnotate, chapters.length, ensurePdfPageRangeParsed, isPdf, pdfCurrentPage, pdfTotalPages]);
 
     // Chapter navigation
     const goToChapter = (idx: number, startFromEnd = false) => {
@@ -1947,6 +2042,15 @@ export function ReadingViewer({ book, onBack }: Props) {
         ? chatMessages.find((msg) => msg.id === readingMessageMenu.messageId) || null
         : null;
 
+    /** 更新 PDF 渲染配置（缩放率/预渲染页数/预加载开关），改动即时生效并持久化 */
+    const updatePdfRenderConfig = (patch: { pdfZoom?: number; pdfPreloadRadius?: number; pdfPreloadEnabled?: boolean }) => {
+        setReadingConfig((prev) => {
+            const next = { ...prev, ...patch };
+            saveReadingInteractionConfig(next);
+            return next;
+        });
+    };
+
     return (
         <div className="reading-app-surface absolute inset-0 z-[100] flex flex-col bg-[var(--c-page-body-bg)]" data-immersive={immersive} style={{ paddingTop: "var(--page-header-safe-top, 48px)" }}>
             {/* Page flip overlay */}
@@ -2046,6 +2150,9 @@ export function ReadingViewer({ book, onBack }: Props) {
                             jumpToPage={pdfJumpPage}
                             onCopyAnnotation={copyToClipboard}
                             onDeleteAnnotation={(annotationId) => { void handleDeleteReadingAnnotation(annotationId); }}
+                            zoom={readingConfig.pdfZoom ?? 1}
+                            preloadRadius={readingConfig.pdfPreloadRadius ?? 3}
+                            preloadEnabled={readingConfig.pdfPreloadEnabled !== false}
                         />
                     </>
                 ) : !chaptersLoaded ? (
@@ -2187,6 +2294,17 @@ export function ReadingViewer({ book, onBack }: Props) {
                             <PenLine size={22} strokeWidth={1.7} />
                             <span>写批注</span>
                         </button>
+                        {isPdf && (
+                            <button
+                                type="button"
+                                className="reading-footer-icon-btn"
+                                onClick={openPdfPrefetchDialog}
+                                disabled={generating || !companionId}
+                            >
+                                <Rocket size={22} strokeWidth={1.7} />
+                                <span>预批注</span>
+                            </button>
+                        )}
                         <button
                             type="button"
                             className="reading-footer-icon-btn"
@@ -2438,9 +2556,45 @@ export function ReadingViewer({ book, onBack }: Props) {
                     </div>
                 </ContentDialog>
             )}
+            {pdfPrefetchDialogOpen && (
+                <ContentDialog
+                    title="PDF 预批注"
+                    confirmLabel="开始预批注"
+                    cancelLabel="取消"
+                    onConfirm={() => { void handlePdfManualPrefetch(); }}
+                    onCancel={() => setPdfPrefetchDialogOpen(false)}
+                >
+                    <div className="reading-settings-grid">
+                        <p className="reading-settings-inline-note">
+                            <span>为指定页码范围提前生成批注（先解析文本层再生成，翻到那里就是现成的）。</span>
+                        </p>
+                        <div className="reading-settings-inline-note">
+                            <span>起始页</span>
+                            <input
+                                value={pdfPrefetchStartInput}
+                                onChange={(e) => setPdfPrefetchStartInput(e.target.value.replace(/[^\d]/g, ""))}
+                                className="ui-input"
+                                inputMode="numeric"
+                            />
+                        </div>
+                        <div className="reading-settings-inline-note">
+                            <span>结束页</span>
+                            <input
+                                value={pdfPrefetchEndInput}
+                                onChange={(e) => setPdfPrefetchEndInput(e.target.value.replace(/[^\d]/g, ""))}
+                                className="ui-input"
+                                inputMode="numeric"
+                            />
+                        </div>
+                        <p className="reading-settings-inline-note">
+                            <span>当前第 {Math.max(1, pdfCurrentPage)} / {Math.max(1, pdfTotalPages)} 页。页码范围越大，批注生成越久。</span>
+                        </p>
+                    </div>
+                </ContentDialog>
+            )}
             {showReadingSettings && (
                 <ContentDialog
-                    title="阅读双语翻译"
+                    title="阅读设置"
                     confirmLabel="完成"
                     cancelLabel="关闭"
                     onConfirm={() => setShowReadingSettings(false)}
@@ -2502,6 +2656,54 @@ export function ReadingViewer({ book, onBack }: Props) {
                                     }}
                                 />
                             </div>
+                        )}
+
+                        {isPdf && (
+                            <section className="reading-settings-group">
+                                <div className="reading-settings-heading">
+                                    <ZoomIn size={15} />
+                                    <span>PDF 渲染</span>
+                                </div>
+                                <div className="reading-settings-toggle-row">
+                                    <span className="reading-settings-toggle-label">预加载后续页</span>
+                                    <Toggle
+                                        checked={readingConfig.pdfPreloadEnabled !== false}
+                                        onChange={(next) => updatePdfRenderConfig({ pdfPreloadEnabled: next })}
+                                    />
+                                </div>
+                                <p className="reading-settings-inline-note">
+                                    <span>开启后阅读时会提前渲染当前页之后的页面，滚动更平滑；关闭则只渲染屏幕内的页。</span>
+                                </p>
+                                <div className="reading-settings-inline-note">
+                                    <span>页面缩放率</span>
+                                    <span>{Math.round((readingConfig.pdfZoom ?? 1) * 100)}%</span>
+                                </div>
+                                <input
+                                    type="range"
+                                    className="w-full my-1"
+                                    min={0.5}
+                                    max={2}
+                                    step={0.05}
+                                    value={readingConfig.pdfZoom ?? 1}
+                                    onChange={(e) => updatePdfRenderConfig({ pdfZoom: Number(e.target.value) })}
+                                />
+                                <div className="reading-settings-inline-note">
+                                    <span>一次渲染页数（当前页前后各几页）</span>
+                                    <span>{readingConfig.pdfPreloadRadius ?? 3} 页</span>
+                                </div>
+                                <input
+                                    type="range"
+                                    className="w-full my-1"
+                                    min={1}
+                                    max={8}
+                                    step={1}
+                                    value={readingConfig.pdfPreloadRadius ?? 3}
+                                    onChange={(e) => updatePdfRenderConfig({ pdfPreloadRadius: Number(e.target.value) })}
+                                />
+                                <p className="reading-settings-inline-note">
+                                    <span>提示：一次渲染页数过少时，滑动到未渲染的页会反复渲染，造成闪烁卡顿；调大并开启预加载可缓解。缩放率调大后一页更接近一屏。</span>
+                                </p>
+                            </section>
                         )}
                     </div>
                 </ContentDialog>

--- a/lib/reading-parser.ts
+++ b/lib/reading-parser.ts
@@ -77,7 +77,13 @@ function scoreDecodedTxt(text: string): number {
         - controlCount * 20;
 }
 
-export function decodeTxtArrayBuffer(buffer: ArrayBuffer): TxtDecodeResult {
+/**
+ * 解码 TXT 字节流为文本。
+ * @param preferredEncoding 用户手动指定的编码（auto 或 undefined = 自动探测）。
+ *   指定时优先用该编码解码（BOM 仍优先，因为 BOM 是权威的）；用于用户遇到自动探测
+ *   误判导致的乱码时，手动指定 TXT 的真实编码重新导入。
+ */
+export function decodeTxtArrayBuffer(buffer: ArrayBuffer, preferredEncoding?: string): TxtDecodeResult {
     const bytes = new Uint8Array(buffer);
     const bomCandidates: Array<[string, boolean]> = [];
 
@@ -89,9 +95,17 @@ export function decodeTxtArrayBuffer(buffer: ArrayBuffer): TxtDecodeResult {
         bomCandidates.push(["utf-16be", true]);
     }
 
+    // BOM 优先：有 BOM 就以 BOM 声明的编码为准（BOM 比手选更权威）
     for (const [encoding] of bomCandidates) {
         const text = decodeWithEncoding(buffer, encoding);
         if (text !== null) return { text, encoding };
+    }
+
+    // 用户手动指定了编码：直接用指定编码解码，不再自动探测
+    if (preferredEncoding && preferredEncoding !== "auto") {
+        const text = decodeWithEncoding(buffer, preferredEncoding);
+        if (text !== null) return { text, encoding: preferredEncoding };
+        return { text: "", encoding: preferredEncoding };
     }
 
     let best: TxtDecodeResult | null = null;

--- a/lib/reading-storage.ts
+++ b/lib/reading-storage.ts
@@ -64,16 +64,26 @@ export type ReadingInteractionConfig = {
     bilingualTranslationPrompt: string;
     /** 导入 TXT 时如何划分段落（默认自动探测书格式） */
     paragraphMode: ReadingParagraphMode;
+    /** TXT 编码解析：auto=自动探测（默认）/ utf-8 / gb18030 / gbk / big5 / utf-16le / utf-16be */
+    txtEncoding: "auto" | "utf-8" | "gb18030" | "gbk" | "big5" | "utf-16le" | "utf-16be";
     /** 阅读模式：翻页 / 连续滚动 */
     readingMode: ReadingViewMode;
     /** 自动批注失败时的静默重试次数（0=不重试） */
     annotationRetryCount: number;
-    /** 上一批自动批注读到该比例时，提前生成下一批批注（避免用户读到下一批时批注还没好）；默认关闭，由用户手动开启 */
+    /** TXT 预批注：读到上一批批注阈值时提前生成下一批（TXT 按段落分批）；默认关闭，由用户手动开启 */
     autoAnnotatePrefetch: boolean;
+    /** PDF 预批注：同上，但针对 PDF（按页分批）；默认关闭，由用户手动开启 */
+    autoAnnotatePrefetchPdf: boolean;
     /** 批注预生成触发时机：读到上一批批注的多少比例时提前生成下一批（0-1，默认 2/3） */
     annotationPrefetchThreshold: number;
     /** 共读讨论悬浮窗展开时是否自动滚动到最新消息（默认开启；用户可随后自由滑动打断） */
     chatAutoScrollOnOpen: boolean;
+    /** PDF 渲染：页面缩放率（1=按容器宽度原样，>1 放大；配合「一屏一页」使用） */
+    pdfZoom: number;
+    /** PDF 渲染：当前页前后各预渲染几页（懒加载粒度；过小会导致滚动到未渲染页反复渲染闪烁） */
+    pdfPreloadRadius: number;
+    /** PDF 预加载：开启后阅读时提前渲染后续页，滚动更平滑 */
+    pdfPreloadEnabled: boolean;
 };
 
 export const DEFAULT_READING_INTERACTION_CONFIG: ReadingInteractionConfig = {
@@ -81,11 +91,16 @@ export const DEFAULT_READING_INTERACTION_CONFIG: ReadingInteractionConfig = {
     collapseBilingualTranslation: true,
     bilingualTranslationPrompt: DEFAULT_READING_BILINGUAL_PROMPT,
     paragraphMode: "auto",
+    txtEncoding: "auto",
     readingMode: "page",
     annotationRetryCount: 3,
     autoAnnotatePrefetch: false,
+    autoAnnotatePrefetchPdf: false,
     annotationPrefetchThreshold: 2 / 3,
     chatAutoScrollOnOpen: true,
+    pdfZoom: 1,
+    pdfPreloadRadius: 3,
+    pdfPreloadEnabled: true,
 };
 
 export async function hydrateReadingStorage(): Promise<void> {


### PR DESCRIPTION
贡献者：温铎（@yechen1844）

阅读体验系列优化，共 6 个文件：
- PDF 渲染优化（reading-pdf-viewer.tsx）：页面缩放、前后预加载页数可调、渲染并发限流、渲染分辨率封顶 2x、批注钉与页面渲染解耦（开批注不闪烁）、换书防串
- PDF 阅读优化（reading-viewer.tsx）：手动预批注对话框、进度恢复优化（打开停在上次位置而非开头）、TXT 按配置编码导入
- TXT 编码优化（reading-parser.ts + reading-shelf.tsx + reading-storage.ts）：解码支持手动指定编码（自动/UTF-8/GB18030/GBK/Big5/UTF-16，BOM 优先、手选次之、自动兜底），导入按配置编码解码，新增配置字段
- 设置优化（reading-interaction-dialog.tsx）：新增 TXT 编码选项、预批注触发阈值滑块、PDF 预批注开关

一点小建议，如果能建议一下的话：很多 bug 可能比较依赖不同 user 的环境（特定的文件、特定的编码，自部署时环境变量差异更大），对其她 user 来说往往很难复现，自然也就无从改起。如果能在 bug 反馈区引导其她 user 在发帖之前，先自行用工坊 AI 助手排查修复一下，或许比作者远程排查更高效一些。比如资源市场上 TXT 导入乱码的反馈，我为了复现它前后找了十几个 TXT 文件才勉强撞出乱码场景，才做了这点优化。以上只是个人一点浅见，仅供参考。

---
_经小手机「共同建设」通道提交_