### PR TITLE
善后(3/3)：聊天流式按会话拆分 + 思维链标签绑定预设 + 正则编译缓存 + 会话预览增量 + 预设剔除文本（对 #130/#131/#132 的优化完善）

### DIFF
--- a/components/settings/preset-manager.tsx
+++ b/components/settings/preset-manager.tsx
@@ -954,6 +954,73 @@ export function PresetManager({ isActive = true }: { isActive?: boolean } = {}) 
                                                                 用于从剧情模式和聊天线下模式的原始 XML 输出中提取事件摘要字段名。默认读取 {"<summary>"}。
                                                             </div>
                                                         </div>
+                                                        <div className="flex flex-col gap-2 col-span-full">
+                                                            <label className="ui-slider-label">剧情/线下模式思维链字段</label>
+                                                            <input
+                                                                type="text"
+                                                                value={preset.thinking_tag || "thinking"}
+                                                                onChange={(e) => updatePreset(preset.id, { thinking_tag: e.target.value })}
+                                                                placeholder="thinking"
+                                                                className="ui-input"
+                                                            />
+                                                            <div className="ui-slider-hint">
+                                                                从线下模式原始 XML 中提取思考过程（思维链）的字段名。仅当下方「线下思维链解析」开启时生效；关闭时走模型原生思维链。
+                                                            </div>
+                                                        </div>
+                                                        <div className="flex flex-col gap-2 col-span-full">
+                                                            <label className="ui-slider-label">线上模式思维链字段</label>
+                                                            <input
+                                                                type="text"
+                                                                value={preset.online_thinking_tag || "thinking"}
+                                                                onChange={(e) => updatePreset(preset.id, { online_thinking_tag: e.target.value })}
+                                                                placeholder="thinking"
+                                                                className="ui-input"
+                                                            />
+                                                            <div className="ui-slider-hint">
+                                                                从线上模式 AI 输出中提取思考过程（思维链）的标签字段名。仅当下方「线上思维链解析」开启时生效；关闭时走模型原生思维链。
+                                                            </div>
+                                                        </div>
+                                                        <div className="flex items-center justify-between gap-3 col-span-full">
+                                                            <div className="flex flex-col gap-1">
+                                                                <label className="ui-slider-label">线上思维链解析</label>
+                                                                <span className="ui-slider-hint">开启后按上方标签字段解析线上思维链；关闭走模型原生思维链（官方默认）</span>
+                                                            </div>
+                                                            <label className="ui-mini-toggle" onClick={(e) => e.stopPropagation()}>
+                                                                <input
+                                                                    type="checkbox"
+                                                                    checked={preset.online_thinking_enabled === true}
+                                                                    onChange={(e) => updatePreset(preset.id, { online_thinking_enabled: e.target.checked })}
+                                                                />
+                                                            </label>
+                                                        </div>
+                                                        <div className="flex items-center justify-between gap-3 col-span-full">
+                                                            <div className="flex flex-col gap-1">
+                                                                <label className="ui-slider-label">线下思维链解析</label>
+                                                                <span className="ui-slider-hint">开启后按「剧情/线下模式思维链字段」解析线下思维链；关闭走模型原生思维链（官方默认）</span>
+                                                            </div>
+                                                            <label className="ui-mini-toggle" onClick={(e) => e.stopPropagation()}>
+                                                                <input
+                                                                    type="checkbox"
+                                                                    checked={preset.offline_thinking_enabled === true}
+                                                                    onChange={(e) => updatePreset(preset.id, { offline_thinking_enabled: e.target.checked })}
+                                                                />
+                                                            </label>
+                                                        </div>
+                                                        <div className="flex flex-col gap-2 col-span-full">
+                                                            <label className="ui-slider-label">剔除文本（一行一个）</label>
+                                                            <textarea
+                                                                rows={3}
+                                                                value={(preset.strip_texts || []).join("\n")}
+                                                                onChange={(e) => updatePreset(preset.id, {
+                                                                    strip_texts: e.target.value.split("\n").map(s => s.trim()).filter(Boolean),
+                                                                })}
+                                                                placeholder={"<思考结束>\n</思考结束>"}
+                                                                className="ui-input"
+                                                            />
+                                                            <div className="ui-slider-hint">
+                                                                模型回复中出现这些文本时直接删除，不进入消息、不进入发给模型的记录（如思维链残留标签）。字面量删除，不走正则。
+                                                            </div>
+                                                        </div>
                                                     </div>
                                                 </div>
                                             )}

--- a/lib/chat-offline-storage.ts
+++ b/lib/chat-offline-storage.ts
@@ -14,6 +14,8 @@ export type ChatOfflineTurn = {
     summaryTag: string;
     rawText?: string;
     reasoningText?: string; // 模型思维链（reasoning/CoT）内容
+    thinkingText?: string; // 预设格式 <thinking> 标签解析出的思维链（展示优先于 reasoningText）
+    thinkingTag?: string; // 实际用于提取思维链的标签名（preset.thinking_tag 或默认 thinking）
     createdAt: string;
 };
 
@@ -30,6 +32,8 @@ export type ParsedOfflineResponse = {
     content: string;
     summary: string;
     summaryTag: string;
+    thinking?: string; // 预设格式 <thinking> 标签内容（与模型 API 原生 reasoning 无关）
+    thinkingTag?: string; // 实际用于提取思维链的标签名
 };
 
 function storageKey(sessionId: string): string {
@@ -54,6 +58,8 @@ function normalizeTurn(value: unknown): ChatOfflineTurn | null {
         summary: typeof item.summary === "string" ? item.summary : "",
         summaryTag: typeof item.summaryTag === "string" && item.summaryTag.trim() ? item.summaryTag.trim() : "summary",
         rawText: typeof item.rawText === "string" ? item.rawText : undefined,
+        thinkingText: typeof item.thinkingText === "string" ? item.thinkingText : undefined,
+        thinkingTag: typeof item.thinkingTag === "string" ? item.thinkingTag : undefined,
         createdAt: item.createdAt,
     };
 }
@@ -92,6 +98,8 @@ export function appendChatOfflineTurn(input: {
     summaryTag: string;
     rawText?: string;
     reasoningText?: string;
+    thinkingText?: string;
+    thinkingTag?: string;
 }): ChatOfflineTurn {
     const turn: ChatOfflineTurn = {
         id: createTurnId(),
@@ -102,6 +110,8 @@ export function appendChatOfflineTurn(input: {
         summaryTag: input.summaryTag.trim() || "summary",
         rawText: input.rawText,
         reasoningText: input.reasoningText,
+        thinkingText: input.thinkingText,
+        thinkingTag: input.thinkingTag,
         createdAt: new Date().toISOString(),
     };
     saveChatOfflineTurns(input.sessionId, [...loadChatOfflineTurns(input.sessionId), turn]);
@@ -111,7 +121,7 @@ export function appendChatOfflineTurn(input: {
 export function updateChatOfflineTurn(
     sessionId: string,
     turnId: string,
-    patch: Partial<Pick<ChatOfflineTurn, "userContent" | "assistantContent" | "summary" | "summaryTag" | "rawText" | "reasoningText">>,
+    patch: Partial<Pick<ChatOfflineTurn, "userContent" | "assistantContent" | "summary" | "summaryTag" | "rawText" | "reasoningText" | "thinkingText" | "thinkingTag">>,
 ): ChatOfflineTurn | null {
     let updated: ChatOfflineTurn | null = null;
     const turns = loadChatOfflineTurns(sessionId).map((turn) => {
@@ -207,12 +217,23 @@ function stripXmlField(rawText: string, tag: string): string {
     return rawText.replace(new RegExp(`<${escaped}>[\\s\\S]*?</${escaped}>`, "gi"), "").trim();
 }
 
+/** 从原始输出中提取指定标签包裹的思维链（仅当预设开启标签解析时调用）。
+ *  默认标签 thinking 时兼容 thought。 */
+export function extractThinkingTag(rawText: string, tag?: string): string {
+    const effective = (tag || "thinking").trim() || "thinking";
+    const tags = effective === "thinking" ? ["thinking", "thought"] : [effective];
+    return extractXmlField(rawText.trim(), tags).trim();
+}
+
 export function parseOfflineResponse(rawText: string, summaryTag: string): ParsedOfflineResponse {
     const trimmed = rawText.trim();
     const effectiveSummaryTag = summaryTag.trim() || "summary";
     const summary = extractXmlField(trimmed, [effectiveSummaryTag, "summary"]);
-    const content = extractXmlField(trimmed, ["content"])
-        || stripXmlField(stripXmlField(trimmed, effectiveSummaryTag), "summary");
+    let content = extractXmlField(trimmed, ["content"]);
+    if (!content) {
+        // 无 <content> 标签时回退到剥掉摘要标签后的全文
+        content = stripXmlField(stripXmlField(trimmed, effectiveSummaryTag), "summary");
+    }
     return {
         rawText: trimmed,
         content: content.trim(),

--- a/lib/llm-prompt-assembler.ts
+++ b/lib/llm-prompt-assembler.ts
@@ -1338,25 +1338,38 @@ export type RegexContext = {
     isEdit?: boolean;        // true when user is editing a message
     depth?: number;          // message depth (0 = latest)
     activeTags?: string[];   // current app tags used for tag-scoped rule filtering
-    history?: boolean;       // true when the block is a chat history message (historyOnly rules only fire here)
     macroEngine?: MacroEngine;  // for {{char}} etc. in findRegex & replaceString
+    history?: boolean;       // true when the block is a chat history message (historyOnly rules only fire here)
 };
+
+/**
+ * 编译缓存：同一 findRegex 字符串复用编译结果。
+ * 显示层每条消息每次渲染都会命中相同规则，之前每次都 new RegExp 重新编译，
+ * 匹配替换走慢路径的会话（如含 <思考结束> 残留标签）会明显卡顿。
+ */
+const _regexFromStringCache = new Map<string, RegExp | null>();
 
 /**
  * Parse a regex string like `/pattern/flags` into a RegExp.
  * Returns null if invalid. Does NOT force any flags — uses exactly what the user wrote.
  */
 function regexFromString(input: string): RegExp | null {
+    if (_regexFromStringCache.has(input)) return _regexFromStringCache.get(input)!;
+    let compiled: RegExp | null = null;
     try {
         const m = input.match(/(\/?)(.+)\1([a-z]*)/i);
-        if (!m) return null;
-        if (m[3] && !/^(?!.*?(.).*?\1)[dgimsuyv]+$/.test(m[3])) {
-            return new RegExp(input);
+        if (m) {
+            if (m[3] && !/^(?!.*?(.).*?\1)[dgimsuyv]+$/.test(m[3])) {
+                compiled = new RegExp(input);
+            } else {
+                compiled = new RegExp(m[2], m[3]);
+            }
         }
-        return new RegExp(m[2], m[3]);
     } catch {
-        return null;
+        compiled = null;
     }
+    _regexFromStringCache.set(input, compiled);
+    return compiled;
 }
 
 /** Escape special regex chars in a macro value so it can be embedded in a findRegex pattern. */

--- a/lib/settings-types.ts
+++ b/lib/settings-types.ts
@@ -82,6 +82,19 @@ export type PresetConfig = SettingItemMeta & {
     scenario_format?: string;
     personality_format?: string;
     story_summary_tag?: string;
+    /** 线下/剧情模式的思维链标签名：从模型输出的 XML 里提取思考过程（默认 thinking，兼容 thought）。
+     *  仅当 offline_thinking_enabled 开启时才启用标签解析；关闭时走模型原生 reasoning。 */
+    thinking_tag?: string;
+    /** 线上模式的思维链标签名：从模型输出的 XML 里提取思考过程（默认 thinking）。
+     *  仅当 online_thinking_enabled 开启时才启用标签解析；关闭时走模型原生 reasoning。 */
+    online_thinking_tag?: string;
+    /** 线上模式是否启用思维链标签解析（默认关；关 = 走模型原生 reasoning） */
+    online_thinking_enabled?: boolean;
+    /** 线下模式是否启用思维链标签解析（默认关；关 = 走模型原生 reasoning） */
+    offline_thinking_enabled?: boolean;
+    /** 模型回复中直接剔除的文本片段列表（字面量删除，不走正则）：如 <思考结束> 等残留标签，
+     *  生成时即删除，不进入消息、不进入发给模型的记录。 */
+    strip_texts?: string[];
     prompt_order?: PromptOrderEntry[];
     prompts: Prompt[];
 };


### PR DESCRIPTION
贡献者：温铎（@yechen1844）

本 PR 是「善后」提交（批次 3/3，最后一批；批次 1=chat-engine/group-chat-engine/chat-storage 见 #136，批次 2=chat-room/chat-settings-panel 见 #138）。包含 4 个后续提交，均为对之前已提交功能的优化与完善，部分改动建立在 #130「AI 调用日志重构」、#131「大模型调用日志 UI/思维链」、#132「聊天流式生成」之上，请优先合并 #130/#131/#132 后再合入（或一并处理）。

改动明细（4 个提交）：

1. bc21d89 feat(chat): 流式生成按会话拆分（线上/线下独立开关）+ 思维链标签解析绑定预设
   - 对 #132 流式功能的完善：删除全局流式开关 streamChatGeneration，改为会话级 streamOnline / streamOffline（默认关，不改变原整段请求行为），单聊/群聊均生效。
   - 对 #131 思维链功能的完善：预设新增线上思维链字段 online_thinking_tag 与线上/线下解析开关（默认关）；parseOfflineResponse 回归官方两参数；关闭标签解析时线上/线下均走模型原生思维链（官方默认行为），开启才按标签提取并剥离。

2. 3e0282f perf(chat): 正则规则编译缓存——同一 findRegex 字符串复用编译结果，消除显示层/记录层每次渲染重复 new RegExp 的卡顿（匹配替换走慢路径的会话，如含 <思考结束> 残留标签，之前会明显卡顿）。

3. 68823e6 perf(chat): 发送消息不再全量刷新会话预览——直接增量更新内存会话缓存并异步写单条，避免每次发送都走 loadChatSessions + saveChatSessions 触发全量会话预览重算（会话/消息多了以后会明显卡顿）。

4. 2627c1b feat(chat): 预设「剔除文本」功能——模型回复直接删除指定文本（不经过正则）。
   背景说明：某些模型（深度思考类）会在回复里输出 <!--thinkingend--> 之类结束标记，属于多余文字但又不得不输出。曾尝试用正则隐藏、以及不注入输入等方式处理，但会造成明显卡顿（每条消息每次渲染都重新编译正则、回溯匹配）。无奈之下做了这个「剔除文本」功能：预设里配置一行一个的文本片段，模型回复生成时直接字面量删除（split/join），不进入消息、不进入发给模型的记录，不走正则，无编译/回溯开销。

本批文件（4 个，均在贡献白名单内）：
components/settings/preset-manager.tsx、lib/chat-offline-storage.ts、lib/llm-prompt-assembler.ts、lib/settings-types.ts

验证：功能在 fork 本地均实测通过（流式按会话开关、思维链标签提取与剥离、剔除文本、正则缓存、会话预览增量）。

---
_经小手机「共同建设」通道提交_