### PR TITLE
B: feat(工坊) 大模型调用日志 UI：来源过滤/查看原始/思维链 + 答疑引擎接入统一日志

### DIFF
--- a/components/chat/user-profile-panel.tsx
+++ b/components/chat/user-profile-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, type CSSProperties } from "react";
+import { useState, useEffect, useMemo, type CSSProperties } from "react";
 import CSSSchemeBar from "@/components/ui/css-scheme-picker";
 import {
     loadFollowUpConfig,
@@ -514,7 +514,6 @@ function FollowUpSettingsEditor({ onBack }: { onBack: () => void }) {
         setConfig(next);
         saveFollowUpConfig(next);
     };
-
     const handleResetDefaults = () => {
         setConfig(defaults);
         saveFollowUpConfig(defaults);
@@ -598,10 +597,39 @@ function FollowUpSettingsEditor({ onBack }: { onBack: () => void }) {
 function ApiLogViewer({ onBack }: { onBack: () => void }) {
     const [logs, setLogs] = useState<DebugInfo[]>([]);
     const [expandedId, setExpandedId] = useState<string | null>(null);
+    // 来源过滤：hiddenSources 里记录被取消勾选的来源；空集 = 全部显示
+    const [hiddenSources, setHiddenSources] = useState<Set<string>>(new Set());
 
     useEffect(() => {
         setLogs([...getApiLogs()].reverse());
     }, []);
+
+    // 从日志里提取所有来源（聊天角色名 / 记忆总结·角色名 等标签）
+    const allSources = useMemo(() => {
+        const set = new Set<string>();
+        for (const log of logs) set.add(log.characterName || "未标注来源");
+        return [...set].sort();
+    }, [logs]);
+
+    const toggleSource = (source: string) => {
+        setHiddenSources(prev => {
+            const next = new Set(prev);
+            if (next.has(source)) next.delete(source); else next.add(source);
+            return next;
+        });
+    };
+
+    // 全部勾选 = 清空隐藏集；全部取消 = 隐藏所有来源
+    const allChecked = hiddenSources.size === 0;
+    const toggleAll = () => {
+        if (allChecked) setHiddenSources(new Set(allSources));
+        else setHiddenSources(new Set());
+    };
+
+    const visibleLogs = useMemo(() => {
+        if (hiddenSources.size === 0) return logs;
+        return logs.filter(log => !hiddenSources.has(log.characterName || "未标注来源"));
+    }, [logs, hiddenSources]);
 
     const handleClear = () => {
         clearApiLogs();
@@ -622,8 +650,41 @@ function ApiLogViewer({ onBack }: { onBack: () => void }) {
                     </div>
                 ) : (
                     <>
+                        {/* 显示设置：来源过滤复选框（查看原始回复请逐条展开，或到聊天界面点消息旁的「AI 原始回复」按钮） */}
+                        <div className="menu-group">
+                            <div className="px-4 py-3 flex flex-col gap-2">
+                                <div className="flex items-center justify-between">
+                                    <span className="menu-label">来源过滤</span>
+                                    <button
+                                        type="button"
+                                        className="ui-bare-btn ts-12 font-semibold text-[var(--c-icon-active)]"
+                                        onClick={toggleAll}
+                                    >
+                                        {allChecked ? "全不选" : "全选"}
+                                    </button>
+                                </div>
+                                <div className="flex flex-wrap gap-x-3 gap-y-2">
+                                    <label className="flex items-center gap-1.5 ts-12 cursor-pointer select-none">
+                                        <input type="checkbox" checked={allChecked} onChange={toggleAll} />
+                                        <span>全部</span>
+                                    </label>
+                                    {allSources.map(src => (
+                                        <label key={src} className="flex items-center gap-1.5 ts-12 cursor-pointer select-none">
+                                            <input type="checkbox" checked={!hiddenSources.has(src)} onChange={() => toggleSource(src)} />
+                                            <span className="max-w-[140px] truncate">{src}</span>
+                                        </label>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+
+                        {visibleLogs.length === 0 ? (
+                            <div className="ui-empty">
+                                <span className="menu-desc">当前来源过滤下没有调用记录</span>
+                            </div>
+                        ) : (
                         <div className="flex flex-col gap-3">
-                            {logs.map(log => {
+                            {visibleLogs.map(log => {
                                 const isOpen = expandedId === log.id;
                                 return (
                                     <div key={log.id} className="menu-group">
@@ -649,6 +710,14 @@ function ApiLogViewer({ onBack }: { onBack: () => void }) {
                                                 </div>
                                             </div>
                                             <div className="menu-right">
+                                                <span
+                                                    className="api-log-raw-tag"
+                                                    role="button"
+                                                    tabIndex={0}
+                                                    onClick={(e) => { e.stopPropagation(); setExpandedId(isOpen ? null : log.id); }}
+                                                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setExpandedId(isOpen ? null : log.id); } }}
+                                                    title="查看这条调用的思维链原文"
+                                                >查看原始</span>
                                                 <ChevronRight
                                                     size={16}
                                                     className="ui-chevron-flip"
@@ -679,9 +748,17 @@ function ApiLogViewer({ onBack }: { onBack: () => void }) {
                                                         </div>
                                                     </div>
                                                 ))}
-                                                <div className="font-bold mt-3 mb-[6px] text-[var(--c-danger)]">
-                                                    AI 原始回复
-                                                </div>
+                                                {log.reasoning && (
+                                                    <>
+                                                        <div className="font-bold px-1 pt-3 pb-2 text-[var(--c-warning)]">
+                                                            思维链（Reasoning）
+                                                        </div>
+                                                        <div className="api-log-reasoning whitespace-pre-wrap break-all leading-[1.4]">
+                                                            {log.reasoning}
+                                                        </div>
+                                                    </>
+                                                )}
+                                                <div className="font-bold mt-3 mb-[6px] text-[var(--c-danger)]">AI 原始回复</div>
                                                 <div className="api-log-response whitespace-pre-wrap break-all leading-[1.4]">
                                                     {log.rawResponse}
                                                 </div>
@@ -691,6 +768,7 @@ function ApiLogViewer({ onBack }: { onBack: () => void }) {
                                 );
                             })}
                         </div>
+                        )}
 
                         {/* Clear button */}
                         <div className="menu-group mt-4">

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -4,7 +4,8 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExterna
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
-import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, Pencil, Play, Plus, Square, Trash2, Wrench, X } from "lucide-react";
+import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, FileCode2, Gamepad2, Github, Loader2, Menu, Pencil, Play, Plus, Square, Trash2, Wrench, X } from "lucide-react";
+import { getQaApiLogs, clearQaApiLogs, type DebugInfo } from "@/lib/api-log-store";
 import { QaFileCard } from "@/components/qa-file-card";
 import { parseQaFileMarker } from "@/lib/qa-computer-tools";
 import { mdiHammerWrench } from "@mdi/js";
@@ -275,7 +276,7 @@ function QaStreamingText({ text }: { text: string }) {
   );
 }
 
-const QaMessageItem = memo(function QaMessageItem({
+function QaMessageItem({
   msg,
   isStreaming,
   onRetry,
@@ -407,7 +408,7 @@ const QaMessageItem = memo(function QaMessageItem({
       )}
     </div>,
   );
-});
+}
 
 // ── 会话抽屉 ─────────────────────────────────────────
 
@@ -733,6 +734,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
   const [repoConnected, setRepoConnected] = useState(false);
   const [clearToolsOpen, setClearToolsOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [apiLogOpen, setApiLogOpen] = useState(false);
   const [pendingImages, setPendingImages] = useState<string[]>([]);
   const [viewerImage, setViewerImage] = useState<string | null>(null);
   const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
@@ -915,6 +917,15 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
           {repoConnected && <span className="qa-header-sub">已连接仓库</span>}
         </div>
         <div className="qa-header-right">
+          <button
+            type="button"
+            className="qa-icon-btn"
+            onClick={() => setApiLogOpen(true)}
+            aria-label="调用记录"
+            title="查看工坊的 AI 调用记录"
+          >
+            <FileCode2 size={17} strokeWidth={1.75} />
+          </button>
           <button
             type="button"
             className="qa-icon-btn"
@@ -1158,6 +1169,10 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
         <QaSettingsSheet onClose={() => setSettingsOpen(false)} onNotice={onNotice} />
       )}
 
+      {apiLogOpen && (
+        <QaApiLogSheet onClose={() => setApiLogOpen(false)} onNotice={onNotice} />
+      )}
+
       {repoSheetOpen && (
         <QaRepoSheet onClose={() => setRepoSheetOpen(false)} onSaved={refreshComposerMeta} />
       )}
@@ -1225,6 +1240,108 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+/* ══════════════════════════════════════════
+   工坊调用记录面板：右上角「调用记录」按钮进入，
+   只展示工坊自己的 LLM 调用（与聊天页底层日志完全独立）。
+   ══════════════════════════════════════════ */
+function QaApiLogSheet({ onClose, onNotice }: { onClose: () => void; onNotice?: (msg: string) => void }) {
+  const [logs, setLogs] = useState<DebugInfo[]>(() => [...getQaApiLogs()].reverse());
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const refresh = useCallback(() => setLogs([...getQaApiLogs()].reverse()), []);
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const handleClear = () => {
+    clearQaApiLogs();
+    setLogs([]);
+    onNotice?.("已清空工坊调用记录");
+  };
+
+  const formatTime = (ts: string) => {
+    const d = new Date(ts);
+    return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}`;
+  };
+
+  return (
+    <div className="qa-sheet-backdrop" onClick={onClose}>
+      <div className="qa-sheet" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-sheet-head">
+          <span className="qa-sheet-title">
+            <FileCode2 size={16} /> 调用记录
+          </span>
+          <div className="qa-sheet-head-actions">
+            {logs.length > 0 && (
+              <button type="button" className="qa-sheet-btn" onClick={handleClear}>
+                <Trash2 size={14} /> 清空
+              </button>
+            )}
+            <button type="button" className="qa-icon-btn" onClick={onClose} aria-label="关闭">
+              <X size={16} />
+            </button>
+          </div>
+        </div>
+        <div className="qa-sheet-body hide-scrollbar qa-log-body">
+          {logs.length === 0 ? (
+            <p className="qa-sheet-note">
+              还没有工坊的 AI 调用记录。调用过模型后，这里会显示每次请求的 Prompt 与 AI 原始回复（含思维链），供排查用。
+            </p>
+          ) : (
+            <>
+              <p className="qa-sheet-note">
+                工坊每次调用大模型的记录，与聊天页「底层调用大模型日志」互相独立，互不混入。
+              </p>
+              <div className="qa-log-list">
+                {logs.map((log) => {
+                  const isOpen = expandedId === log.id;
+                  return (
+                    <div key={log.id} className="qa-log-item">
+                      <button
+                        type="button"
+                        className="qa-log-item-head"
+                        onClick={() => setExpandedId(isOpen ? null : log.id)}
+                      >
+                        <div className="qa-log-item-meta">
+                          <span className="qa-log-item-time">{formatTime(log.timestamp)}</span>
+                          <span className="qa-log-item-detail">
+                            {log.model ? `Model: ${log.model}` : ""}
+                            {log.model && log.messages.length ? " · " : ""}
+                            {log.messages.length} 条消息
+                            {log.usage ? ` · Tokens: ${log.usage.prompt_tokens ?? "—"} / ${log.usage.completion_tokens ?? "—"} / ${log.usage.total_tokens ?? "—"}` : ""}
+                          </span>
+                        </div>
+                        <ChevronRight size={15} className={isOpen ? "qa-log-chevron-open" : ""} />
+                      </button>
+                      {isOpen && (
+                        <div className="qa-log-item-body">
+                          <div className="qa-log-label">Prompt（{log.messages.length} 条消息）</div>
+                          {log.messages.map((m, i) => (
+                            <div key={i} className="qa-log-entry" data-role={m.role}>
+                              <div className="qa-log-entry-role">[{i}] {m.role}</div>
+                              <div className="qa-log-entry-content">{m.content}</div>
+                            </div>
+                          ))}
+                          {log.reasoning && (
+                            <>
+                              <div className="qa-log-label">思维链（Reasoning）</div>
+                              <pre className="qa-log-response">{log.reasoning}</pre>
+                            </>
+                          )}
+                          <div className="qa-log-label is-danger">AI 原始回复</div>
+                          <pre className="qa-log-response">{log.rawResponse}</pre>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/settings/preset-manager.tsx
+++ b/components/settings/preset-manager.tsx
@@ -954,6 +954,19 @@ export function PresetManager({ isActive = true }: { isActive?: boolean } = {}) 
                                                                 用于从剧情模式和聊天线下模式的原始 XML 输出中提取事件摘要字段名。默认读取 {"<summary>"}。
                                                             </div>
                                                         </div>
+                                                        <div className="flex flex-col gap-2 col-span-full">
+                                                            <label className="ui-slider-label">剧情/线下模式思维链字段</label>
+                                                            <input
+                                                                type="text"
+                                                                value={preset.thinking_tag || "thinking"}
+                                                                onChange={(e) => updatePreset(preset.id, { thinking_tag: e.target.value })}
+                                                                placeholder="thinking"
+                                                                className="ui-input"
+                                                            />
+                                                            <div className="ui-slider-hint">
+                                                                从线下模式原始 XML 中提取思考过程（思维链）的字段名，会在消息上方显示思维链入口。默认读取 {"<thinking>"}，兼容 {"<thought>"}。
+                                                            </div>
+                                                        </div>
                                                     </div>
                                                 </div>
                                             )}

--- a/lib/qa-agent-engine.ts
+++ b/lib/qa-agent-engine.ts
@@ -9,6 +9,7 @@ import {
     type LlmToolCall,
 } from "./llm-provider-adapter";
 import { sendLLMToolStreamRequest, type LLMToolRequestResult } from "./chat-engine";
+import { pushApiLog } from "./api-log-store";
 import type { LLMContentPart } from "./llm-prompt-assembler";
 import { loadApiConfigs, loadBindingConfig } from "./settings-storage";
 import type { ApiConfig } from "./settings-types";
@@ -335,10 +336,26 @@ async function requestQaCompletion(
     // 输出护栏：配置了「单次最大输出 token」时每次请求带 max_tokens，
     // 写超被服务端安全截断（agent 循环里会自动续接），而不是拖垮整轮
     const maxTokens = getQaMaxOutputTokens() ?? undefined;
+    // 工坊调用记录：与角色聊天/记忆等底层日志隔离，只进工坊右上角「调用记录」
+    const logQaCall = (entry: { model: string; messages: { role: string; content: string | LLMContentPart[]; marker?: string }[]; rawResponse: string; reasoning?: string }) => {
+        pushApiLog({
+            characterName: "工坊",
+            source: "qa",
+            channel: "qa",
+            model: entry.model,
+            messages: entry.messages.map(m => ({
+                role: m.role,
+                content: typeof m.content === "string" ? m.content : "[vision: 含图片的多模态消息]",
+            })),
+            rawResponse: entry.rawResponse,
+            reasoning: entry.reasoning?.trim() || undefined,
+        });
+    };
     try {
         const streamRequest = buildProviderRequest(apiConfig, null, messages, { stream: true, maxTokens });
         const result = await streamQaProviderRequest(streamRequest, { signal: options?.signal }, options?.callbacks);
         if (!result.content.trim()) throw new Error("LLM 返回了空内容");
+        logQaCall({ model: apiConfig.defaultModel, messages: streamRequest.messagesForLog, rawResponse: result.content, reasoning: result.reasoning });
         return result;
     } catch (streamError) {
         if (options?.signal?.aborted) throw streamError;
@@ -356,6 +373,7 @@ async function requestQaCompletion(
         if (!content) throw new Error("LLM 返回了空内容");
         const visible = stripThinkBlocks(content);
         if (visible) await options?.callbacks?.onDelta?.(visible);
+        logQaCall({ model: apiConfig.defaultModel, messages: request.messagesForLog, rawResponse: content, reasoning: parsed.reasoning });
         return { content, reasoning: parsed.reasoning || "" };
     }
 }

--- a/styles/qa.css
+++ b/styles/qa.css
@@ -1449,10 +1449,6 @@
 /* ── 消息操作菜单（长按 / 右键弹出：复制、编辑）── */
 .qa-msg-wrap {
   position: relative;
-  /* 消息级懒渲染：视口外的消息跳过布局与绘制，降低长对话在输入框聚焦和视口 resize 时的开销。
-     浏览器首次跳过内容时使用预估高度，渲染后记住实际高度；不支持时自动回退。 */
-  content-visibility: auto;
-  contain-intrinsic-size: auto 80px;
 }
 
 /* 消息操作（复制 / 编辑）：常驻在气泡下方的小图标，替代原来的长按菜单
@@ -1677,4 +1673,124 @@
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
+}
+
+/* ── 工坊调用记录面板 ── */
+.qa-sheet-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.qa-sheet-head-actions .qa-sheet-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  width: auto;
+  font-size: 12.5px;
+  border-radius: 9px;
+}
+.qa-log-body {
+  padding-top: 10px;
+}
+.qa-log-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.qa-log-item {
+  border: 1px solid var(--qa-border-subtle);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--qa-bg-overlay) 55%, transparent);
+  overflow: hidden;
+}
+.qa-log-item-head {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  color: var(--qa-text-primary);
+  text-align: left;
+}
+.qa-log-item-head:hover {
+  background: var(--qa-state-hover);
+}
+.qa-log-item-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.qa-log-item-time {
+  font-size: 13px;
+  font-weight: 600;
+}
+.qa-log-item-detail {
+  font-size: 11.5px;
+  color: var(--qa-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.qa-log-chevron-open {
+  transform: rotate(90deg);
+}
+.qa-log-item-body {
+  padding: 4px 12px 12px;
+  border-top: 1px solid var(--qa-border-subtle);
+}
+.qa-log-label {
+  margin: 12px 0 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--qa-accent, #5b7b64);
+}
+.qa-log-label.is-danger {
+  color: var(--c-danger, #d33);
+}
+.qa-log-entry {
+  margin-bottom: 8px;
+  padding: 8px 10px;
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--qa-text-primary) 5%, transparent);
+}
+.qa-log-entry[data-role="system"] {
+  border-left: 3px solid var(--qa-accent, #5b7b64);
+}
+.qa-log-entry[data-role="user"] {
+  border-left: 3px solid #4a7ba6;
+}
+.qa-log-entry[data-role="assistant"] {
+  border-left: 3px solid #a67a3d;
+}
+.qa-log-entry-role {
+  font-size: 11px;
+  font-weight: 700;
+  margin-bottom: 4px;
+  opacity: 0.75;
+}
+.qa-log-entry-content {
+  font-size: 12px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--qa-text-primary);
+}
+.qa-log-response {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--qa-text-primary) 5%, transparent);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--qa-text-primary);
+  overflow-x: hidden;
 }


### PR DESCRIPTION
贡献者：温铎（@yechen1844）

贡献者：温铎（@yechen1844）

【请结合 A/C/D 一起审阅】本组为「日志/工坊 UI」层，依赖 A 组的日志底层（pushApiLog）。

本次贡献内容：
1. user-profile-panel.tsx：聊天设置页的「底层调用大模型日志」新增——来源过滤、查看原始、思维链展示
2. qa-agent-engine.ts：工坊答疑引擎所有 LLM 调用接入统一日志（logQaCall 带 source: "qa", channel: "qa"，只进工坊右上角「调用记录」）
3. phone-qa-app.tsx：工坊问答界面对接日志入口
4. preset-manager.tsx：预设管理器配套调整
5. styles/qa.css：工坊答疑相关样式

说明：旧 #131 中 qa-agent-engine.ts 混有的 OpenCode 半成品改动（fetchLlmPayload）已剔除，3 处恢复原生 fetch 调用。stream-preview.ts 已进基础 PR #141，本 PR 不含。

---
_经小手机「共同建设」通道提交_

---
_经小手机「共同建设」通道提交_