### PR TITLE
善后(1/3)：聊天流式按会话拆分 + 思维链标签绑定预设 + 正则编译缓存 + 会话预览增量 + 预设剔除文本（对 #130/#131/#132 的优化完善）

### DIFF
--- a/lib/chat-engine.ts
+++ b/lib/chat-engine.ts
@@ -19,6 +19,7 @@ import {
     normalizeVisionImagePromptLimit,
     createResponseBatchId,
     createToolExecutionId,
+    isSessionStreamingEnabled,
 } from "./chat-storage";
 import { extractTextToolDirectiveText, stripTextToolDirectives } from "./text-tool-protocol";
 import type { ApiConfig, PresetConfig, Prompt, PromptOrderEntry, RegexConfig } from "./settings-types";
@@ -52,6 +53,7 @@ import {
 } from "./llm-provider-adapter";
 import { setDebugPromptSnapshot, type DebugPromptSnapshot } from "./debug-store";
 import { extractFinishReason } from "./api-helpers";
+import { fetchLlmPayload } from "./llm-http";
 import { loadMemoryConfig, incrementEventCounter } from "./memory-storage";
 import { retrieveCoreMemoriesForPrompt, retrieveMemoriesForPrompt } from "./memory-service";
 import { formatCoreMemories, formatLongTermMemories } from "./memory-injector";
@@ -71,7 +73,9 @@ import { buildCalendarScheduleMarker, getCurrentCalendarScheduleForPrompt } from
 import { getWeekStartIso } from "./calendar-utils";
 import { buildCharacterTimeContext } from "./character-time";
 import { getPromptTimestampOptionsForTimeContext } from "./prompt-time";
-import { kvGet, kvSet, kvRemove, registerKvMigration } from "./kv-db";
+import { kvGet, kvSet, registerKvMigration } from "./kv-db";
+import { pushApiLog } from "./api-log-store";
+export { getApiLogs, clearApiLogs, type DebugInfo } from "./api-log-store";
 import { stripStateAndInnerForPrompt } from "./prompt-sanitizer";
 import { getInternalCapability, getInternalCapabilitySubToolDefinitions } from "./internal-capability-storage";
 import { isMediaStoreRef, loadMediaBlob } from "./media-cache-storage";
@@ -82,7 +86,7 @@ import {
     DEFAULT_OFFLINE_CHAT_BILINGUAL_PROMPT,
     resolveBilingualPrompt,
 } from "./bilingual-prompt-defaults";
-import { parseOfflineResponse, type ParsedOfflineResponse } from "./chat-offline-storage";
+import { parseOfflineResponse, extractThinkingTag, type ParsedOfflineResponse } from "./chat-offline-storage";
 import { throwIfAborted } from "./abort-utils";
 
 
@@ -321,32 +325,8 @@ export function applyVisionImagePromptLimit(history: ChatMessage[], limitValue: 
     return history;
 }
 
-// API Log store — captures recent request/response history for inspection
-export type DebugInfo = {
-    id: string;
-    characterName?: string;
-    model?: string;
-    messages: { role: string; content: string; marker?: string }[];
-    rawResponse: string;
-    timestamp: string;
-    usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
-};
-const MAX_API_LOGS = 50;
-const API_LOGS_KEY = "ai_phone_api_logs_v1";
-registerKvMigration(API_LOGS_KEY);
-
-function _loadLogs(): DebugInfo[] {
-    try {
-        const raw = typeof window !== "undefined" ? kvGet(API_LOGS_KEY) : null;
-        return raw ? JSON.parse(raw) as DebugInfo[] : [];
-    } catch { return []; }
-}
-function _saveLogs(logs: DebugInfo[]): void {
-    try { kvSet(API_LOGS_KEY, JSON.stringify(logs)); } catch { /* quota exceeded — ignore */ }
-}
-
-export function getApiLogs(): DebugInfo[] { return _loadLogs(); }
-export function clearApiLogs(): void { try { kvRemove(API_LOGS_KEY); } catch { } }
+// API 调用日志存储已抽到 ./api-log-store（聊天引擎与 simpleLLMCall 通用），
+// 本文件通过上方 re-export 保持 getApiLogs/clearApiLogs/DebugInfo 的对外路径不变。
 
 export type DebugPromptRequestOptions = {
     appId?: string;
@@ -418,6 +398,25 @@ function mergeAppTags(base: string[] | undefined, extra: string[] | undefined, f
     return Array.from(tags);
 }
 
+/** 从输出正文中剥离思维链标签块（仅标签解析开启时用于清洗展示文本）。 */
+export function stripOnlineThinkingTag(rawOutput: string, tag: string): string {
+    if (!tag.trim()) return rawOutput;
+    return rawOutput
+        .replace(new RegExp(`<${tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}>[\\s\\S]*?</${tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}>`, "gi"), "")
+        .trim();
+}
+
+/** 剔除预设配置的文本片段（如 <思考结束> 残留标签）。字面量删除，不走正则，避免编译/回溯开销。 */
+export function stripPresetTexts(text: string, preset: PresetConfig | null | undefined): string {
+    const list = preset?.strip_texts;
+    if (!list || list.length === 0 || !text) return text;
+    let result = text;
+    for (const s of list) {
+        if (s) result = result.split(s).join("");
+    }
+    return result;
+}
+
 function getPromptFilterTags(prompt: Prompt): string[] | null {
     if (prompt.tags && prompt.tags.length > 0) return prompt.tags;
     const legacy: string[] = [];
@@ -473,22 +472,18 @@ export function appendEmptyGenerateGuardMessage(
     const hasRealUserHistory = history.some(isRealUserHistoryMessage);
     if (!hasRealUserHistory) return;
 
-    let lastAssistantIndex = -1;
-    for (let index = messages.length - 1; index >= 0; index -= 1) {
-        if (messages[index].role === "assistant") {
-            lastAssistantIndex = index;
-            break;
-        }
+    // 判定用户这次是否真的输入了新消息：看原始对话 history 的末尾，而不是组装后的 messages。
+    // 原因：预设里 role=assistant 的条目（例如「模型输出格式」放在 chatHistory 标记之后）会以
+    // assistant 角色注入到 messages 末尾，旧逻辑「最后一条 assistant 之后没有 user」就会把
+    // 「用户已输入」误判成「未输入」，错误追加续写提示（EMPTY_GENERATE_CONTINUATION_PROMPT）。
+    // history 末尾是真实用户消息（含图片/红包等媒体输入）→ 本次是正常回复，不追加续写提示；
+    // 末尾是 assistant / system（如 follow-up 静默提示）→ 用户未输入新消息，照常追加。
+    const lastHistoryMessage = history[history.length - 1];
+    if (lastHistoryMessage && isRealUserHistoryMessage(lastHistoryMessage)) {
+        return;
     }
-    if (lastAssistantIndex < 0) return;
 
-    const hasUserAfterLastAssistant = messages
-        .slice(lastAssistantIndex + 1)
-        .some(message => message.role === "user");
-
-    if (!hasUserAfterLastAssistant) {
-        messages.push({ role: "user", content: EMPTY_GENERATE_CONTINUATION_PROMPT });
-    }
+    messages.push({ role: "user", content: EMPTY_GENERATE_CONTINUATION_PROMPT });
 }
 
 export function publishDebugPromptSnapshot(params: {
@@ -778,23 +773,28 @@ export async function sendLLMStreamRequest(
     } : undefined;
     const requestMessages = toLlmRequestMessages(afterPlugins.messages);
     const request = buildProviderRequest(config, effectivePreset, requestMessages, { stream: true });
-    const requestBodyJson = JSON.stringify(request.body);
     const llmAbort = new AbortController();
     const llmTimeout = setTimeout(() => llmAbort.abort(), 500_000);
     const detachExternalAbort = attachExternalAbort(llmAbort, options?.signal);
 
     try {
-        const response = await fetch(request.url, {
-            method: "POST",
-            headers: request.headers,
-            body: requestBodyJson,
-            signal: llmAbort.signal,
-        });
+        const response = await fetchLlmPayload(request, { signal: llmAbort.signal });
         if (!response.ok) {
             const errorText = await response.text();
             throw new ChatEngineError(`API Stream Error ${response.status}: ${errorText}`);
         }
-        const { content: streamedContent, rawResponse } = await readSseStream(response, request.providerKind, pluginCallbacks ?? callbacks);
+        // 流式路径收集思维链原文：readSseStream 只通过 onReasoningDelta 回调透传，
+        // 不额外包一层的话日志里就只有清洗后的回复正文，思维链被吞。
+        // 注意：必须无条件创建回调对象（不能 callbacks 为空就不传），否则思维链收集不到。
+        let streamedReasoning = "";
+        const streamLogCallbacks: ChatCompletionStreamCallbacks = {
+            ...(pluginCallbacks ?? callbacks),
+            onReasoningDelta: async (text: string) => {
+                streamedReasoning += text;
+                await (pluginCallbacks ?? callbacks)?.onReasoningDelta?.(text);
+            },
+        };
+        const { content: streamedContent, rawResponse } = await readSseStream(response, request.providerKind, streamLogCallbacks);
         if (!streamedContent.trim()) {
             throw new ChatEngineError("流式响应没有解析到文本增量。");
         }
@@ -802,23 +802,18 @@ export async function sendLLMStreamRequest(
         rawOutput = await applyChatPluginLlmResponse(rawOutput, pluginPurpose);
 
         // Store API log entry — mirror sendLLMRequest so streaming calls also show up
-        // in the "底层调用大模型日志" panel.
+        // in the "底层调用大模型日志" panel. reasoning 单独存思维链原文，供「查看原始」直接展示。
         const sanitizedMessages = request.messagesForLog.map(m => ({
             ...m,
             content: typeof m.content === "string" ? m.content : "[vision: 含图片的多模态消息]",
         }));
-        const logEntry: DebugInfo = {
-            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        pushApiLog({
             characterName: meta?.characterName,
             model: config.defaultModel,
             messages: sanitizedMessages,
             rawResponse: rawOutput,
-            timestamp: new Date().toISOString(),
-        };
-        const logs = _loadLogs();
-        logs.push(logEntry);
-        while (logs.length > MAX_API_LOGS) logs.shift();
-        _saveLogs(logs);
+            reasoning: streamedReasoning.trim() || undefined,
+        });
 
         if (!options?.skipOutputRegex) {
             const macroEngine = new MacroEngine(meta?.characterName ?? "", meta?.userName ?? "用户");
@@ -901,12 +896,7 @@ export async function sendLLMRequest(
     const detachExternalAbort = attachExternalAbort(llmAbort, options?.signal);
 
     try {
-        const response = await fetch(request.url, {
-            method: "POST",
-            headers: request.headers,
-            body: requestBodyJson,
-            signal: llmAbort.signal,
-        });
+        const response = await fetchLlmPayload(request, { signal: llmAbort.signal });
 
         if (!response.ok) {
             const errorText = await response.text();
@@ -949,19 +939,15 @@ export async function sendLLMRequest(
             ...m,
             content: typeof m.content === "string" ? m.content : "[vision: 含图片的多模态消息]",
         }));
-        const logEntry: DebugInfo = {
-            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        pushApiLog({
             characterName: meta?.characterName,
             model: config.defaultModel,
             messages: sanitizedMessages,
             rawResponse: rawOutput,
-            timestamp: new Date().toISOString(),
             usage: parsed.usage,
-        };
-        const logs = _loadLogs();
-        logs.push(logEntry);
-        while (logs.length > MAX_API_LOGS) logs.shift();
-        _saveLogs(logs);
+            // 思维链只经 onReasoning 回调透传，之前没进日志；这里单独存一份原文
+            reasoning: parsed.reasoning || undefined,
+        });
 
         if (options?.skipOutputRegex) {
             return rawOutput;
@@ -1074,7 +1060,6 @@ export async function sendLLMToolStreamRequest(
     const effectivePreset = afterPlugins.preset;
     const request = buildProviderRequest(config, effectivePreset, afterPlugins.messages, { tools, stream: true, maxTokens: options?.maxTokens });
     publishDebugPromptSnapshot({ request, config, preset: effectivePreset, meta, options, requestKind: "native-tools-stream", tools });
-    const requestBodyJson = JSON.stringify(request.body);
     const llmAbort = new AbortController();
     const llmTimeout = setTimeout(() => llmAbort.abort(), 500_000);
     const detachExternalAbort = attachExternalAbort(llmAbort, options?.signal);
@@ -1086,12 +1071,7 @@ export async function sendLLMToolStreamRequest(
     const firedToolCallStarts = new Set<number>();
 
     try {
-        const response = await fetch(request.url, {
-            method: "POST",
-            headers: request.headers,
-            body: requestBodyJson,
-            signal: llmAbort.signal,
-        });
+        const response = await fetchLlmPayload(request, { signal: llmAbort.signal });
 
         if (!response.ok) {
             const errorText = await response.text();
@@ -1175,18 +1155,14 @@ export async function sendLLMToolStreamRequest(
             content: typeof m.content === "string" ? m.content : "[vision: 含图片的多模态消息]",
         }));
         const { calls: toolCalls, truncatedNames } = finalizeStreamToolCalls(toolDrafts);
-        const logEntry: DebugInfo = {
-            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        const logEntryRaw = JSON.stringify({ content, reasoning, toolCalls, raw: rawResponse });
+        pushApiLog({
             characterName: meta?.characterName,
             model: config.defaultModel,
             messages: sanitizedMessages,
-            rawResponse: JSON.stringify({ content, reasoning, toolCalls, raw: rawResponse }),
-            timestamp: new Date().toISOString(),
-        };
-        const logs = _loadLogs();
-        logs.push(logEntry);
-        while (logs.length > MAX_API_LOGS) logs.shift();
-        _saveLogs(logs);
+            rawResponse: logEntryRaw,
+            reasoning: reasoning || undefined,
+        });
 
         if (!content && toolCalls.length === 0 && truncatedNames.length === 0) {
             throw new ChatEngineError("原生动作流式响应没有解析到文本或动作。");
@@ -1198,7 +1174,7 @@ export async function sendLLMToolStreamRequest(
             openRouterReasoningDetails: undefined,
             toolCalls,
             truncatedToolCalls: truncatedNames.length ? truncatedNames : undefined,
-            rawResponse: logEntry.rawResponse,
+            rawResponse: logEntryRaw,
             providerKind: request.providerKind,
         };
     } catch (error: unknown) {
@@ -1237,18 +1213,12 @@ export async function sendLLMToolRequest(
     const effectivePreset = afterPlugins.preset;
     const request = buildProviderRequest(config, effectivePreset, afterPlugins.messages, { tools });
     publishDebugPromptSnapshot({ request, config, preset: effectivePreset, meta, options, requestKind: "native-tools", tools });
-    const requestBodyJson = JSON.stringify(request.body);
     const llmAbort = new AbortController();
     const llmTimeout = setTimeout(() => llmAbort.abort(), 500_000);
     const detachExternalAbort = attachExternalAbort(llmAbort, options?.signal);
 
     try {
-        const response = await fetch(request.url, {
-            method: "POST",
-            headers: request.headers,
-            body: requestBodyJson,
-            signal: llmAbort.signal,
-        });
+        const response = await fetchLlmPayload(request, { signal: llmAbort.signal });
 
         if (!response.ok) {
             const errorText = await response.text();
@@ -1287,19 +1257,13 @@ export async function sendLLMToolRequest(
             toolCalls: parsed.toolCalls,
             raw: parsed.raw,
         });
-        const logEntry: DebugInfo = {
-            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        pushApiLog({
             characterName: meta?.characterName,
             model: config.defaultModel,
             messages: sanitizedMessages,
             rawResponse,
-            timestamp: new Date().toISOString(),
             usage: parsed.usage,
-        };
-        const logs = _loadLogs();
-        logs.push(logEntry);
-        while (logs.length > MAX_API_LOGS) logs.shift();
-        _saveLogs(logs);
+        });
 
         if (!options?.skipOutputRegex && rawOutput) {
             const macroEngine = new MacroEngine(meta?.characterName ?? "", meta?.userName ?? "用户");
@@ -1954,6 +1918,9 @@ export type ChatCompletionCallbacks = {
         responseBatchId?: string;
         rawResponseText?: string;
     }) => void | Promise<void>;
+    /** 流式生成增量回调（仅在开启流式生成时触发）：每到达一段原文增量就调用一次，
+     *  由 UI 层累积后做预览净化显示。delta 为原始增量（可能含未闭合的富媒体/工具标签）。 */
+    onStreamDelta?: (delta: string) => void | Promise<void>;
     onToolNotice?: (notice: string) => void;
     onToolResult?: (content: string, options?: { toolExecutionId?: string }) => void;
     onToolAssistantTurn?: (content: string, options?: {
@@ -1990,7 +1957,7 @@ export type OfflineChatCompletionResult = ParsedOfflineResponse & {
 export async function generateOfflineChatCompletion(
     session: ChatSession,
     history: ChatMessage[],
-    options?: { signal?: AbortSignal },
+    options?: { signal?: AbortSignal; onStreamDelta?: (delta: string) => void },
 ): Promise<OfflineChatCompletionResult> {
     const { llmMessages, character, config, preset, regexes, userIdentity } = await buildChatPromptMessages(
         session,
@@ -2001,18 +1968,72 @@ export async function generateOfflineChatCompletion(
         },
     );
     const summaryTag = preset?.story_summary_tag?.trim() || "summary";
+    const thinkingTag = preset?.thinking_tag?.trim() || "thinking";
+    const offlineTagEnabled = preset?.offline_thinking_enabled === true;
     let reasoning = "";
-    const rawOutput = await sendLLMRequest(config, preset, llmMessages, regexes, {
-        characterName: character.name,
-        userName: userIdentity?.name,
-    }, {
+    const meta = { characterName: character.name, userName: userIdentity?.name };
+    const requestOptions = {
         appTags: ["chat", "offline"],
         debugSessionId: session.id,
         signal: options?.signal,
-        onReasoning: (t) => { reasoning = t; },
-    });
+        onReasoning: (t: string) => { reasoning = t; },
+    };
+    let rawOutput: string;
+    if (isSessionStreamingEnabled(session, false) && options?.onStreamDelta) {
+        // 线下流式：正文边生成边通过 onStreamDelta 交给 UI 做实时预览；
+        // 摘要补提仍走整段请求（输出短，无需流式）。
+        const streamResult = await sendLLMStreamRequest(config, preset, llmMessages, regexes, meta, {
+            appId: "chat",
+            appTags: ["chat", "offline"],
+            signal: options?.signal,
+        }, {
+            onDelta: (text) => options.onStreamDelta?.(text),
+            onReasoningDelta: (t) => { reasoning += t; },
+        });
+        rawOutput = streamResult.content;
+    } else {
+        rawOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, requestOptions);
+    }
+    // 剔除预设配置的文本片段（<思考结束> 等残留标签），不进入记录/提示词
+    rawOutput = stripPresetTexts(rawOutput, preset);
+    let parsed = parseOfflineResponse(rawOutput, summaryTag);
+    // 思维链：预设开启「线下标签解析」时从正文提取 <thinking> 标签；关闭时走模型原生 reasoning（官方默认行为）
+    if (offlineTagEnabled) {
+        const tagThinking = extractThinkingTag(rawOutput, thinkingTag);
+        if (tagThinking) reasoning = tagThinking;
+    }
+
+    // 摘要缺失时自动补提：拿上次完整输出做上下文，只要求模型补一段摘要，
+    // 避免「静默结束」导致该轮线下记录没有摘要、进不了短期记忆事件流。
+    const MAX_SUMMARY_RETRY = 2;
+    for (let attempt = 0; attempt < MAX_SUMMARY_RETRY; attempt += 1) {
+        if (parsed.summary.trim()) break;
+        if (!parsed.content.trim() && !rawOutput.trim()) break; // 连正文都没有，补提没有意义
+        const retryMessages: LLMMessage[] = [
+            ...llmMessages,
+            { role: "assistant", content: rawOutput },
+            {
+                role: "user",
+                content: `刚才的回复里没有输出 <${summaryTag}> 摘要。请只针对上面这段对话的关键事件补一段第三人称摘要，严格按以下格式输出，不要输出任何其他内容：\n<${summaryTag}>一句话摘要</${summaryTag}>`,
+            },
+        ];
+        throwIfAborted(options?.signal);
+        // 补提请求不带 onReasoning：避免用补提请求的思维链覆盖主请求已累积的完整思维链
+        const retryRaw = stripPresetTexts(await sendLLMRequest(config, preset, retryMessages, regexes, meta, { ...requestOptions, onReasoning: undefined }), preset);
+        const retried = parseOfflineResponse(retryRaw, summaryTag);
+        if (retried.summary.trim()) {
+            parsed = { ...parsed, summary: retried.summary.trim() };
+            break;
+        }
+    }
+
     return {
-        ...parseOfflineResponse(rawOutput, summaryTag),
+        ...parsed,
+        // 标签解析开启时补 thinking/thinkingTag（供离线记录展示）；关闭时保持 undefined，思维链走 reasoning（模型原生）
+        ...(offlineTagEnabled ? {
+            thinking: extractThinkingTag(rawOutput, thinkingTag) || undefined,
+            thinkingTag,
+        } : {}),
         model: config.defaultModel,
         presetName: preset?.name || "默认预设",
         reasoning: reasoning || undefined,
@@ -2052,24 +2073,52 @@ async function generateNativeChatCompletion(
     const expandableSourceKeys = new Set(enabledTools.filter(tool => !isNativeSingleTool(tool)).map(nativeToolSourceKey));
 
     const maxToolRounds = getMaxToolRounds();
+    const onlineThinkingEnabled = preset?.online_thinking_enabled === true;
+    const onlineThinkingTag = preset?.online_thinking_tag?.trim() || "thinking";
     for (let round = 0; round < maxToolRounds; round += 1) {
         let result: LLMToolRequestResult;
         try {
-            result = await sendLLMToolRequest(
-                config,
-                preset,
-                requestMessages,
-                nativeBundle.definitions,
-                regexes,
-                meta,
-                {
-                    appId: options?.appId ?? "chat",
-                    appTags: requestAppTags,
-                    followUpCount: options?.followUpCount,
-                    debugSessionId: session.id,
-                    signal: options?.signal,
-                },
-            );
+            if (isSessionStreamingEnabled(session, true)) {
+                let streamReasoning = "";
+                result = await sendLLMToolStreamRequest(
+                    config,
+                    preset,
+                    requestMessages,
+                    nativeBundle.definitions,
+                    regexes,
+                    meta,
+                    {
+                        appId: options?.appId ?? "chat",
+                        appTags: requestAppTags,
+                        followUpCount: options?.followUpCount,
+                        debugSessionId: session.id,
+                        signal: options?.signal,
+                    },
+                    {
+                        onDelta: (text) => callbacks?.onStreamDelta?.(text),
+                        // 流式下 onReasoningDelta 收到的是单段增量：本地累积后再喂 onReasoning，
+                        // 保证下游拿到的是完整思维链（与整段请求的 onReasoning 语义一致）。
+                        // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
+                        onReasoningDelta: onlineThinkingEnabled ? undefined : (text) => { streamReasoning += text; callbacks?.onReasoning?.(streamReasoning); },
+                    },
+                );
+            } else {
+                result = await sendLLMToolRequest(
+                    config,
+                    preset,
+                    requestMessages,
+                    nativeBundle.definitions,
+                    regexes,
+                    meta,
+                    {
+                        appId: options?.appId ?? "chat",
+                        appTags: requestAppTags,
+                        followUpCount: options?.followUpCount,
+                        debugSessionId: session.id,
+                        signal: options?.signal,
+                    },
+                );
+            }
         } catch (err) {
             const errMsg = `⚠️ 回复生成失败: ${err instanceof Error ? err.message : String(err)}`;
             if (parts.length > 0) {
@@ -2082,17 +2131,28 @@ async function generateNativeChatCompletion(
         }
         throwIfAborted(options?.signal);
 
-        const { cleanText: afterActionStrip, actions } = parseActionTags(result.content);
+        // 线上思维链标签解析：开启时从正文提取 <tag> 思维链（覆盖原生），并剥离标签后再做后续解析
+        let displayContent = result.content;
+        if (onlineThinkingEnabled) {
+            const tagThinking = extractThinkingTag(displayContent, onlineThinkingTag);
+            if (tagThinking) callbacks?.onReasoning?.(tagThinking);
+            displayContent = stripOnlineThinkingTag(displayContent, onlineThinkingTag);
+        }
+        // 剔除预设配置的文本片段（<思考结束> 等残留标签）
+        displayContent = stripPresetTexts(displayContent, preset);
+
+        const { cleanText: afterActionStrip, actions } = parseActionTags(displayContent);
         if (actions.length > 0) {
             throwIfAborted(options?.signal);
             dispatchActions(actions, actionContext).catch(err => console.warn("[ChatEngine] Action dispatch failed:", err));
         }
-        const assistantForToolContext = stripStateAndInnerForPrompt(result.content);
+        const assistantForToolContext = stripStateAndInnerForPrompt(displayContent);
 
         if (result.toolCalls.length === 0) {
             throwIfAborted(options?.signal);
             // 无工具调用的最终轮：把解析到的思维链先交给回调（先于 onTextPart，与非原生路径一致）
-            if (result.reasoning) callbacks?.onReasoning?.(result.reasoning);
+            // 标签解析开启时已在上方用标签思维链覆盖，此处不再重复喂原生
+            if (result.reasoning && !onlineThinkingEnabled) callbacks?.onReasoning?.(result.reasoning);
             await callbacks?.onTextPart?.(afterActionStrip);
             parts.push({ text: afterActionStrip });
             break;
@@ -2101,9 +2161,9 @@ async function generateNativeChatCompletion(
         throwIfAborted(options?.signal);
         await callbacks?.onNativeToolAssistantTurn?.({
             content: afterActionStrip,
-            rawContent: result.content,
-            reasoning: result.reasoning,
-            openRouterReasoningDetails: result.openRouterReasoningDetails,
+            rawContent: displayContent,
+            reasoning: onlineThinkingEnabled ? (extractThinkingTag(result.content, onlineThinkingTag) || undefined) : result.reasoning,
+            openRouterReasoningDetails: onlineThinkingEnabled ? undefined : result.openRouterReasoningDetails,
             toolCalls: result.toolCalls,
         });
         if (afterActionStrip) {
@@ -2296,17 +2356,41 @@ export async function generateChatCompletion(
     const actionContext = { characterId: session.contactId, sessionId: session.id, sourceEngine: "chat" as const, signal: options?.signal };
 
     const maxToolRounds = getMaxToolRounds();
+    const onlineThinking = {
+        enabled: preset?.online_thinking_enabled === true,
+        tag: preset?.online_thinking_tag?.trim() || "thinking",
+        reasoning: undefined as string | undefined,
+    };
     for (let round = 0; round < maxToolRounds; round++) {
         let filteredOutput: string;
         try {
-            filteredOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
-                appId: options?.appId ?? "chat",
-                appTags: requestAppTags,
-                followUpCount: options?.followUpCount,
-                debugSessionId: session.id,
-                signal: options?.signal,
-                onReasoning: callbacks?.onReasoning,
-            });
+            if (isSessionStreamingEnabled(session, true)) {
+                // 流式分支：与 sendLLMRequest 走同一套请求构造/日志/正则，仅把「整段等待」换成
+                // SSE 增量，并通过 onStreamDelta 把原文增量实时交给 UI 层做预览显示。
+                let streamReasoning = "";
+                const streamResult = await sendLLMStreamRequest(config, preset, llmMessages, regexes, meta, {
+                    appId: options?.appId ?? "chat",
+                    appTags: requestAppTags,
+                    followUpCount: options?.followUpCount,
+                    signal: options?.signal,
+                }, {
+                    onDelta: (text) => callbacks?.onStreamDelta?.(text),
+                    // 流式下 onReasoningDelta 是单段增量：累积后再喂 onReasoning（保持整段请求语义）
+                    // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
+                    onReasoningDelta: onlineThinking.enabled ? undefined : (text) => { streamReasoning += text; callbacks?.onReasoning?.(streamReasoning); },
+                });
+                filteredOutput = streamResult.content;
+            } else {
+                filteredOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
+                    appId: options?.appId ?? "chat",
+                    appTags: requestAppTags,
+                    followUpCount: options?.followUpCount,
+                    debugSessionId: session.id,
+                    signal: options?.signal,
+                    // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
+                    onReasoning: onlineThinking.enabled ? undefined : callbacks?.onReasoning,
+                });
+            }
         } catch (err) {
             const errMsg = `⚠️ 回复生成失败: ${err instanceof Error ? err.message : String(err)}`;
             if (parts.length > 0) {
@@ -2318,6 +2402,18 @@ export async function generateChatCompletion(
             throw err;
         }
         throwIfAborted(options?.signal);
+
+        // 线上思维链标签解析：开启时每轮从正文提取 <tag> 思维链（覆盖原生），并剥离标签后再做后续解析
+        if (onlineThinking.enabled) {
+            const tagThinking = extractThinkingTag(filteredOutput, onlineThinking.tag);
+            if (tagThinking) {
+                onlineThinking.reasoning = tagThinking;
+                callbacks?.onReasoning?.(tagThinking);
+            }
+            filteredOutput = stripOnlineThinkingTag(filteredOutput, onlineThinking.tag);
+        }
+        // 剔除预设配置的文本片段（<思考结束> 等残留标签），不进入消息/提示词
+        filteredOutput = stripPresetTexts(filteredOutput, preset);
 
         // Parse actions (朋友圈 etc) — strip from display text but keep tool tags
         const { cleanText: afterActionStrip, actions } = parseActionTags(filteredOutput);
@@ -2464,15 +2560,40 @@ export async function generateChatCompletion(
             // Last round — one final call
             if (round === maxToolRounds - 1) {
                 try {
-                    const finalOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
-                        appId: options?.appId ?? "chat",
-                        appTags: requestAppTags,
-                        followUpCount: options?.followUpCount,
-                        debugSessionId: session.id,
-                        signal: options?.signal,
-                        onReasoning: callbacks?.onReasoning,
-                    });
+                    let finalOutput: string;
+                    if (isSessionStreamingEnabled(session, true)) {
+                        let streamReasoning = "";
+                        const streamFinal = await sendLLMStreamRequest(config, preset, llmMessages, regexes, meta, {
+                            appId: options?.appId ?? "chat",
+                            appTags: requestAppTags,
+                            followUpCount: options?.followUpCount,
+                            signal: options?.signal,
+                        }, {
+                            onDelta: (text) => callbacks?.onStreamDelta?.(text),
+                            // 流式下 onReasoningDelta 是单段增量：累积后再喂 onReasoning（保持整段请求语义）。
+                            // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
+                            onReasoningDelta: onlineThinking.enabled ? undefined : (text) => { streamReasoning += text; callbacks?.onReasoning?.(streamReasoning); },
+                        });
+                        finalOutput = streamFinal.content;
+                    } else {
+                        finalOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
+                            appId: options?.appId ?? "chat",
+                            appTags: requestAppTags,
+                            followUpCount: options?.followUpCount,
+                            debugSessionId: session.id,
+                            signal: options?.signal,
+                            onReasoning: onlineThinking.enabled ? undefined : callbacks?.onReasoning,
+                        });
+                    }
                     throwIfAborted(options?.signal);
+                    // 线上思维链标签解析：开启时从正文提取 <tag> 思维链并剥离标签
+                    if (onlineThinking.enabled) {
+                        const tagThinking = extractThinkingTag(finalOutput, onlineThinking.tag);
+                        if (tagThinking) callbacks?.onReasoning?.(tagThinking);
+                        finalOutput = stripOnlineThinkingTag(finalOutput, onlineThinking.tag);
+                    }
+                    // 剔除预设配置的文本片段（<思考结束> 等残留标签）
+                    finalOutput = stripPresetTexts(finalOutput, preset);
                     await callbacks?.onTextPart?.(finalOutput);
                     parts.push({ text: finalOutput });
                 } catch (err) {

--- a/lib/chat-storage.ts
+++ b/lib/chat-storage.ts
@@ -57,6 +57,10 @@ export type ChatSession = {
     offlineBilingualTranslationPrompt?: string;
     nativeExpandedToolSourceIds?: string[];
     visionImagePromptLimit?: number;
+    /** 流式生成（线上）：开启后该会话的线上 AI 回复边生成边显示（默认关，保持原整段请求行为） */
+    streamOnline?: boolean;
+    /** 流式生成（线下）：开启后该会话的线下 AI 回复边生成边显示（默认关，保持原整段请求行为） */
+    streamOffline?: boolean;
     // Group chat fields
     isGroup?: boolean;
     groupName?: string;
@@ -265,6 +269,12 @@ export function getMaxToolRounds(): number {
     const raw = loadChatAppSettings().maxToolRounds;
     if (typeof raw !== "number" || !Number.isFinite(raw)) return 5;
     return Math.max(1, Math.min(20, Math.round(raw)));
+}
+
+/** 会话是否开启线上流式生成（默认关；按会话独立控制，单聊/群聊都生效） */
+export function isSessionStreamingEnabled(session: Pick<ChatSession, "streamOnline" | "streamOffline"> | null | undefined, online: boolean): boolean {
+    if (!session) return false;
+    return online ? session.streamOnline === true : session.streamOffline === true;
 }
 
 export const CHAT_APP_SETTINGS_UPDATED_EVENT = "chat-app-settings-updated";
@@ -1129,16 +1139,26 @@ export function pushChatMessage(msg: Omit<ChatMessage, "id" | "createdAt" | "sta
     dbPutMessage(newMsg);
 
     // Auto update session last message only for records that can produce a list preview.
+    // 优化：直接增量更新内存会话缓存并异步写单条，避免每次发送都走 loadChatSessions +
+    // saveChatSessions 触发全量会话预览重算（会话/消息多了以后会明显卡顿）。
     const preview = getChatMessagePreview(newMsg);
-    const sessions = loadChatSessions();
-    const sessIdx = sessions.findIndex(s => s.id === msg.sessionId);
+    const sessIdx = _sessionsCache.findIndex(s => s.id === msg.sessionId);
     if (sessIdx !== -1 && isSessionPreviewCandidate(newMsg)) {
-        sessions[sessIdx].lastMessageId = newMsg.id;
-        if (preview) {
-            sessions[sessIdx].lastMessagePreview = preview;
+        const target = _sessionsCache[sessIdx];
+        target.lastMessageId = newMsg.id;
+        if (preview) target.lastMessagePreview = preview;
+        target.updatedAt = newMsg.createdAt;
+        dbPutSessions([target]);
+    } else if (sessIdx === -1) {
+        // 缓存未命中（极端情况）：回退全量路径，保证列表预览仍会刷新
+        const sessions = loadChatSessions();
+        const idx2 = sessions.findIndex(s => s.id === msg.sessionId);
+        if (idx2 !== -1 && isSessionPreviewCandidate(newMsg)) {
+            sessions[idx2].lastMessageId = newMsg.id;
+            if (preview) sessions[idx2].lastMessagePreview = preview;
+            sessions[idx2].updatedAt = newMsg.createdAt;
+            saveChatSessions(sessions);
         }
-        sessions[sessIdx].updatedAt = newMsg.createdAt;
-        saveChatSessions(sessions);
     }
 
     if (typeof window !== "undefined") {

--- a/lib/group-chat-engine.ts
+++ b/lib/group-chat-engine.ts
@@ -1,7 +1,7 @@
 // lib/group-chat-engine.ts
 // Group chat engine: single API call for all characters.
 
-import { ChatSession, ChatMessage, loadChatAppSettings, createResponseBatchId, createResponseRoundId, createToolExecutionId, loadChatSessions, getLatestCharacterStateValues } from "./chat-storage";
+import { ChatSession, ChatMessage, loadChatAppSettings, createResponseBatchId, createResponseRoundId, createToolExecutionId, loadChatSessions, getLatestCharacterStateValues, isSessionStreamingEnabled } from "./chat-storage";
 import { extractTextToolDirectiveText } from "./text-tool-protocol";
 import type { ApiConfig, PresetConfig, RegexConfig } from "./settings-types";
 import { loadCharacters } from "./character-storage";
@@ -10,7 +10,9 @@ import { runChatPluginTransform } from "./chat-plugin-hooks";
 import { buildChatPluginPromptFragments } from "./chat-plugin-storage";
 import {
     sendLLMRequest,
+    sendLLMStreamRequest,
     sendLLMToolRequest,
+    sendLLMToolStreamRequest,
     ChatEngineError,
     buildMusicLocalMacro,
     buildMusicCloudMacro,
@@ -31,6 +33,8 @@ import {
     touchNativeExpandedToolSource,
     appendEmptyGenerateGuardMessage,
     applyCustomPromptProfileToPreset,
+    stripOnlineThinkingTag,
+    stripPresetTexts,
     type ChatCompletionCallbacks,
     type NativeChatToolBundle,
 } from "./chat-engine";
@@ -73,7 +77,7 @@ import { formatToolsForPrompt, formatGroupToolsForPrompt, formatToolSchema } fro
 import { parseToolCalls, parseToolFetches, executeToolCalls, formatToolResults, type ToolCall } from "./tool-executor";
 import { stripStateAndInnerForPrompt } from "./prompt-sanitizer";
 import { buildGroupRosterMacro } from "./group-admin";
-import { parseOfflineResponse, type ParsedOfflineResponse } from "./chat-offline-storage";
+import { parseOfflineResponse, extractThinkingTag, type ParsedOfflineResponse } from "./chat-offline-storage";
 import { buildProviderRequest, nativeToolProtocolForConfig, toLlmRequestMessages, type LlmRequestMessage, type LlmToolCall } from "./llm-provider-adapter";
 import type { DebugPromptSnapshot } from "./debug-store";
 import { throwIfAborted } from "./abort-utils";
@@ -565,6 +569,8 @@ async function runNativeGroupToolLoop(params: {
 }): Promise<string> {
     const { session, llmMessages, config, preset, regexes, nameToId, memberNames, enabledTools, appTags, signal, callbacks } = params;
     const MAX_TOOL_ROUNDS = 5;
+    const onlineThinkingEnabled = preset?.online_thinking_enabled === true;
+    const onlineThinkingTag = preset?.online_thinking_tag?.trim() || "thinking";
     const persistedSession = loadChatSessions().find(item => item.id === session.id);
     let expandedSourceIds = normalizeNativeExpandedToolSourceIds(
         persistedSession?.nativeExpandedToolSourceIds || session.nativeExpandedToolSourceIds,
@@ -584,12 +590,27 @@ async function runNativeGroupToolLoop(params: {
     for (let round = 0; round < MAX_TOOL_ROUNDS; round += 1) {
         let result: Awaited<ReturnType<typeof sendLLMToolRequest>>;
         try {
-            result = await sendLLMToolRequest(config, preset, requestMessages, nativeBundle.definitions, regexes, meta, {
-                appId: "group_chat",
-                appTags,
-                debugSessionId: session.id,
-                signal,
-            });
+            if (isSessionStreamingEnabled(session, true)) {
+                let streamReasoning = "";
+                result = await sendLLMToolStreamRequest(config, preset, requestMessages, nativeBundle.definitions, regexes, meta, {
+                    appId: "group_chat",
+                    appTags,
+                    debugSessionId: session.id,
+                    signal,
+                }, {
+                    onDelta: (text) => callbacks?.onStreamDelta?.(text),
+                    // 流式下 onReasoningDelta 是单段增量：累积后再喂 onReasoning（保持整段请求语义）
+                    // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
+                    onReasoningDelta: onlineThinkingEnabled ? undefined : (text) => { streamReasoning += text; callbacks?.onReasoning?.(streamReasoning); },
+                });
+            } else {
+                result = await sendLLMToolRequest(config, preset, requestMessages, nativeBundle.definitions, regexes, meta, {
+                    appId: "group_chat",
+                    appTags,
+                    debugSessionId: session.id,
+                    signal,
+                });
+            }
         } catch (err) {
             if (finalRawOutput) {
                 throwIfAborted(signal);
@@ -600,21 +621,31 @@ async function runNativeGroupToolLoop(params: {
         }
         throwIfAborted(signal);
 
-        const assistantForToolContext = stripStateAndInnerForPrompt(result.content);
+        // 线上思维链标签解析：开启时每轮从正文提取 <tag> 思维链（覆盖原生），并剥离标签后再做后续解析
+        let displayContent = result.content;
+        if (onlineThinkingEnabled) {
+            const tagThinking = extractThinkingTag(displayContent, onlineThinkingTag);
+            if (tagThinking) callbacks?.onReasoning?.(tagThinking);
+            displayContent = stripOnlineThinkingTag(displayContent, onlineThinkingTag);
+        }
+        // 剔除预设配置的文本片段（<思考结束> 等残留标签）
+        displayContent = stripPresetTexts(displayContent, preset);
+        const assistantForToolContext = stripStateAndInnerForPrompt(displayContent);
         if (result.toolCalls.length === 0) {
             throwIfAborted(signal);
             // 无工具调用的最终轮：把解析到的思维链交给回调（随后由 processGroupParts 挂到本轮首条气泡）
-            if (result.reasoning) callbacks?.onReasoning?.(result.reasoning);
-            finalRawOutput = result.content;
+            // 标签解析开启时已用标签思维链覆盖，此处不再重复喂原生
+            if (result.reasoning && !onlineThinkingEnabled) callbacks?.onReasoning?.(result.reasoning);
+            finalRawOutput = displayContent;
             break;
         }
 
         throwIfAborted(signal);
         await callbacks?.onNativeToolAssistantTurn?.({
-            content: result.content,
-            rawContent: result.content,
-            reasoning: result.reasoning,
-            openRouterReasoningDetails: result.openRouterReasoningDetails,
+            content: displayContent,
+            rawContent: displayContent,
+            reasoning: onlineThinkingEnabled ? (extractThinkingTag(result.content, onlineThinkingTag) || undefined) : result.reasoning,
+            openRouterReasoningDetails: onlineThinkingEnabled ? undefined : result.openRouterReasoningDetails,
             toolCalls: result.toolCalls,
         });
 
@@ -720,8 +751,8 @@ async function runNativeGroupToolLoop(params: {
         requestMessages.push({
             role: "assistant",
             content: assistantForToolContext,
-            reasoning: result.reasoning,
-            openRouterReasoningDetails: result.openRouterReasoningDetails,
+            reasoning: onlineThinkingEnabled ? (extractThinkingTag(result.content, onlineThinkingTag) || undefined) : result.reasoning,
+            openRouterReasoningDetails: onlineThinkingEnabled ? undefined : result.openRouterReasoningDetails,
             toolCalls: result.toolCalls,
         });
         const toolExecutionId = createToolExecutionId();
@@ -780,6 +811,9 @@ export async function generateGroupChatCompletion(
     const MAX_TOOL_ROUNDS = 5;
     const meta = { characterName: `群聊:${session.groupName || "群聊"}` };
     let finalRawOutput = "";
+    // 线上思维链标签解析：预设开启时从正文提取 <tag> 思维链（覆盖原生），并剥离标签后再做后续解析
+    const onlineThinkingEnabled = preset?.online_thinking_enabled === true;
+    const onlineThinkingTag = preset?.online_thinking_tag?.trim() || "thinking";
 
     if (nativeToolProtocolForConfig(config) && enabledTools.length > 0) {
         finalRawOutput = await runNativeGroupToolLoop({
@@ -808,13 +842,29 @@ export async function generateGroupChatCompletion(
     for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
         let filteredOutput: string;
         try {
-            filteredOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
-                appId: "group_chat",
-                appTags,
-                debugSessionId: session.id,
-                signal: options?.signal,
-                onReasoning: callbacks?.onReasoning,
-            });
+            if (isSessionStreamingEnabled(session, true)) {
+                let streamReasoning = "";
+                const streamResult = await sendLLMStreamRequest(config, preset, llmMessages, regexes, meta, {
+                    appId: "group_chat",
+                    appTags,
+                    signal: options?.signal,
+                }, {
+                    onDelta: (text) => callbacks?.onStreamDelta?.(text),
+                    // 流式下 onReasoningDelta 是单段增量：累积后再喂 onReasoning（保持整段请求语义）
+                    // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
+                    onReasoningDelta: onlineThinkingEnabled ? undefined : (text) => { streamReasoning += text; callbacks?.onReasoning?.(streamReasoning); },
+                });
+                filteredOutput = streamResult.content;
+            } else {
+                filteredOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
+                    appId: "group_chat",
+                    appTags,
+                    debugSessionId: session.id,
+                    signal: options?.signal,
+                    // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
+                    onReasoning: onlineThinkingEnabled ? undefined : callbacks?.onReasoning,
+                });
+            }
         } catch (err) {
             if (finalRawOutput) {
                 throwIfAborted(options?.signal);
@@ -824,6 +874,15 @@ export async function generateGroupChatCompletion(
             throw err;
         }
         throwIfAborted(options?.signal);
+
+        // 线上思维链标签解析：开启时每轮从正文提取 <tag> 思维链（覆盖原生），并剥离标签后再做后续解析
+        if (onlineThinkingEnabled) {
+            const tagThinking = extractThinkingTag(filteredOutput, onlineThinkingTag);
+            if (tagThinking) callbacks?.onReasoning?.(tagThinking);
+            filteredOutput = stripOnlineThinkingTag(filteredOutput, onlineThinkingTag);
+        }
+        // 剔除预设配置的文本片段（<思考结束> 等残留标签），不进入消息/提示词
+        filteredOutput = stripPresetTexts(filteredOutput, preset);
 
         const toolFetches = parseToolFetches(filteredOutput);
         const { toolCalls } = parseToolCalls(filteredOutput);
@@ -957,14 +1016,38 @@ export async function generateGroupChatCompletion(
 
             if (round === MAX_TOOL_ROUNDS - 1) {
                 try {
-                    finalRawOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
-                        appId: "group_chat",
-                        appTags,
-                        debugSessionId: session.id,
-                        signal: options?.signal,
-                        onReasoning: callbacks?.onReasoning,
-                    });
+                    if (isSessionStreamingEnabled(session, true)) {
+                        let streamReasoning = "";
+                        const streamFinal = await sendLLMStreamRequest(config, preset, llmMessages, regexes, meta, {
+                            appId: "group_chat",
+                            appTags,
+                            signal: options?.signal,
+                        }, {
+                            onDelta: (text) => callbacks?.onStreamDelta?.(text),
+                            // 流式下 onReasoningDelta 是单段增量：累积后再喂 onReasoning（保持整段请求语义）
+                            // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
+                            onReasoningDelta: onlineThinkingEnabled ? undefined : (text) => { streamReasoning += text; callbacks?.onReasoning?.(streamReasoning); },
+                        });
+                        finalRawOutput = streamFinal.content;
+                    } else {
+                        finalRawOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
+                            appId: "group_chat",
+                            appTags,
+                            debugSessionId: session.id,
+                            signal: options?.signal,
+                            // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
+                            onReasoning: onlineThinkingEnabled ? undefined : callbacks?.onReasoning,
+                        });
+                    }
                     throwIfAborted(options?.signal);
+                    // 线上思维链标签解析：开启时从正文提取 <tag> 思维链并剥离标签
+                    if (onlineThinkingEnabled) {
+                        const tagThinking = extractThinkingTag(finalRawOutput, onlineThinkingTag);
+                        if (tagThinking) callbacks?.onReasoning?.(tagThinking);
+                        finalRawOutput = stripOnlineThinkingTag(finalRawOutput, onlineThinkingTag);
+                    }
+                    // 剔除预设配置的文本片段（<思考结束> 等残留标签）
+                    finalRawOutput = stripPresetTexts(finalRawOutput, preset);
                 } catch {
                     throwIfAborted(options?.signal);
                     /* use last output */
@@ -1049,7 +1132,7 @@ export type GroupOfflineChatCompletionResult = ParsedOfflineResponse & {
 export async function generateGroupOfflineChatCompletion(
     session: ChatSession,
     history: ChatMessage[],
-    options?: { signal?: AbortSignal },
+    options?: { signal?: AbortSignal; onStreamDelta?: (delta: string) => void },
 ): Promise<GroupOfflineChatCompletionResult> {
     const { llmMessages, config, preset, regexes } = await buildGroupChatPromptMessages(
         session,
@@ -1061,18 +1144,71 @@ export async function generateGroupOfflineChatCompletion(
         },
     );
     const summaryTag = preset?.story_summary_tag?.trim() || "summary";
+    const thinkingTag = preset?.thinking_tag?.trim() || "thinking";
+    const offlineTagEnabled = preset?.offline_thinking_enabled === true;
     let reasoning = "";
-    const rawOutput = await sendLLMRequest(config, preset, llmMessages, regexes, {
-        characterName: `群聊:${session.groupName || "群聊"}`,
-    }, {
+    const meta = { characterName: `群聊:${session.groupName || "群聊"}` };
+    const requestOptions = {
         appId: "group_chat",
         appTags: ["group_chat", "offline"],
         debugSessionId: session.id,
         signal: options?.signal,
-        onReasoning: (t) => { reasoning = t; },
-    });
+        onReasoning: (t: string) => { reasoning = t; },
+    };
+    let rawOutput: string;
+    if (isSessionStreamingEnabled(session, false) && options?.onStreamDelta) {
+        const streamResult = await sendLLMStreamRequest(config, preset, llmMessages, regexes, meta, {
+            appId: "group_chat",
+            appTags: ["group_chat", "offline"],
+            signal: options?.signal,
+        }, {
+            onDelta: (text) => options.onStreamDelta?.(text),
+            onReasoningDelta: (t) => { reasoning += t; },
+        });
+        rawOutput = streamResult.content;
+    } else {
+        rawOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, requestOptions);
+    }
+    // 剔除预设配置的文本片段（<思考结束> 等残留标签），不进入记录/提示词
+    rawOutput = stripPresetTexts(rawOutput, preset);
+    let parsed = parseOfflineResponse(rawOutput, summaryTag);
+    // 思维链：预设开启「线下标签解析」时从正文提取 <thinking> 标签；关闭时走模型原生 reasoning（官方默认行为）
+    if (offlineTagEnabled) {
+        const tagThinking = extractThinkingTag(rawOutput, thinkingTag);
+        if (tagThinking) reasoning = tagThinking;
+    }
+
+    // 摘要缺失时自动补提：拿上次完整输出做上下文，只要求模型补一段摘要，
+    // 避免「静默结束」导致该轮线下记录没有摘要、进不了短期记忆事件流。
+    const MAX_SUMMARY_RETRY = 2;
+    for (let attempt = 0; attempt < MAX_SUMMARY_RETRY; attempt += 1) {
+        if (parsed.summary.trim()) break;
+        if (!parsed.content.trim() && !rawOutput.trim()) break; // 连正文都没有，补提没有意义
+        const retryMessages: LLMMessage[] = [
+            ...llmMessages,
+            { role: "assistant", content: rawOutput },
+            {
+                role: "user",
+                content: `刚才的回复里没有输出 <${summaryTag}> 摘要。请只针对上面这段对话的关键事件补一段第三人称摘要，严格按以下格式输出，不要输出任何其他内容：\n<${summaryTag}>一句话摘要</${summaryTag}>`,
+            },
+        ];
+        throwIfAborted(options?.signal);
+        // 补提请求不带 onReasoning：避免用补提请求的思维链覆盖主请求已累积的完整思维链
+        const retryRaw = stripPresetTexts(await sendLLMRequest(config, preset, retryMessages, regexes, meta, { ...requestOptions, onReasoning: undefined }), preset);
+        const retried = parseOfflineResponse(retryRaw, summaryTag);
+        if (retried.summary.trim()) {
+            parsed = { ...parsed, summary: retried.summary.trim() };
+            break;
+        }
+    }
+
     return {
-        ...parseOfflineResponse(rawOutput, summaryTag),
+        ...parsed,
+        // 标签解析开启时补 thinking/thinkingTag（供离线记录展示）；关闭时保持 undefined，思维链走 reasoning（模型原生）
+        ...(offlineTagEnabled ? {
+            thinking: extractThinkingTag(rawOutput, thinkingTag) || undefined,
+            thinkingTag,
+        } : {}),
         model: config.defaultModel,
         presetName: preset?.name || "默认预设",
         reasoning: reasoning || undefined,


### PR DESCRIPTION
贡献者：温铎（@yechen1844）

本 PR 是「善后」提交（批次 1/3，因单次提交有文件数与总量限制而拆分；其余批次：2=chat-room/chat-settings-panel/preset-manager，3=chat-offline-storage/llm-prompt-assembler/settings-types）。包含 4 个后续提交，均为对之前已提交功能的优化与完善，部分改动建立在 #130「AI 调用日志重构」、#131「大模型调用日志 UI/思维链」、#132「聊天流式生成」之上，请优先合并 #130/#131/#132 后再合入（或一并处理）。

改动明细（4 个提交）：

1. bc21d89 feat(chat): 流式生成按会话拆分（线上/线下独立开关）+ 思维链标签解析绑定预设
   - 对 #132 流式功能的完善：删除全局流式开关 streamChatGeneration，改为会话级 streamOnline / streamOffline（默认关，不改变原整段请求行为），单聊/群聊均生效。
   - 对 #131 思维链功能的完善：预设新增线上思维链字段 online_thinking_tag 与线上/线下解析开关（默认关）；parseOfflineResponse 回归官方两参数；关闭标签解析时线上/线下均走模型原生思维链（官方默认行为），开启才按标签提取并剥离。

2. 3e0282f perf(chat): 正则规则编译缓存——同一 findRegex 字符串复用编译结果，消除显示层/记录层每次渲染重复 new RegExp 的卡顿（匹配替换走慢路径的会话，如含 <思考结束> 残留标签，之前会明显卡顿）。

3. 68823e6 perf(chat): 发送消息不再全量刷新会话预览——直接增量更新内存会话缓存并异步写单条，避免每次发送都走 loadChatSessions + saveChatSessions 触发全量会话预览重算（会话/消息多了以后会明显卡顿）。

4. 2627c1b feat(chat): 预设「剔除文本」功能——模型回复直接删除指定文本（不经过正则）。
   背景说明：某些模型（深度思考类）会在回复里输出 <!--thinkingend--> 之类结束标记，属于多余文字但又不得不输出。曾尝试用正则隐藏、以及不注入输入等方式处理，但会造成明显卡顿（每条消息每次渲染都重新编译正则、回溯匹配）。无奈之下做了这个「剔除文本」功能：预设里配置一行一个的文本片段，模型回复生成时直接字面量删除（split/join），不进入消息、不进入发给模型的记录，不走正则，无编译/回溯开销。

本批文件（3 个，均在贡献白名单内）：
lib/chat-engine.ts、lib/group-chat-engine.ts、lib/chat-storage.ts

验证：功能在 fork 本地均实测通过（流式按会话开关、思维链标签提取与剥离、剔除文本、正则缓存、会话预览增量）。

---
_经小手机「共同建设」通道提交_