### PR TITLE
角色卡新增内外页图分开编辑功能+图像清晰优化

### DIFF
--- a/components/phone-character-app.tsx
+++ b/components/phone-character-app.tsx
@@ -280,9 +280,11 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
                 const nextVersion = createVersion
                   ? backupCharacterVersion(existing, "manual", "手动编辑前备份")
                   : overwriteCharacterVersion(existing.id);
+                const { archivePhoto: _legacyExistingArchivePhoto, ...cleanExisting } = existing;
+                const { archivePhoto: _legacyDataArchivePhoto, ...cleanData } = data;
                 const updated: Character = {
-                  ...existing,
-                  ...data,
+                  ...cleanExisting,
+                  ...cleanData,
                   updatedAt: new Date().toISOString(),
                 };
                 updateChars(characters.map((c) => (c.id === existing.id ? updated : c)));
@@ -301,8 +303,9 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
               const existing = view.id ? characters.find((c) => c.id === view.id) : null;
               if (!existing) return;
               const activeVersion = switchCharacterVersion(existing, version);
+              const { archivePhoto: _legacyVersionArchivePhoto, ...cleanVersionData } = version.data;
               const restored: Character = {
-                ...version.data,
+                ...cleanVersionData,
                 id: existing.id,
                 createdAt: existing.createdAt,
                 updatedAt: new Date().toISOString(),
@@ -418,14 +421,28 @@ function FlipTransitionOverlay({ transit }: { transit: TransitionState }) {
           </div>
         </div>
 
-        <div className="char-flipper-back">
-          {/* Scaled down or full archive rendering so it doesn't look weird */}
-          <div className="absolute top-0 left-0" style={{
-            width: targetWidth, height: targetHeight,
-            opacity: isFlipped ? 1 : 0.5,
-            transition: `opacity ${duration} ease`
-          }}>
-            <CharArchiveView dummy char={char} onBack={() => { }} onEdit={() => { }} onDelete={() => { }} onExportJson={() => { }} onExportPng={async () => { }} />
+        <div className="char-flipper-back" aria-hidden="true">
+          <div
+            className="char-flipper-paper"
+            style={{
+              width: targetWidth,
+              height: targetHeight,
+              opacity: isFlipped ? 1 : 0.5,
+              transition: `opacity ${duration} ease`,
+            }}
+          >
+            <div className="char-flipper-paper-stamp">CLASSIFIED</div>
+            <div className="char-flipper-paper-title">ARCHIVAL INFORMATION</div>
+            <div className="char-flipper-paper-rule" />
+            <div className="char-flipper-paper-grid">
+              <div className="char-flipper-paper-portrait">
+                {char.avatar ? <img src={char.avatar} alt="" /> : null}
+              </div>
+              <div>
+                <strong>{char.name || "UNNAMED"}</strong>
+                <span>THE INTELLIGENCE DATABASE</span>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -1835,7 +1852,8 @@ function CharArchiveView({
   const [timeZoneSearch, setTimeZoneSearch] = useState(char.timeZone || "");
   const [avatar, setAvatar] = useState<string | null>(char.avatar || null);
   const [archiveCover, setArchiveCover] = useState<CharacterImageDisplay | undefined>(() => normalizeCharacterImageDisplay(char.archiveCover));
-  const [archivePhoto, setArchivePhoto] = useState<CharacterImageDisplay | undefined>(() => normalizeCharacterImageDisplay(char.archivePhoto));
+  const [avatarCropSource, setAvatarCropSource] = useState<string | null>(null);
+  const [avatarCropError, setAvatarCropError] = useState("");
   const [polaroidStyle, setPolaroidStyle] = useState<number | undefined>(char.polaroidStyle);
   const [polaroidSize, setPolaroidSize] = useState<CharacterPolaroidSize | undefined>(char.polaroidSize);
   const [showUrlInput, setShowUrlInput] = useState(false);
@@ -1891,7 +1909,6 @@ function CharArchiveView({
     if (timeZone !== (char.timeZone || "")) return true;
     if (avatar !== (char.avatar || null)) return true;
     if (JSON.stringify(archiveCover) !== JSON.stringify(normalizeCharacterImageDisplay(char.archiveCover))) return true;
-    if (JSON.stringify(archivePhoto) !== JSON.stringify(normalizeCharacterImageDisplay(char.archivePhoto))) return true;
     if (polaroidStyle !== char.polaroidStyle) return true;
     if (polaroidSize !== char.polaroidSize) return true;
     const origTags = char.tags || [];
@@ -1920,21 +1937,31 @@ function CharArchiveView({
       setTags(char.tags || []);
       setAvatar(char.avatar || null);
       setArchiveCover(normalizeCharacterImageDisplay(char.archiveCover));
-      setArchivePhoto(normalizeCharacterImageDisplay(char.archivePhoto));
+      setAvatarCropSource(null);
+      setAvatarCropError("");
       setPolaroidStyle(char.polaroidStyle);
       setPolaroidSize(char.polaroidSize);
     }
   }, [isEditing, char]);
 
   async function handleAvatarFile(file: File) {
-    const url = await fileToDataUrl(file);
-    setAvatar(url);
+    try {
+      const url = await fileToDataUrl(file);
+      setAvatarCropError("");
+      setAvatarCropSource(url);
+    } catch (error) {
+      setAvatarCropError(error instanceof Error ? error.message : "读取头像文件失败");
+    }
   }
 
   function handleAvatarUrl() {
     const trimmed = urlInput.trim();
-    if (!isSafeCharacterImageUrl(trimmed)) return;
-    setAvatar(trimmed);
+    if (!isSafeCharacterImageUrl(trimmed)) {
+      setAvatarCropError("请输入 data:、http:// 或 https:// 图片地址");
+      return;
+    }
+    setAvatarCropError("");
+    setAvatarCropSource(trimmed);
     setShowUrlInput(false);
     setUrlInput("");
   }
@@ -1966,7 +1993,6 @@ function CharArchiveView({
         tags,
         avatar: avatar ?? null,
         archiveCover,
-        archivePhoto,
         polaroidStyle,
         polaroidSize,
       }, createVersion);
@@ -2020,13 +2046,6 @@ function CharArchiveView({
     : timeZoneOptions;
   const filteredTimeZoneOptions = matchedTimeZoneOptions.slice(0, 80);
   const hasMoreTimeZoneOptions = matchedTimeZoneOptions.length > filteredTimeZoneOptions.length;
-  const effectiveArchivePhoto: CharacterImageDisplay = {
-    image: archivePhoto?.image || avatar || null,
-    positionX: archivePhoto?.positionX ?? 50,
-    positionY: archivePhoto?.positionY ?? 50,
-    scale: archivePhoto?.scale ?? 1,
-  };
-
   function openTimeZonePicker() {
     setTimeZoneSearch(timeZone);
     setShowTimeZonePicker(true);
@@ -2074,8 +2093,8 @@ function CharArchiveView({
                 if (isEditing) fileRef.current?.click();
               }}
             >
-              {effectiveArchivePhoto.image ? (
-                <img src={effectiveArchivePhoto.image} alt="Archive portrait" style={getCharacterImageStyle(effectiveArchivePhoto)} />
+              {avatar ? (
+                <img src={avatar} alt="Archive portrait" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
               ) : (
                 <CharAvatarFallback name={name || char.name} size="100%" />
               )}
@@ -2098,6 +2117,24 @@ function CharArchiveView({
                 e.target.value = "";
               }}
             />
+            {isEditing && avatarCropSource && (
+              <AvatarCropEditor
+                source={avatarCropSource}
+                onConfirm={(croppedAvatar) => {
+                  setAvatar(croppedAvatar);
+                  setAvatarCropSource(null);
+                  setAvatarCropError("");
+                }}
+                onCancel={() => {
+                  setAvatarCropSource(null);
+                  setAvatarCropError("");
+                }}
+                onError={setAvatarCropError}
+              />
+            )}
+            {isEditing && avatarCropError && (
+              <div className="char-avatar-crop-error" role="alert">{avatarCropError}</div>
+            )}
             {isEditing && (
               <div className="mt-2 flex flex-col gap-1 w-full justify-center">
                 <button
@@ -2171,7 +2208,7 @@ function CharArchiveView({
         {isEditing && (
           <div className="char-image-diy-section">
             <div className="char-image-diy-title">DIY IMAGE PROFILE</div>
-            <p className="char-image-diy-help">封面用于档案墙；档案形象用于详情、剧情顶部和漫卷。可直接在预览图上拖动取景。</p>
+            <p className="char-image-diy-help">基础头像请在上方头像区域上传并裁剪；档案墙封面可独立设置并拖动取景，清除后会回退显示基础头像。</p>
             <CharacterImageEditor
               label="档案墙封面 / ARCHIVE COVER"
               value={archiveCover}
@@ -2179,13 +2216,6 @@ function CharArchiveView({
               fallbackName={name || char.name}
               aspectRatio={getPolaroidAspectRatio(polaroidStyle ?? 1)}
               onChange={setArchiveCover}
-            />
-            <CharacterImageEditor
-              label="基础档案形象 / ARCHIVE PHOTO"
-              value={archivePhoto}
-              fallbackImage={avatar}
-              fallbackName={name || char.name}
-              onChange={setArchivePhoto}
             />
             <div className="char-polaroid-options">
               <div>
@@ -2648,6 +2678,135 @@ function CharArchiveView({
 // The CharEditView component has been removed as editing is now inline within CharArchiveView.
 
 // ── 共享子组件 ───────────────────────────────────────
+
+function AvatarCropEditor({
+  source,
+  onConfirm,
+  onCancel,
+  onError,
+}: {
+  source: string;
+  onConfirm: (dataUrl: string) => void;
+  onCancel: () => void;
+  onError: (message: string) => void;
+}) {
+  const previewRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{ x: number; y: number; positionX: number; positionY: number } | null>(null);
+  const [positionX, setPositionX] = useState(50);
+  const [positionY, setPositionY] = useState(50);
+  const [scale, setScale] = useState(1);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    setPositionX(50);
+    setPositionY(50);
+    setScale(1);
+  }, [source]);
+
+  function handlePointerDown(event: React.PointerEvent<HTMLDivElement>) {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    dragRef.current = { x: event.clientX, y: event.clientY, positionX, positionY };
+  }
+
+  function handlePointerMove(event: React.PointerEvent<HTMLDivElement>) {
+    const start = dragRef.current;
+    const rect = previewRef.current?.getBoundingClientRect();
+    if (!start || !rect) return;
+    setPositionX(Math.min(100, Math.max(0, start.positionX - ((event.clientX - start.x) / rect.width) * 100 / scale)));
+    setPositionY(Math.min(100, Math.max(0, start.positionY - ((event.clientY - start.y) / rect.height) * 100 / scale)));
+  }
+
+  function stopDragging(event: React.PointerEvent<HTMLDivElement>) {
+    dragRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  }
+
+  async function confirmCrop() {
+    if (busy) return;
+    setBusy(true);
+    onError("");
+    try {
+      const image = await loadCropImage(source);
+      const outputSize = 400;
+      const coverScale = Math.max(outputSize / image.naturalWidth, outputSize / image.naturalHeight);
+      const drawWidth = image.naturalWidth * coverScale * scale;
+      const drawHeight = image.naturalHeight * coverScale * scale;
+      const drawX = (outputSize - drawWidth) * (positionX / 100);
+      const drawY = (outputSize - drawHeight) * (positionY / 100);
+      const canvas = document.createElement("canvas");
+      canvas.width = outputSize;
+      canvas.height = outputSize;
+      const context = canvas.getContext("2d");
+      if (!context) throw new Error("当前浏览器无法创建头像画布");
+      context.imageSmoothingEnabled = true;
+      context.imageSmoothingQuality = "high";
+      context.drawImage(image, drawX, drawY, drawWidth, drawHeight);
+      const result = canvas.toDataURL("image/png");
+      if (!result.startsWith("data:image/png")) throw new Error("头像导出失败");
+      onConfirm(result);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      onError(source.startsWith("http")
+        ? `无法裁剪该远程图片：${detail}。请改为上传本地图片，或使用允许跨域访问的图片地址。`
+        : `头像裁剪失败：${detail}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const previewStyle: React.CSSProperties = {
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+    objectPosition: `${positionX}% ${positionY}%`,
+    transform: `scale(${scale})`,
+    transformOrigin: `${positionX}% ${positionY}%`,
+  };
+
+  return (
+    <div className="char-avatar-crop-editor">
+      <div
+        ref={previewRef}
+        className="char-avatar-crop-preview"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={stopDragging}
+        onPointerCancel={stopDragging}
+      >
+        <img src={source} alt="头像裁剪预览" draggable={false} style={previewStyle} />
+        <span>拖动取景 · 1:1</span>
+      </div>
+      <div className="char-avatar-crop-controls">
+        <label>X <input type="range" min="0" max="100" step="1" value={positionX} onChange={event => setPositionX(Number(event.target.value))} /></label>
+        <label>Y <input type="range" min="0" max="100" step="1" value={positionY} onChange={event => setPositionY(Number(event.target.value))} /></label>
+        <label>缩放 <input type="range" min="1" max="3" step="0.05" value={scale} onChange={event => setScale(Number(event.target.value))} /></label>
+        <div className="char-avatar-crop-actions">
+          <button type="button" onClick={onCancel} disabled={busy}>取消</button>
+          <button type="button" onClick={confirmCrop} disabled={busy}>{busy ? "处理中…" : "确认裁剪"}</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function loadCropImage(source: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    if (/^https?:\/\//i.test(source)) image.crossOrigin = "anonymous";
+    image.onload = () => {
+      if (!image.naturalWidth || !image.naturalHeight) {
+        reject(new Error("图片尺寸无效"));
+        return;
+      }
+      resolve(image);
+    };
+    image.onerror = () => reject(new Error("图片加载失败"));
+    image.src = source;
+  });
+}
 
 function CharacterImageEditor({
   label,

--- a/components/phone-character-app.tsx
+++ b/components/phone-character-app.tsx
@@ -2713,8 +2713,22 @@ function AvatarCropEditor({
     onError("");
     try {
       const image = await loadCropImage(source);
-      const outputWidth = 450;
-      const outputHeight = 600;
+      const cropAspectRatio = 3 / 4;
+      const availableCropWidth = Math.min(
+        image.naturalWidth,
+        image.naturalHeight * cropAspectRatio,
+      ) / scale;
+      const availableCropHeight = availableCropWidth / cropAspectRatio;
+      const outputSizes = [
+        { width: 900, height: 1200 },
+        { width: 675, height: 900 },
+        { width: 450, height: 600 },
+      ];
+      const outputSize = outputSizes.find(size =>
+        availableCropWidth >= size.width && availableCropHeight >= size.height
+      ) ?? outputSizes[outputSizes.length - 1];
+      const outputWidth = outputSize.width;
+      const outputHeight = outputSize.height;
       const coverScale = Math.max(outputWidth / image.naturalWidth, outputHeight / image.naturalHeight);
       const drawWidth = image.naturalWidth * coverScale * scale;
       const drawHeight = image.naturalHeight * coverScale * scale;
@@ -2769,7 +2783,7 @@ function AvatarCropEditor({
         <label>Y <input type="range" min="0" max="100" step="1" value={positionY} onChange={event => setPositionY(Number(event.target.value))} /></label>
         <label>缩放 <input type="range" min="1" max="3" step="0.05" value={scale} onChange={event => setScale(Number(event.target.value))} /></label>
         <div className="char-avatar-crop-actions">
-          <button type="button" onClick={confirmCrop} disabled={busy}>{busy ? "处理中…" : "确认裁剪"}</button>
+          <button type="button" onClick={confirmCrop} disabled={busy}>{busy ? "处理中…" : "确认"}</button>
           <button type="button" onClick={onCancel} disabled={busy}>取消</button>
         </div>
       </div>

--- a/components/phone-character-app.tsx
+++ b/components/phone-character-app.tsx
@@ -1594,17 +1594,14 @@ function CharListView({
       {/* 转移世界 Modal */}
       {activeMoveChar && (
         <div className="modal-overlay" data-ui="modal" onPointerDown={() => setActiveMoveChar(null)}>
-          <div className="modal-dialog" data-ui="modal-dialog" onPointerDown={(e) => e.stopPropagation()} style={{ padding: 0, overflow: 'hidden' }}>
-            <div className="modal-header" data-ui="modal-header" style={{ padding: '20px 20px 10px' }}>
-              <h3 className="modal-title" style={{ margin: 0, fontSize: '16px' }}>档案卡片设置</h3>
-            </div>
-            <div style={{ padding: '4px 20px', fontSize: 12, color: '#777' }}>转移到其他卷宗</div>
-            <div role="listbox" style={{ maxHeight: '40dvh', padding: '10px 16px', overflowY: 'auto' }}>
+          <div className="char-move-world-dialog" role="dialog" aria-modal="true" aria-label="转移到其他卷宗" onPointerDown={(e) => e.stopPropagation()}>
+            <h3 className="char-move-world-title">转移到其他卷宗</h3>
+            <div className="char-move-world-list" role="listbox">
               {worldGroups.filter(g => g.id !== currentWorldId).map(group => (
                 <button
                   key={group.id}
                   type="button"
-                  style={{ width: '100%', padding: '12px 16px', textAlign: 'left', borderRadius: '8px', background: 'rgba(0,0,0,0.03)', marginBottom: '8px', border: '1px solid rgba(0,0,0,0.05)', fontWeight: '500', fontSize: '14px', color: '#333' }}
+                  className="char-move-world-option"
                   onClick={() => {
                     moveCharacterToWorld(activeMoveChar.id, group.id);
                     setActiveMoveChar(null);
@@ -1615,11 +1612,11 @@ function CharListView({
                 </button>
               ))}
               {worldGroups.filter(g => g.id !== currentWorldId).length === 0 && (
-                <div style={{ padding: '20px', textAlign: 'center', color: '#999' }}>没有其他卷宗可供转移</div>
+                <div className="char-move-world-empty">没有其他卷宗可供转移</div>
               )}
             </div>
-            <div className="modal-footer" data-ui="modal-footer" style={{ padding: '10px 20px 20px' }}>
-              <button className="ui-btn ui-btn-outline" style={{ width: '100%' }} onClick={() => setActiveMoveChar(null)}>取消</button>
+            <div className="char-move-world-footer">
+              <button type="button" className="char-move-world-cancel" onClick={() => setActiveMoveChar(null)}>取消</button>
             </div>
           </div>
         </div>

--- a/components/phone-character-app.tsx
+++ b/components/phone-character-app.tsx
@@ -1197,6 +1197,7 @@ function CharListView({
                   onEditTap={handleCharEditTap}
                   onDragMoveAt={handleCharDragMoveAt}
                   onDropAt={handleCharDropAt}
+                  use2dTransform
                   trashBinRef={trashBinRef}
                   onDragActiveChange={setIsAnyDragging}
                   onOverTrashChange={setOverTrashBin}
@@ -1630,7 +1631,7 @@ function CharListView({
 function DraggableNode({
   id, x, y, rot, zIndex, children, onDragEnd, onClick, className, w, isEditing, onDeleteIntent,
   trashBinRef, onDragActiveChange, onOverTrashChange, zoom = 1, pinchRef,
-  onEditTap, onDragMoveAt, onDropAt
+  onEditTap, onDragMoveAt, onDropAt, use2dTransform = false
 }: {
   id: string; x: number; y: number; rot: number; zIndex: number;
   children: React.ReactNode;
@@ -1649,6 +1650,8 @@ function DraggableNode({
   onDragMoveAt?: (clientX: number, clientY: number) => void;
   /** 松手时的落点处理；返回 true 表示已被消费（如归档进其他世界），位置回弹 */
   onDropAt?: (id: string, clientX: number, clientY: number) => boolean;
+  /** 档案墙角色卡使用二维变换，减少移动端合成层的额外采样 */
+  use2dTransform?: boolean;
 }) {
   const [pos, setPos] = useState({ x, y });
   const [isDragging, setIsDragging] = useState(false);
@@ -1770,7 +1773,7 @@ function DraggableNode({
       onClickCapture={handleClick}
       style={{
         width: w,
-        transform: `translate3d(${pos.x}px, ${pos.y}px, 0) rotate(${rot}deg)`,
+        transform: `${use2dTransform ? `translate(${pos.x}px, ${pos.y}px)` : `translate3d(${pos.x}px, ${pos.y}px, 0)`} rotate(${rot}deg)`,
         zIndex: isDragging ? 9999999 : zIndex,
         cursor: isDragging ? 'grabbing' : 'grab',
         touchAction: 'none',

--- a/components/phone-character-app.tsx
+++ b/components/phone-character-app.tsx
@@ -1929,7 +1929,7 @@ function CharArchiveView({
 
   async function handleAvatarFile(file: File) {
     try {
-      const url = await fileToDataUrl(file);
+      const url = await fileToDataUrl(file, { maxSize: 2560, quality: 0.92 });
       setAvatarCropError("");
       setAvatarCropSource(url);
     } catch (error) {
@@ -2914,7 +2914,7 @@ function CharacterImageEditor({
             className="hidden"
             onChange={async event => {
               const file = event.target.files?.[0];
-              if (file) patch({ image: await fileToDataUrl(file) });
+              if (file) patch({ image: await fileToDataUrl(file, { maxSize: 2560, quality: 0.92 }) });
               event.target.value = "";
             }}
           />
@@ -3004,22 +3004,25 @@ function AutoResizingTextarea({
 
 // ── 工具函数 ─────────────────────────────────────────
 
-function fileToDataUrl(file: File): Promise<string> {
+function fileToDataUrl(
+  file: File,
+  options: { maxSize?: number; quality?: number } = {},
+): Promise<string> {
+  const { maxSize = 400, quality = 0.8 } = options;
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => {
       const img = new Image();
       img.onload = () => {
-        const MAX_SIZE = 400;
         let w = img.width;
         let h = img.height;
-        if (w > MAX_SIZE || h > MAX_SIZE) {
+        if (w > maxSize || h > maxSize) {
           if (w > h) {
-            h = Math.round(h * MAX_SIZE / w);
-            w = MAX_SIZE;
+            h = Math.round(h * maxSize / w);
+            w = maxSize;
           } else {
-            w = Math.round(w * MAX_SIZE / h);
-            h = MAX_SIZE;
+            w = Math.round(w * maxSize / h);
+            h = maxSize;
           }
         }
         const canvas = document.createElement("canvas");
@@ -3027,10 +3030,11 @@ function fileToDataUrl(file: File): Promise<string> {
         canvas.height = h;
         const ctx = canvas.getContext("2d");
         if (!ctx) return resolve(reader.result as string);
+        ctx.imageSmoothingEnabled = true;
+        ctx.imageSmoothingQuality = "high";
         ctx.drawImage(img, 0, 0, w, h);
 
-        // Use webp or jpeg to heavily compress large png files before saving to localstorage
-        resolve(canvas.toDataURL("image/webp", 0.8));
+        resolve(canvas.toDataURL("image/webp", quality));
       };
       img.onerror = () => resolve(reader.result as string); // fallback to raw
       img.src = reader.result as string;

--- a/components/phone-character-app.tsx
+++ b/components/phone-character-app.tsx
@@ -71,6 +71,19 @@ type CanvasRelationLine = { key: string; aId: string; bId: string; labels: strin
 // 每个世界一张画布：平移缩放记忆按世界分 key（默认世界沿用旧 key，存量零迁移）
 const PAN_STORAGE_BASE_KEY = 'ai_phone_canvas_pan_v2';
 const WORLD_TAB_KEY = 'ai_phone_character_app_world_v1';
+const ARCHIVE_ANIMATION_KEY = 'ai_phone_character_archive_animation_v1';
+
+type ArchiveAnimationMode = "original" | "clear" | "random";
+type ResolvedArchiveAnimation = Exclude<ArchiveAnimationMode, "random">;
+
+function loadArchiveAnimationMode(): ArchiveAnimationMode {
+  if (typeof window === "undefined") return "original";
+  try {
+    const saved = kvGet(ARCHIVE_ANIMATION_KEY);
+    if (saved === "original" || saved === "clear" || saved === "random") return saved;
+  } catch { }
+  return "original";
+}
 function worldPanKey(worldId: string): string {
   return worldId === DEFAULT_CHARACTER_WORLD_ID ? PAN_STORAGE_BASE_KEY : `${PAN_STORAGE_BASE_KEY}_${worldId}`;
 }
@@ -92,6 +105,7 @@ type TransitionState = {
   sourceRect: DOMRect;
   polaroidStyle: number;
   phase: "start" | "fly" | "flip";
+  animation: ResolvedArchiveAnimation;
   onComplete?: () => void;
   reverse?: boolean;
 };
@@ -162,6 +176,7 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
   const [characters, setCharacters] = useState<Character[]>(() => loadCharacters());
   const [bgItems, setBgItems] = useState<CanvasBgItem[]>(() => loadBackgroundItems());
   const [transition, setTransition] = useState<TransitionState | null>(null);
+  const [archiveAnimationMode, setArchiveAnimationMode] = useState<ArchiveAnimationMode>(() => loadArchiveAnimationMode());
   const [pendingPlacementChar, setPendingPlacementChar] = useState<Character | null>(null);
   const [pendingPolaroidStyle, setPendingPolaroidStyle] = useState<number>(0);
 
@@ -198,27 +213,42 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
   // Handle clicking a polaroid
   function handleSelectChar(char: Character, e: React.MouseEvent<HTMLDivElement>, polaroidStyle: number) {
     const rect = e.currentTarget.getBoundingClientRect();
+    const animation: ResolvedArchiveAnimation = archiveAnimationMode === "random"
+      ? (Math.random() < 0.5 ? "original" : "clear")
+      : archiveAnimationMode;
 
     setTransition({
       char,
       sourceRect: rect,
       polaroidStyle,
       phase: "start",
+      animation,
     });
 
-    // Animate
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         setTransition((p) => p ? { ...p, phase: "fly" } : null);
+        if (animation === "clear") {
+          setTimeout(() => {
+            setView({ type: "detail", id: char.id });
+            setTransition(null);
+          }, 450);
+          return;
+        }
         setTimeout(() => {
           setTransition((p) => p ? { ...p, phase: "flip" } : null);
           setTimeout(() => {
             setView({ type: "detail", id: char.id });
             setTransition(null);
-          }, 400); // Wait for flip 0.4s
-        }, 400); // Wait for fly 0.4s
+          }, 400);
+        }, 400);
       });
     });
+  }
+
+  function updateArchiveAnimationMode(mode: ArchiveAnimationMode) {
+    setArchiveAnimationMode(mode);
+    try { kvSet(ARCHIVE_ANIMATION_KEY, mode); } catch { }
   }
 
   // Handle back from detail
@@ -240,7 +270,8 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
             onUpdateBgItems={updateBgItems}
             onClose={onClose}
             onSelect={handleSelectChar}
-            onEditArchive={(char: Character) => setView({ type: "detail", id: char.id, isEditing: true })}
+            archiveAnimationMode={archiveAnimationMode}
+            onArchiveAnimationModeChange={updateArchiveAnimationMode}
             onCreate={(style: number) => { setPendingPolaroidStyle(style); setView({ type: "detail", id: null, isEditing: true }); }}
             pendingPlacementChar={pendingPlacementChar}
             onStartCharPlacement={(char: Character) => setPendingPlacementChar(char)}
@@ -337,9 +368,11 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
         )}
       </div>
 
-      {/* Fly & Flip Transition Overlay */}
+      {/* Character archive transition overlay */}
       {transition && (
-        <FlipTransitionOverlay transit={transition} />
+        transition.animation === "clear"
+          ? <ClearTransitionOverlay transit={transition} />
+          : <FlipTransitionOverlay transit={transition} />
       )}
     </>
   );
@@ -455,6 +488,51 @@ function FlipTransitionOverlay({ transit }: { transit: TransitionState }) {
 }
 
 
+function ClearTransitionOverlay({ transit }: { transit: TransitionState }) {
+  const { char, sourceRect, polaroidStyle, phase } = transit;
+  const [shellRect, setShellRect] = useState<DOMRect | null>(null);
+
+  useEffect(() => {
+    const shell = document.querySelector(".char-app");
+    if (shell) setShellRect(shell.getBoundingClientRect());
+  }, []);
+
+  if (!shellRect) return null;
+
+  const isStart = phase === "start";
+  const normalizedStyle = ((polaroidStyle % 5) + 5) % 5;
+  const imageAspectRatio = [1, 3 / 4, 4 / 3, 16 / 9, 9 / 16][normalizedStyle];
+  const targetWidth = Math.min(shellRect.width * 0.72, 300);
+  const targetHeight = (targetWidth - 12) / imageAspectRatio + 38;
+  const cover = getCharacterArchiveCover(char);
+
+  return (
+    <div
+      className="char-clear-transition fixed"
+      style={{
+        top: isStart ? sourceRect.top : shellRect.top + (shellRect.height - targetHeight) / 2,
+        left: isStart ? sourceRect.left : shellRect.left + (shellRect.width - targetWidth) / 2,
+        width: isStart ? sourceRect.width : targetWidth,
+        height: isStart ? sourceRect.height : targetHeight,
+        opacity: isStart ? 1 : 0,
+        transform: isStart ? "scale(1)" : "scale(1.04)",
+        transition: isStart ? "none" : "top 0.45s cubic-bezier(0.25, 1, 0.5, 1), left 0.45s cubic-bezier(0.25, 1, 0.5, 1), width 0.45s cubic-bezier(0.25, 1, 0.5, 1), height 0.45s cubic-bezier(0.25, 1, 0.5, 1), opacity 0.45s ease, transform 0.45s cubic-bezier(0.25, 1, 0.5, 1)",
+      }}
+    >
+      <div className={`char-polaroid ${getPolaroidRatioClass(polaroidStyle)}`}>
+        <div className="char-polaroid-img-wrapper">
+          {cover.image ? (
+            <img src={cover.image} className="char-polaroid-img" style={getCharacterImageStyle(cover)} alt="" />
+          ) : (
+            <CharAvatarFallback name={char.name} size="100%" />
+          )}
+        </div>
+        <div className="char-polaroid-text">{char.name || "UNNAMED"}</div>
+      </div>
+    </div>
+  );
+}
+
 // ── 列表视图（照片墙） ─────────────────────────────────────────
 
 function CharListView({
@@ -467,7 +545,8 @@ function CharListView({
   onUpdateBgItems,
   onClose,
   onSelect,
-  onEditArchive,
+  archiveAnimationMode,
+  onArchiveAnimationModeChange,
   onCreate,
   pendingPlacementChar,
   onStartCharPlacement,
@@ -484,7 +563,8 @@ function CharListView({
   onUpdateBgItems: (next: CanvasBgItem[]) => void;
   onClose: () => void;
   onSelect: (char: Character, e: React.MouseEvent<HTMLDivElement>, polaroidStyle: number) => void;
-  onEditArchive: (char: Character) => void;
+  archiveAnimationMode: ArchiveAnimationMode;
+  onArchiveAnimationModeChange: (mode: ArchiveAnimationMode) => void;
   onCreate: (polaroidStyle: number) => void;
   pendingPlacementChar: Character | null;
   onStartCharPlacement: (char: Character) => void;
@@ -1062,14 +1142,28 @@ function CharListView({
         rightAction={
           <div className="flex items-center gap-2">
             {isEditing && (
-              <button
-                className="flex items-center justify-center w-[34px] h-[34px] rounded-full bg-black/5 text-[#666] hover:bg-black/10 transition-colors"
-                onClick={() => resetViewToFit()}
-                aria-label="恢复视角"
-                title="恢复视角"
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3"></path><path d="M21 8V5a2 2 0 0 0-2-2h-3"></path><path d="M3 16v3a2 2 0 0 0 2 2h3"></path><path d="M16 21h3a2 2 0 0 0 2-2v-3"></path><circle cx="12" cy="12" r="2.5"></circle></svg>
-              </button>
+              <div className="char-edit-tools-stack">
+                <div className="char-animation-mode-control" aria-label="档案打开动画">
+                  <span>动画</span>
+                  <select
+                    value={archiveAnimationMode}
+                    onChange={(event) => onArchiveAnimationModeChange(event.target.value as ArchiveAnimationMode)}
+                    title="档案打开动画"
+                  >
+                    <option value="original">原版立体</option>
+                    <option value="clear">清晰飞入</option>
+                    <option value="random">随机</option>
+                  </select>
+                </div>
+                <button
+                  className="char-reset-view-btn"
+                  onClick={() => resetViewToFit()}
+                  aria-label="恢复视角"
+                  title="恢复视角"
+                >
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3"></path><path d="M21 8V5a2 2 0 0 0-2-2h-3"></path><path d="M3 16v3a2 2 0 0 0 2 2h3"></path><path d="M16 21h3a2 2 0 0 0 2-2v-3"></path><circle cx="12" cy="12" r="2.5"></circle></svg>
+                </button>
+              </div>
             )}
             <button
               className={`flex items-center justify-center w-[34px] h-[34px] rounded-full transition-colors ${
@@ -1603,21 +1697,6 @@ function CharListView({
           <div className="modal-dialog" data-ui="modal-dialog" onPointerDown={(e) => e.stopPropagation()} style={{ padding: 0, overflow: 'hidden' }}>
             <div className="modal-header" data-ui="modal-header" style={{ padding: '20px 20px 10px' }}>
               <h3 className="modal-title" style={{ margin: 0, fontSize: '16px' }}>档案卡片设置</h3>
-            </div>
-            <div style={{ padding: '0 16px 10px' }}>
-              <button
-                type="button"
-                className="ui-btn ui-btn-primary"
-                style={{ width: '100%' }}
-                onClick={() => {
-                  const target = activeMoveChar;
-                  if (!target) return;
-                  setActiveMoveChar(null);
-                  onEditArchive(target);
-                }}
-              >
-                编辑封面、档案照片、比例与尺寸
-              </button>
             </div>
             <div style={{ padding: '4px 20px', fontSize: 12, color: '#777' }}>转移到其他卷宗</div>
             <div role="listbox" style={{ maxHeight: '40dvh', padding: '10px 16px', overflowY: 'auto' }}>
@@ -2737,15 +2816,16 @@ function AvatarCropEditor({
     onError("");
     try {
       const image = await loadCropImage(source);
-      const outputSize = 400;
-      const coverScale = Math.max(outputSize / image.naturalWidth, outputSize / image.naturalHeight);
+      const outputWidth = 450;
+      const outputHeight = 600;
+      const coverScale = Math.max(outputWidth / image.naturalWidth, outputHeight / image.naturalHeight);
       const drawWidth = image.naturalWidth * coverScale * scale;
       const drawHeight = image.naturalHeight * coverScale * scale;
-      const drawX = (outputSize - drawWidth) * (positionX / 100);
-      const drawY = (outputSize - drawHeight) * (positionY / 100);
+      const drawX = (outputWidth - drawWidth) * (positionX / 100);
+      const drawY = (outputHeight - drawHeight) * (positionY / 100);
       const canvas = document.createElement("canvas");
-      canvas.width = outputSize;
-      canvas.height = outputSize;
+      canvas.width = outputWidth;
+      canvas.height = outputHeight;
       const context = canvas.getContext("2d");
       if (!context) throw new Error("当前浏览器无法创建头像画布");
       context.imageSmoothingEnabled = true;
@@ -2785,15 +2865,15 @@ function AvatarCropEditor({
         onPointerCancel={stopDragging}
       >
         <img src={source} alt="头像裁剪预览" draggable={false} style={previewStyle} />
-        <span>拖动取景 · 1:1</span>
+        <span>拖动取景 · 3:4</span>
       </div>
       <div className="char-avatar-crop-controls">
         <label>X <input type="range" min="0" max="100" step="1" value={positionX} onChange={event => setPositionX(Number(event.target.value))} /></label>
         <label>Y <input type="range" min="0" max="100" step="1" value={positionY} onChange={event => setPositionY(Number(event.target.value))} /></label>
         <label>缩放 <input type="range" min="1" max="3" step="0.05" value={scale} onChange={event => setScale(Number(event.target.value))} /></label>
         <div className="char-avatar-crop-actions">
-          <button type="button" onClick={onCancel} disabled={busy}>取消</button>
           <button type="button" onClick={confirmCrop} disabled={busy}>{busy ? "处理中…" : "确认裁剪"}</button>
+          <button type="button" onClick={onCancel} disabled={busy}>取消</button>
         </div>
       </div>
     </div>

--- a/components/phone-character-app.tsx
+++ b/components/phone-character-app.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import type { Character } from "@/lib/character-types";
+import type { Character, CharacterImageDisplay, CharacterPolaroidSize } from "@/lib/character-types";
+import {
+  getCharacterArchiveCover,
+  getCharacterImageStyle,
+  getPolaroidAspectRatio,
+  getPolaroidRatioClass,
+  getPolaroidWidth,
+  isSafeCharacterImageUrl,
+  normalizeCharacterImageDisplay,
+} from "@/lib/character-images";
 import {
   createCharacter,
   exportCharacterAsJson,
@@ -81,6 +90,7 @@ function loadWorldPan(worldId: string): { x: number; y: number; zoom: number } {
 type TransitionState = {
   char: Character;
   sourceRect: DOMRect;
+  polaroidStyle: number;
   phase: "start" | "fly" | "flip";
   onComplete?: () => void;
   reverse?: boolean;
@@ -186,12 +196,13 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
   }
 
   // Handle clicking a polaroid
-  function handleSelectChar(char: Character, e: React.MouseEvent<HTMLDivElement>) {
+  function handleSelectChar(char: Character, e: React.MouseEvent<HTMLDivElement>, polaroidStyle: number) {
     const rect = e.currentTarget.getBoundingClientRect();
 
     setTransition({
       char,
       sourceRect: rect,
+      polaroidStyle,
       phase: "start",
     });
 
@@ -229,6 +240,7 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
             onUpdateBgItems={updateBgItems}
             onClose={onClose}
             onSelect={handleSelectChar}
+            onEditArchive={(char: Character) => setView({ type: "detail", id: char.id, isEditing: true })}
             onCreate={(style: number) => { setPendingPolaroidStyle(style); setView({ type: "detail", id: null, isEditing: true }); }}
             pendingPlacementChar={pendingPlacementChar}
             onStartCharPlacement={(char: Character) => setPendingPlacementChar(char)}
@@ -248,7 +260,9 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
 
         {view.type === "detail" && (
           <CharArchiveView
-            char={view.id ? (characters.find((c) => c.id === view.id) ?? createCharacter({ name: "", persona: "", avatar: null })) : createCharacter({ name: "", persona: "", avatar: null })}
+            char={view.id
+              ? (characters.find((c) => c.id === view.id) ?? createCharacter({ name: "", persona: "", avatar: null }))
+              : createCharacter({ name: "", persona: "", avatar: null, polaroidStyle: pendingPolaroidStyle })}
             isEditing={view.isEditing}
             isExisting={Boolean(view.id)}
             onBack={handleBackFromDetail}
@@ -278,7 +292,6 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
                   : `已覆盖旧版本，当前为 V${nextVersion}`);
               } else {
                 const newChar = createCharacter(data);
-                newChar.polaroidStyle = pendingPolaroidStyle;
                 setPendingPlacementChar(newChar);
                 setView({ type: "list", id: null, isEditing: false });
                 onNotice("点击画布放置角色");
@@ -332,7 +345,7 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
 // ── 过渡动效层 ───────────────────────────────────────
 
 function FlipTransitionOverlay({ transit }: { transit: TransitionState }) {
-  const { char, sourceRect, phase } = transit;
+  const { char, sourceRect, polaroidStyle, phase } = transit;
 
   // Calculate relative bounds based on parent .phone-shell
   const [shellRect, setShellRect] = useState<DOMRect | null>(null);
@@ -363,6 +376,7 @@ function FlipTransitionOverlay({ transit }: { transit: TransitionState }) {
   const isFlipped = phase === "flip";
 
   const duration = isStart ? "0s" : "0.4s";
+  const cover = getCharacterArchiveCover(char);
 
   return (
     <div
@@ -390,11 +404,12 @@ function FlipTransitionOverlay({ transit }: { transit: TransitionState }) {
             {isStart && <div className="char-polaroid-tape" />}
             <div className="char-polaroid-img-wrapper" style={{
               height: isStart ? "auto" : "100%",
-              aspectRatio: isStart ? "1/1" : "auto",
-              transition: `all ${duration} ease`
+              aspectRatio: isStart ? getPolaroidAspectRatio(polaroidStyle) : "auto",
+              transition: `height ${duration} ease`,
+              willChange: "transform",
             }}>
-              {char.avatar ? (
-                <img src={char.avatar} className="char-polaroid-img" alt="" />
+              {cover.image ? (
+                <img src={cover.image} className="char-polaroid-img" style={getCharacterImageStyle(cover)} alt="" />
               ) : (
                 <div className="w-full h-full bg-[#9b8aaa]" />
               )}
@@ -431,6 +446,7 @@ function CharListView({
   onUpdateBgItems,
   onClose,
   onSelect,
+  onEditArchive,
   onCreate,
   pendingPlacementChar,
   onStartCharPlacement,
@@ -446,7 +462,8 @@ function CharListView({
   onUpdateChars: (next: Character[]) => void;
   onUpdateBgItems: (next: CanvasBgItem[]) => void;
   onClose: () => void;
-  onSelect: (char: Character, e: React.MouseEvent<HTMLDivElement>) => void;
+  onSelect: (char: Character, e: React.MouseEvent<HTMLDivElement>, polaroidStyle: number) => void;
+  onEditArchive: (char: Character) => void;
   onCreate: (polaroidStyle: number) => void;
   pendingPlacementChar: Character | null;
   onStartCharPlacement: (char: Character) => void;
@@ -880,7 +897,7 @@ function CharListView({
         const data = parseCharacterFromJson(text);
         if (!data) return onNotice("解析失败，请检查文件格式");
         const c = createCharacter(data);
-        c.polaroidStyle = styleIdx;
+        c.polaroidStyle = data.polaroidStyle ?? styleIdx;
         onStartCharPlacement(c);
         onNotice("点击画布放置角色");
       } else if (file.type === "image/png" || file.name.endsWith(".png")) {
@@ -897,7 +914,7 @@ function CharListView({
           avatar = data.avatar;
         }
         const c = createCharacter({ ...data, avatar });
-        c.polaroidStyle = styleIdx;
+        c.polaroidStyle = data.polaroidStyle ?? styleIdx;
         onStartCharPlacement(c);
         onNotice("点击画布放置角色");
       } else {
@@ -1143,9 +1160,9 @@ function CharListView({
               const styleIdx = char.polaroidStyle ?? (hash % 5);
 
               const sizeMod = (hash % 5);
-              const w = 110 + sizeMod * 10;
-              const ratioClassArray = ["ratio-square", "ratio-portrait", "ratio-landscape", "ratio-16-9", "ratio-9-16"];
-              const ratioClass = ratioClassArray[styleIdx % ratioClassArray.length];
+              const w = getPolaroidWidth(char, 110 + sizeMod * 10);
+              const ratioClass = getPolaroidRatioClass(styleIdx);
+              const cover = getCharacterArchiveCover(char);
 
               const tapeStyles = ["char-polaroid-tape-white", "char-polaroid-tape-red", "char-polaroid-tape-black"];
               const tapeMod = char.polaroidStyle !== undefined ? styleIdx % tapeStyles.length : hash % 3;
@@ -1157,7 +1174,7 @@ function CharListView({
                   key={char.id} id={char.id}
                   x={char.canvasX} y={char.canvasY || 0} rot={char.canvasRot || 0} zIndex={char.canvasZIndex || 100}
                   onDragEnd={handleDragEndChar}
-                  onClick={isEditing ? undefined : (e) => onSelect(char, e)}
+                  onClick={isEditing ? undefined : (e) => onSelect(char, e, styleIdx)}
                   className={`char-polaroid char-polaroid-board-item ${ratioClass} ${linkFromId === char.id ? "wt-link-source" : ""}`}
                   w={w}
                   isEditing={isEditing}
@@ -1178,11 +1195,11 @@ function CharListView({
                     </div>
                   )}
                   <div className="char-polaroid-img-wrapper" style={{ boxShadow: "inset 0 0 10px rgba(0,0,0,0.1)" }}>
-                    {char.avatar ? <img src={char.avatar} alt={char.name} className="char-polaroid-img" draggable={false} /> : <CharAvatarFallback name={char.name} size="100%" />}
+                    {cover.image ? <img src={cover.image} alt={char.name} className="char-polaroid-img" style={getCharacterImageStyle(cover)} draggable={false} /> : <CharAvatarFallback name={char.name} size="100%" />}
                     <button
                       className="char-polaroid-menu-btn absolute top-1 right-1 w-6 h-6 bg-black/20 text-white rounded-full flex items-center justify-center cursor-pointer hover:bg-black/40 transition-colors z-10"
                       onClick={(e) => { e.stopPropagation(); setActiveMoveChar(char); }}
-                      aria-label="转移世界"
+                      aria-label="档案卡片设置"
                     >
                       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
                     </button>
@@ -1260,8 +1277,8 @@ function CharListView({
             {pendingPlacementChar ? (
               <div className="char-polaroid w-[100px]" style={{ boxShadow: '0 2px 8px rgba(0,0,0,0.2)' }}>
                 <div className="char-polaroid-img-wrapper">
-                  {pendingPlacementChar.avatar ? (
-                    <img src={pendingPlacementChar.avatar} className="char-polaroid-img" alt="" draggable={false} />
+                  {getCharacterArchiveCover(pendingPlacementChar).image ? (
+                    <img src={getCharacterArchiveCover(pendingPlacementChar).image!} className="char-polaroid-img" style={getCharacterImageStyle(getCharacterArchiveCover(pendingPlacementChar))} alt="" draggable={false} />
                   ) : (
                     <CharAvatarFallback name={pendingPlacementChar.name} size="100%" />
                   )}
@@ -1564,8 +1581,24 @@ function CharListView({
         <div className="modal-overlay" data-ui="modal" onPointerDown={() => setActiveMoveChar(null)}>
           <div className="modal-dialog" data-ui="modal-dialog" onPointerDown={(e) => e.stopPropagation()} style={{ padding: 0, overflow: 'hidden' }}>
             <div className="modal-header" data-ui="modal-header" style={{ padding: '20px 20px 10px' }}>
-              <h3 className="modal-title" style={{ margin: 0, fontSize: '16px' }}>转移到其他卷宗</h3>
+              <h3 className="modal-title" style={{ margin: 0, fontSize: '16px' }}>档案卡片设置</h3>
             </div>
+            <div style={{ padding: '0 16px 10px' }}>
+              <button
+                type="button"
+                className="ui-btn ui-btn-primary"
+                style={{ width: '100%' }}
+                onClick={() => {
+                  const target = activeMoveChar;
+                  if (!target) return;
+                  setActiveMoveChar(null);
+                  onEditArchive(target);
+                }}
+              >
+                编辑封面、档案照片、比例与尺寸
+              </button>
+            </div>
+            <div style={{ padding: '4px 20px', fontSize: 12, color: '#777' }}>转移到其他卷宗</div>
             <div role="listbox" style={{ maxHeight: '40dvh', padding: '10px 16px', overflowY: 'auto' }}>
               {worldGroups.filter(g => g.id !== currentWorldId).map(group => (
                 <button
@@ -1801,6 +1834,10 @@ function CharArchiveView({
   const [showTimeZonePicker, setShowTimeZonePicker] = useState(false);
   const [timeZoneSearch, setTimeZoneSearch] = useState(char.timeZone || "");
   const [avatar, setAvatar] = useState<string | null>(char.avatar || null);
+  const [archiveCover, setArchiveCover] = useState<CharacterImageDisplay | undefined>(() => normalizeCharacterImageDisplay(char.archiveCover));
+  const [archivePhoto, setArchivePhoto] = useState<CharacterImageDisplay | undefined>(() => normalizeCharacterImageDisplay(char.archivePhoto));
+  const [polaroidStyle, setPolaroidStyle] = useState<number | undefined>(char.polaroidStyle);
+  const [polaroidSize, setPolaroidSize] = useState<CharacterPolaroidSize | undefined>(char.polaroidSize);
   const [showUrlInput, setShowUrlInput] = useState(false);
   const [urlInput, setUrlInput] = useState("");
   const fileRef = useRef<HTMLInputElement>(null);
@@ -1853,6 +1890,10 @@ function CharArchiveView({
     if (briefPersona !== (char.briefPersona || "")) return true;
     if (timeZone !== (char.timeZone || "")) return true;
     if (avatar !== (char.avatar || null)) return true;
+    if (JSON.stringify(archiveCover) !== JSON.stringify(normalizeCharacterImageDisplay(char.archiveCover))) return true;
+    if (JSON.stringify(archivePhoto) !== JSON.stringify(normalizeCharacterImageDisplay(char.archivePhoto))) return true;
+    if (polaroidStyle !== char.polaroidStyle) return true;
+    if (polaroidSize !== char.polaroidSize) return true;
     const origTags = char.tags || [];
     if (tags.length !== origTags.length || tags.some((t, i) => t !== origTags[i])) return true;
     return false;
@@ -1878,6 +1919,10 @@ function CharArchiveView({
       setShowTimeZonePicker(false);
       setTags(char.tags || []);
       setAvatar(char.avatar || null);
+      setArchiveCover(normalizeCharacterImageDisplay(char.archiveCover));
+      setArchivePhoto(normalizeCharacterImageDisplay(char.archivePhoto));
+      setPolaroidStyle(char.polaroidStyle);
+      setPolaroidSize(char.polaroidSize);
     }
   }, [isEditing, char]);
 
@@ -1888,7 +1933,7 @@ function CharArchiveView({
 
   function handleAvatarUrl() {
     const trimmed = urlInput.trim();
-    if (!trimmed) return;
+    if (!isSafeCharacterImageUrl(trimmed)) return;
     setAvatar(trimmed);
     setShowUrlInput(false);
     setUrlInput("");
@@ -1919,7 +1964,11 @@ function CharArchiveView({
           : undefined,
         timeZone: normalizedTimeZone,
         tags,
-        avatar: avatar ?? null
+        avatar: avatar ?? null,
+        archiveCover,
+        archivePhoto,
+        polaroidStyle,
+        polaroidSize,
       }, createVersion);
     }
   }
@@ -1971,6 +2020,12 @@ function CharArchiveView({
     : timeZoneOptions;
   const filteredTimeZoneOptions = matchedTimeZoneOptions.slice(0, 80);
   const hasMoreTimeZoneOptions = matchedTimeZoneOptions.length > filteredTimeZoneOptions.length;
+  const effectiveArchivePhoto: CharacterImageDisplay = {
+    image: archivePhoto?.image || avatar || null,
+    positionX: archivePhoto?.positionX ?? 50,
+    positionY: archivePhoto?.positionY ?? 50,
+    scale: archivePhoto?.scale ?? 1,
+  };
 
   function openTimeZonePicker() {
     setTimeZoneSearch(timeZone);
@@ -2016,20 +2071,18 @@ function CharArchiveView({
               className="char-archive-photo relative"
               style={{ cursor: isEditing ? "pointer" : "default" }}
               onClick={() => {
-                if (isEditing) {
-                  fileRef.current?.click();
-                }
+                if (isEditing) fileRef.current?.click();
               }}
             >
-              {avatar ? (
-                <img src={avatar} alt="Avatar" />
+              {effectiveArchivePhoto.image ? (
+                <img src={effectiveArchivePhoto.image} alt="Archive portrait" style={getCharacterImageStyle(effectiveArchivePhoto)} />
               ) : (
                 <CharAvatarFallback name={name || char.name} size="100%" />
               )}
               {isEditing && (
                 <div className="absolute inset-0 bg-black/30 flex flex-col items-center justify-center pointer-events-none text-white">
                   <IconCamera size={24} />
-                  <span className="ts-10 mt-1">Change Photo</span>
+                  <span className="ts-10 mt-1">修改基础头像</span>
                 </div>
               )}
             </div>
@@ -2051,7 +2104,7 @@ function CharArchiveView({
                   className="ts-10 px-3 py-1 bg-[#111111] text-white border-none rounded-full cursor-pointer hover:bg-[#222222] transition-colors"
                   onClick={() => setShowUrlInput((v) => !v)}
                 >
-                  Use IMG URL
+                  基础头像 URL
                 </button>
                 {showUrlInput && (
                   <div className="flex gap-1 mt-1">
@@ -2114,6 +2167,67 @@ function CharArchiveView({
 
           </div>
         </div>
+
+        {isEditing && (
+          <div className="char-image-diy-section">
+            <div className="char-image-diy-title">DIY IMAGE PROFILE</div>
+            <p className="char-image-diy-help">封面用于档案墙；档案形象用于详情、剧情顶部和漫卷。可直接在预览图上拖动取景。</p>
+            <CharacterImageEditor
+              label="档案墙封面 / ARCHIVE COVER"
+              value={archiveCover}
+              fallbackImage={avatar}
+              fallbackName={name || char.name}
+              aspectRatio={getPolaroidAspectRatio(polaroidStyle ?? 1)}
+              onChange={setArchiveCover}
+            />
+            <CharacterImageEditor
+              label="基础档案形象 / ARCHIVE PHOTO"
+              value={archivePhoto}
+              fallbackImage={avatar}
+              fallbackName={name || char.name}
+              onChange={setArchivePhoto}
+            />
+            <div className="char-polaroid-options">
+              <div>
+                <span className="char-image-diy-label">拍立得比例</span>
+                <div className="char-image-choice-row">
+                  {[
+                    { value: 0, label: "1:1" },
+                    { value: 1, label: "3:4" },
+                    { value: 2, label: "4:3" },
+                    { value: 3, label: "16:9" },
+                    { value: 4, label: "9:16" },
+                  ].map(option => (
+                    <button
+                      type="button"
+                      key={option.value}
+                      className={polaroidStyle === option.value ? "active" : ""}
+                      onClick={() => setPolaroidStyle(option.value)}
+                    >{option.label}</button>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <span className="char-image-diy-label">拍立得尺寸</span>
+                <div className="char-image-choice-row">
+                  {([
+                    { value: undefined, label: "自动（旧版）" },
+                    { value: "small", label: "小" },
+                    { value: "medium", label: "中" },
+                    { value: "large", label: "大" },
+                  ] as const).map(option => (
+                    <button
+                      type="button"
+                      key={option.value ?? "auto"}
+                      className={polaroidSize === option.value ? "active" : ""}
+                      onClick={() => setPolaroidSize(option.value)}
+                    >{option.label}</button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
 
         <div className="char-archive-row">
           <div className="char-archive-cell" style={{ flex: 1.8 }}>
@@ -2534,6 +2648,127 @@ function CharArchiveView({
 // The CharEditView component has been removed as editing is now inline within CharArchiveView.
 
 // ── 共享子组件 ───────────────────────────────────────
+
+function CharacterImageEditor({
+  label,
+  value,
+  fallbackImage,
+  fallbackName,
+  aspectRatio = "3 / 4",
+  onChange,
+}: {
+  label: string;
+  value?: CharacterImageDisplay;
+  fallbackImage: string | null;
+  fallbackName: string;
+  aspectRatio?: string;
+  onChange: (value: CharacterImageDisplay | undefined) => void;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{ x: number; y: number; positionX: number; positionY: number } | null>(null);
+  const [url, setUrl] = useState("");
+  const display: CharacterImageDisplay = {
+    image: value?.image || fallbackImage || null,
+    positionX: value?.positionX ?? 50,
+    positionY: value?.positionY ?? 50,
+    scale: value?.scale ?? 1,
+  };
+
+  function patch(partial: Partial<CharacterImageDisplay>) {
+    onChange({
+      image: value?.image ?? null,
+      positionX: value?.positionX ?? 50,
+      positionY: value?.positionY ?? 50,
+      scale: value?.scale ?? 1,
+      ...partial,
+    });
+  }
+
+  function applyUrl() {
+    const next = url.trim();
+    if (!isSafeCharacterImageUrl(next)) return;
+    patch({ image: next });
+    setUrl("");
+  }
+
+  function handlePointerDown(event: React.PointerEvent<HTMLDivElement>) {
+    if (!display.image) return;
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    dragRef.current = {
+      x: event.clientX,
+      y: event.clientY,
+      positionX: display.positionX ?? 50,
+      positionY: display.positionY ?? 50,
+    };
+  }
+
+  function handlePointerMove(event: React.PointerEvent<HTMLDivElement>) {
+    const start = dragRef.current;
+    const rect = previewRef.current?.getBoundingClientRect();
+    if (!start || !rect) return;
+    const scale = display.scale ?? 1;
+    const positionX = Math.min(100, Math.max(0, start.positionX - ((event.clientX - start.x) / rect.width) * 100 / scale));
+    const positionY = Math.min(100, Math.max(0, start.positionY - ((event.clientY - start.y) / rect.height) * 100 / scale));
+    patch({ positionX, positionY });
+  }
+
+  function stopDragging(event: React.PointerEvent<HTMLDivElement>) {
+    dragRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  }
+
+  return (
+    <div className="char-image-editor">
+      <div className="char-image-diy-label">{label}</div>
+      <div className="char-image-editor-layout">
+        <div
+          ref={previewRef}
+          className="char-image-editor-preview"
+          style={{ aspectRatio }}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={stopDragging}
+          onPointerCancel={stopDragging}
+        >
+          {display.image ? (
+            <img src={display.image} alt="" draggable={false} style={getCharacterImageStyle(display)} />
+          ) : (
+            <CharAvatarFallback name={fallbackName} size="100%" />
+          )}
+          <span>拖动取景</span>
+        </div>
+        <div className="char-image-editor-controls">
+          <div className="char-image-editor-buttons">
+            <button type="button" onClick={() => fileInputRef.current?.click()}>上传独立图片</button>
+            <button type="button" onClick={() => onChange(undefined)}>清除并回退基础头像</button>
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={async event => {
+              const file = event.target.files?.[0];
+              if (file) patch({ image: await fileToDataUrl(file) });
+              event.target.value = "";
+            }}
+          />
+          <div className="char-image-url-row">
+            <input value={url} onChange={event => setUrl(event.target.value)} onKeyDown={event => { if (event.key === "Enter") applyUrl(); }} placeholder="独立图片 URL" />
+            <button type="button" onClick={applyUrl}>应用</button>
+          </div>
+          <label>X <input type="range" min="0" max="100" step="1" value={display.positionX ?? 50} onChange={event => patch({ positionX: Number(event.target.value) })} /></label>
+          <label>Y <input type="range" min="0" max="100" step="1" value={display.positionY ?? 50} onChange={event => patch({ positionY: Number(event.target.value) })} /></label>
+          <label>缩放 <input type="range" min="1" max="3" step="0.05" value={display.scale ?? 1} onChange={event => patch({ scale: Number(event.target.value) })} /></label>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function CharAvatarFallback({
   name,

--- a/components/phone-character-app.tsx
+++ b/components/phone-character-app.tsx
@@ -436,7 +436,11 @@ function FlipTransitionOverlay({ transit }: { transit: TransitionState }) {
             <div className="char-flipper-paper-rule" />
             <div className="char-flipper-paper-grid">
               <div className="char-flipper-paper-portrait">
-                {char.avatar ? <img src={char.avatar} alt="" /> : null}
+                {char.avatar ? (
+                  <img src={char.avatar} alt="" />
+                ) : (
+                  <CharAvatarFallback name={char.name} size="100%" />
+                )}
               </div>
               <div>
                 <strong>{char.name || "UNNAMED"}</strong>
@@ -2120,6 +2124,7 @@ function CharArchiveView({
             {isEditing && avatarCropSource && (
               <AvatarCropEditor
                 source={avatarCropSource}
+                error={avatarCropError}
                 onConfirm={(croppedAvatar) => {
                   setAvatar(croppedAvatar);
                   setAvatarCropSource(null);
@@ -2132,8 +2137,8 @@ function CharArchiveView({
                 onError={setAvatarCropError}
               />
             )}
-            {isEditing && avatarCropError && (
-              <div className="char-avatar-crop-error" role="alert">{avatarCropError}</div>
+            {isEditing && avatarCropError && !avatarCropSource && (
+              <div className="char-avatar-crop-error char-avatar-crop-error-standalone" role="alert">{avatarCropError}</div>
             )}
             {isEditing && (
               <div className="mt-2 flex flex-col gap-1 w-full justify-center">
@@ -2681,11 +2686,13 @@ function CharArchiveView({
 
 function AvatarCropEditor({
   source,
+  error,
   onConfirm,
   onCancel,
   onError,
 }: {
   source: string;
+  error: string;
   onConfirm: (dataUrl: string) => void;
   onCancel: () => void;
   onError: (message: string) => void;
@@ -2768,6 +2775,7 @@ function AvatarCropEditor({
 
   return (
     <div className="char-avatar-crop-editor">
+      {error && <div className="char-avatar-crop-error" role="alert">{error}</div>}
       <div
         ref={previewRef}
         className="char-avatar-crop-preview"

--- a/components/phone-character-app.tsx
+++ b/components/phone-character-app.tsx
@@ -71,19 +71,6 @@ type CanvasRelationLine = { key: string; aId: string; bId: string; labels: strin
 // 每个世界一张画布：平移缩放记忆按世界分 key（默认世界沿用旧 key，存量零迁移）
 const PAN_STORAGE_BASE_KEY = 'ai_phone_canvas_pan_v2';
 const WORLD_TAB_KEY = 'ai_phone_character_app_world_v1';
-const ARCHIVE_ANIMATION_KEY = 'ai_phone_character_archive_animation_v1';
-
-type ArchiveAnimationMode = "original" | "clear" | "random";
-type ResolvedArchiveAnimation = Exclude<ArchiveAnimationMode, "random">;
-
-function loadArchiveAnimationMode(): ArchiveAnimationMode {
-  if (typeof window === "undefined") return "original";
-  try {
-    const saved = kvGet(ARCHIVE_ANIMATION_KEY);
-    if (saved === "original" || saved === "clear" || saved === "random") return saved;
-  } catch { }
-  return "original";
-}
 function worldPanKey(worldId: string): string {
   return worldId === DEFAULT_CHARACTER_WORLD_ID ? PAN_STORAGE_BASE_KEY : `${PAN_STORAGE_BASE_KEY}_${worldId}`;
 }
@@ -105,7 +92,6 @@ type TransitionState = {
   sourceRect: DOMRect;
   polaroidStyle: number;
   phase: "start" | "fly" | "flip";
-  animation: ResolvedArchiveAnimation;
   onComplete?: () => void;
   reverse?: boolean;
 };
@@ -176,7 +162,6 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
   const [characters, setCharacters] = useState<Character[]>(() => loadCharacters());
   const [bgItems, setBgItems] = useState<CanvasBgItem[]>(() => loadBackgroundItems());
   const [transition, setTransition] = useState<TransitionState | null>(null);
-  const [archiveAnimationMode, setArchiveAnimationMode] = useState<ArchiveAnimationMode>(() => loadArchiveAnimationMode());
   const [pendingPlacementChar, setPendingPlacementChar] = useState<Character | null>(null);
   const [pendingPolaroidStyle, setPendingPolaroidStyle] = useState<number>(0);
 
@@ -213,28 +198,17 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
   // Handle clicking a polaroid
   function handleSelectChar(char: Character, e: React.MouseEvent<HTMLDivElement>, polaroidStyle: number) {
     const rect = e.currentTarget.getBoundingClientRect();
-    const animation: ResolvedArchiveAnimation = archiveAnimationMode === "random"
-      ? (Math.random() < 0.5 ? "original" : "clear")
-      : archiveAnimationMode;
 
     setTransition({
       char,
       sourceRect: rect,
       polaroidStyle,
       phase: "start",
-      animation,
     });
 
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         setTransition((p) => p ? { ...p, phase: "fly" } : null);
-        if (animation === "clear") {
-          setTimeout(() => {
-            setView({ type: "detail", id: char.id });
-            setTransition(null);
-          }, 450);
-          return;
-        }
         setTimeout(() => {
           setTransition((p) => p ? { ...p, phase: "flip" } : null);
           setTimeout(() => {
@@ -244,11 +218,6 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
         }, 400);
       });
     });
-  }
-
-  function updateArchiveAnimationMode(mode: ArchiveAnimationMode) {
-    setArchiveAnimationMode(mode);
-    try { kvSet(ARCHIVE_ANIMATION_KEY, mode); } catch { }
   }
 
   // Handle back from detail
@@ -270,8 +239,6 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
             onUpdateBgItems={updateBgItems}
             onClose={onClose}
             onSelect={handleSelectChar}
-            archiveAnimationMode={archiveAnimationMode}
-            onArchiveAnimationModeChange={updateArchiveAnimationMode}
             onCreate={(style: number) => { setPendingPolaroidStyle(style); setView({ type: "detail", id: null, isEditing: true }); }}
             pendingPlacementChar={pendingPlacementChar}
             onStartCharPlacement={(char: Character) => setPendingPlacementChar(char)}
@@ -369,11 +336,7 @@ export function PhoneCharacterApp({ onClose, onNotice }: PhoneCharacterAppProps)
       </div>
 
       {/* Character archive transition overlay */}
-      {transition && (
-        transition.animation === "clear"
-          ? <ClearTransitionOverlay transit={transition} />
-          : <FlipTransitionOverlay transit={transition} />
-      )}
+      {transition && <FlipTransitionOverlay transit={transition} />}
     </>
   );
 }
@@ -488,51 +451,6 @@ function FlipTransitionOverlay({ transit }: { transit: TransitionState }) {
 }
 
 
-function ClearTransitionOverlay({ transit }: { transit: TransitionState }) {
-  const { char, sourceRect, polaroidStyle, phase } = transit;
-  const [shellRect, setShellRect] = useState<DOMRect | null>(null);
-
-  useEffect(() => {
-    const shell = document.querySelector(".char-app");
-    if (shell) setShellRect(shell.getBoundingClientRect());
-  }, []);
-
-  if (!shellRect) return null;
-
-  const isStart = phase === "start";
-  const normalizedStyle = ((polaroidStyle % 5) + 5) % 5;
-  const imageAspectRatio = [1, 3 / 4, 4 / 3, 16 / 9, 9 / 16][normalizedStyle];
-  const targetWidth = Math.min(shellRect.width * 0.72, 300);
-  const targetHeight = (targetWidth - 12) / imageAspectRatio + 38;
-  const cover = getCharacterArchiveCover(char);
-
-  return (
-    <div
-      className="char-clear-transition fixed"
-      style={{
-        top: isStart ? sourceRect.top : shellRect.top + (shellRect.height - targetHeight) / 2,
-        left: isStart ? sourceRect.left : shellRect.left + (shellRect.width - targetWidth) / 2,
-        width: isStart ? sourceRect.width : targetWidth,
-        height: isStart ? sourceRect.height : targetHeight,
-        opacity: isStart ? 1 : 0,
-        transform: isStart ? "scale(1)" : "scale(1.04)",
-        transition: isStart ? "none" : "top 0.45s cubic-bezier(0.25, 1, 0.5, 1), left 0.45s cubic-bezier(0.25, 1, 0.5, 1), width 0.45s cubic-bezier(0.25, 1, 0.5, 1), height 0.45s cubic-bezier(0.25, 1, 0.5, 1), opacity 0.45s ease, transform 0.45s cubic-bezier(0.25, 1, 0.5, 1)",
-      }}
-    >
-      <div className={`char-polaroid ${getPolaroidRatioClass(polaroidStyle)}`}>
-        <div className="char-polaroid-img-wrapper">
-          {cover.image ? (
-            <img src={cover.image} className="char-polaroid-img" style={getCharacterImageStyle(cover)} alt="" />
-          ) : (
-            <CharAvatarFallback name={char.name} size="100%" />
-          )}
-        </div>
-        <div className="char-polaroid-text">{char.name || "UNNAMED"}</div>
-      </div>
-    </div>
-  );
-}
-
 // ── 列表视图（照片墙） ─────────────────────────────────────────
 
 function CharListView({
@@ -545,8 +463,6 @@ function CharListView({
   onUpdateBgItems,
   onClose,
   onSelect,
-  archiveAnimationMode,
-  onArchiveAnimationModeChange,
   onCreate,
   pendingPlacementChar,
   onStartCharPlacement,
@@ -563,8 +479,6 @@ function CharListView({
   onUpdateBgItems: (next: CanvasBgItem[]) => void;
   onClose: () => void;
   onSelect: (char: Character, e: React.MouseEvent<HTMLDivElement>, polaroidStyle: number) => void;
-  archiveAnimationMode: ArchiveAnimationMode;
-  onArchiveAnimationModeChange: (mode: ArchiveAnimationMode) => void;
   onCreate: (polaroidStyle: number) => void;
   pendingPlacementChar: Character | null;
   onStartCharPlacement: (char: Character) => void;
@@ -1142,28 +1056,14 @@ function CharListView({
         rightAction={
           <div className="flex items-center gap-2">
             {isEditing && (
-              <div className="char-edit-tools-stack">
-                <div className="char-animation-mode-control" aria-label="档案打开动画">
-                  <span>动画</span>
-                  <select
-                    value={archiveAnimationMode}
-                    onChange={(event) => onArchiveAnimationModeChange(event.target.value as ArchiveAnimationMode)}
-                    title="档案打开动画"
-                  >
-                    <option value="original">原版立体</option>
-                    <option value="clear">清晰飞入</option>
-                    <option value="random">随机</option>
-                  </select>
-                </div>
-                <button
-                  className="char-reset-view-btn"
-                  onClick={() => resetViewToFit()}
-                  aria-label="恢复视角"
-                  title="恢复视角"
-                >
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3"></path><path d="M21 8V5a2 2 0 0 0-2-2h-3"></path><path d="M3 16v3a2 2 0 0 0 2 2h3"></path><path d="M16 21h3a2 2 0 0 0 2-2v-3"></path><circle cx="12" cy="12" r="2.5"></circle></svg>
-                </button>
-              </div>
+              <button
+                className="char-reset-view-btn"
+                onClick={() => resetViewToFit()}
+                aria-label="恢复视角"
+                title="恢复视角"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3"></path><path d="M21 8V5a2 2 0 0 0-2-2h-3"></path><path d="M3 16v3a2 2 0 0 0 2 2h3"></path><path d="M16 21h3a2 2 0 0 0 2-2v-3"></path><circle cx="12" cy="12" r="2.5"></circle></svg>
+              </button>
             )}
             <button
               className={`flex items-center justify-center w-[34px] h-[34px] rounded-full transition-colors ${

--- a/components/story/story-app-base.tsx
+++ b/components/story/story-app-base.tsx
@@ -39,7 +39,6 @@ import CSSSchemeBar from "@/components/ui/css-scheme-picker";
 import { Avatar } from "@/components/ui/primitives";
 import { StoryHtmlRenderer } from "@/components/ui/story-html-renderer";
 import { loadCharacters } from "@/lib/character-storage";
-import { getCharacterArchiveImage, getCharacterImageStyle } from "@/lib/character-images";
 import { maybeRunSummarization } from "@/lib/memory-summarizer";
 import { incrementEventCounter } from "@/lib/memory-storage";
 import { resolveUserIdentity } from "@/lib/settings-storage";
@@ -1055,11 +1054,10 @@ export function StoryApp({ onClose }: StoryAppProps) {
             <div className="story-meta">
               <div className="story-meta-layout">
                 <div className="story-meta-cover">
-                  {getCharacterArchiveImage(currentCharacter).image ? (
+                  {currentCharacter.avatar ? (
                     <img
-                      src={getCharacterArchiveImage(currentCharacter).image!}
+                      src={currentCharacter.avatar}
                       alt="cover"
-                      style={getCharacterImageStyle(getCharacterArchiveImage(currentCharacter))}
                     />
                   ) : (
                     <div className="story-meta-cover-fallback" aria-hidden="true">

--- a/components/story/story-app-base.tsx
+++ b/components/story/story-app-base.tsx
@@ -39,6 +39,7 @@ import CSSSchemeBar from "@/components/ui/css-scheme-picker";
 import { Avatar } from "@/components/ui/primitives";
 import { StoryHtmlRenderer } from "@/components/ui/story-html-renderer";
 import { loadCharacters } from "@/lib/character-storage";
+import { getCharacterArchiveImage, getCharacterImageStyle } from "@/lib/character-images";
 import { maybeRunSummarization } from "@/lib/memory-summarizer";
 import { incrementEventCounter } from "@/lib/memory-storage";
 import { resolveUserIdentity } from "@/lib/settings-storage";
@@ -1054,8 +1055,12 @@ export function StoryApp({ onClose }: StoryAppProps) {
             <div className="story-meta">
               <div className="story-meta-layout">
                 <div className="story-meta-cover">
-                  {currentCharacter.avatar ? (
-                    <img src={currentCharacter.avatar} alt="cover" />
+                  {getCharacterArchiveImage(currentCharacter).image ? (
+                    <img
+                      src={getCharacterArchiveImage(currentCharacter).image!}
+                      alt="cover"
+                      style={getCharacterImageStyle(getCharacterArchiveImage(currentCharacter))}
+                    />
                   ) : (
                     <div className="story-meta-cover-fallback" aria-hidden="true">
                       <span className="story-meta-cover-char">{currentCharacter.name.trim().charAt(0) || "书"}</span>

--- a/components/vn/vn-select.tsx
+++ b/components/vn/vn-select.tsx
@@ -3,7 +3,6 @@
 import { useMemo, useState, useRef } from "react";
 import { ArrowLeft, ChevronDown, ImagePlus, MoreHorizontal } from "lucide-react";
 import { loadCharacters } from "@/lib/character-storage";
-import { getCharacterArchiveImage, getCharacterImageStyle } from "@/lib/character-images";
 import { DEFAULT_VN_SUMMARY_PROMPT } from "@/lib/vn-engine";
 import { DEFAULT_VN_BILINGUAL_PROMPT } from "@/lib/bilingual-prompt-defaults";
 import { loadMemoryConfig, saveMemoryConfig } from "@/lib/memory-storage";
@@ -57,7 +56,7 @@ export function VnSelect({ onClose, onSelect, vnTheme, onThemeChange, onOpenAsse
       id: c.id,
       name: c.name,
       subtitle: c.personality?.slice(0, 20) || undefined,
-      archiveImage: getCharacterArchiveImage(c),
+      avatar: c.avatar,
       gradient: hashGradient(c.id, currentTheme),
     }));
   }, [currentTheme]);
@@ -488,10 +487,10 @@ export function VnSelect({ onClose, onSelect, vnTheme, onThemeChange, onOpenAsse
             >
               <div
                 className="vns-strip-bg"
-                style={!char.archiveImage.image ? { background: char.gradient } : undefined}
+                style={!char.avatar ? { background: char.gradient } : undefined}
               >
-                {char.archiveImage.image && (
-                  <img src={char.archiveImage.image} alt="" draggable={false} style={getCharacterImageStyle(char.archiveImage)} />
+                {char.avatar && (
+                  <img src={char.avatar} alt="" draggable={false} />
                 )}
               </div>
               <div className="vns-strip-info">

--- a/components/vn/vn-select.tsx
+++ b/components/vn/vn-select.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState, useRef } from "react";
 import { ArrowLeft, ChevronDown, ImagePlus, MoreHorizontal } from "lucide-react";
 import { loadCharacters } from "@/lib/character-storage";
+import { getCharacterArchiveImage, getCharacterImageStyle } from "@/lib/character-images";
 import { DEFAULT_VN_SUMMARY_PROMPT } from "@/lib/vn-engine";
 import { DEFAULT_VN_BILINGUAL_PROMPT } from "@/lib/bilingual-prompt-defaults";
 import { loadMemoryConfig, saveMemoryConfig } from "@/lib/memory-storage";
@@ -56,7 +57,7 @@ export function VnSelect({ onClose, onSelect, vnTheme, onThemeChange, onOpenAsse
       id: c.id,
       name: c.name,
       subtitle: c.personality?.slice(0, 20) || undefined,
-      avatar: c.avatar || undefined,
+      archiveImage: getCharacterArchiveImage(c),
       gradient: hashGradient(c.id, currentTheme),
     }));
   }, [currentTheme]);
@@ -190,9 +191,16 @@ export function VnSelect({ onClose, onSelect, vnTheme, onThemeChange, onOpenAsse
         .vns-strip-bg {
           position: absolute;
           inset: 0;
+          overflow: hidden;
           background-size: cover;
           background-position: center;
           transition: transform 0.4s ease, filter 0.4s ease;
+        }
+        .vns-strip-bg img {
+          display: block;
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
         }
         .vns-strip:not([data-active="true"]) .vns-strip-bg {
           filter: var(--vns-strip-filter, brightness(0.4) saturate(0.6));
@@ -480,10 +488,12 @@ export function VnSelect({ onClose, onSelect, vnTheme, onThemeChange, onOpenAsse
             >
               <div
                 className="vns-strip-bg"
-                style={{
-                  background: char.avatar ? `url(${char.avatar}) center/cover` : char.gradient,
-                }}
-              />
+                style={!char.archiveImage.image ? { background: char.gradient } : undefined}
+              >
+                {char.archiveImage.image && (
+                  <img src={char.archiveImage.image} alt="" draggable={false} style={getCharacterImageStyle(char.archiveImage)} />
+                )}
+              </div>
               <div className="vns-strip-info">
                 <span className="vns-strip-name">{char.name}</span>
                 <span className="vns-strip-sub">{char.subtitle}</span>

--- a/lib/character-images.ts
+++ b/lib/character-images.ts
@@ -51,16 +51,6 @@ export function getCharacterArchiveCover(character: Character): CharacterImageDi
   };
 }
 
-export function getCharacterArchiveImage(character: Character): CharacterImageDisplay {
-  const display = normalizeCharacterImageDisplay(character.archivePhoto);
-  return {
-    image: display?.image || character.avatar || null,
-    positionX: display?.positionX ?? 50,
-    positionY: display?.positionY ?? 50,
-    scale: display?.scale ?? 1,
-  };
-}
-
 export function getCharacterImageStyle(display: CharacterImageDisplay): CSSProperties {
   const positionX = clampNumber(display.positionX, 0, 100, 50);
   const positionY = clampNumber(display.positionY, 0, 100, 50);

--- a/lib/character-images.ts
+++ b/lib/character-images.ts
@@ -1,0 +1,97 @@
+import type { CSSProperties } from "react";
+import type {
+  Character,
+  CharacterImageDisplay,
+  CharacterPolaroidSize,
+} from "./character-types";
+
+export const CHARACTER_POLAROID_RATIOS = [
+  "ratio-square",
+  "ratio-portrait",
+  "ratio-landscape",
+  "ratio-16-9",
+  "ratio-9-16",
+] as const;
+
+export function isSafeCharacterImageUrl(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const url = value.trim();
+  return Boolean(url) && (
+    url.startsWith("data:") ||
+    url.startsWith("http://") ||
+    url.startsWith("https://")
+  );
+}
+
+function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
+  const numberValue = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(numberValue)) return fallback;
+  return Math.min(max, Math.max(min, numberValue));
+}
+
+export function normalizeCharacterImageDisplay(value: unknown): CharacterImageDisplay | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  const image = isSafeCharacterImageUrl(raw.image) ? raw.image.trim() : null;
+  return {
+    image,
+    positionX: clampNumber(raw.positionX, 0, 100, 50),
+    positionY: clampNumber(raw.positionY, 0, 100, 50),
+    scale: clampNumber(raw.scale, 1, 3, 1),
+  };
+}
+
+export function getCharacterArchiveCover(character: Character): CharacterImageDisplay {
+  const display = normalizeCharacterImageDisplay(character.archiveCover);
+  return {
+    image: display?.image || character.avatar || null,
+    positionX: display?.positionX ?? 50,
+    positionY: display?.positionY ?? 50,
+    scale: display?.scale ?? 1,
+  };
+}
+
+export function getCharacterArchiveImage(character: Character): CharacterImageDisplay {
+  const display = normalizeCharacterImageDisplay(character.archivePhoto);
+  return {
+    image: display?.image || character.avatar || null,
+    positionX: display?.positionX ?? 50,
+    positionY: display?.positionY ?? 50,
+    scale: display?.scale ?? 1,
+  };
+}
+
+export function getCharacterImageStyle(display: CharacterImageDisplay): CSSProperties {
+  const positionX = clampNumber(display.positionX, 0, 100, 50);
+  const positionY = clampNumber(display.positionY, 0, 100, 50);
+  const scale = clampNumber(display.scale, 1, 3, 1);
+  return {
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+    objectPosition: `${positionX}% ${positionY}%`,
+    transform: `scale(${scale})`,
+    transformOrigin: `${positionX}% ${positionY}%`,
+  };
+}
+
+export function isCharacterPolaroidSize(value: unknown): value is CharacterPolaroidSize {
+  return value === "small" || value === "medium" || value === "large";
+}
+
+export function getPolaroidWidth(character: Character, legacyWidth: number): number {
+  const widths: Record<CharacterPolaroidSize, number> = {
+    small: 110,
+    medium: 130,
+    large: 150,
+  };
+  return character.polaroidSize ? widths[character.polaroidSize] : legacyWidth;
+}
+
+export function getPolaroidRatioClass(styleIndex: number): typeof CHARACTER_POLAROID_RATIOS[number] {
+  return CHARACTER_POLAROID_RATIOS[((styleIndex % CHARACTER_POLAROID_RATIOS.length) + CHARACTER_POLAROID_RATIOS.length) % CHARACTER_POLAROID_RATIOS.length];
+}
+
+export function getPolaroidAspectRatio(styleIndex: number): string {
+  return ["1 / 1", "3 / 4", "4 / 3", "16 / 9", "9 / 16"][((styleIndex % 5) + 5) % 5];
+}

--- a/lib/character-storage.ts
+++ b/lib/character-storage.ts
@@ -1,4 +1,9 @@
 import type { Character, CanvasBgItem } from "./character-types";
+import {
+  isCharacterPolaroidSize,
+  isSafeCharacterImageUrl,
+  normalizeCharacterImageDisplay,
+} from "./character-images";
 import { normalizeTimeZone } from "./character-time";
 import { kvGet, kvSet, registerKvMigration } from "./kv-db";
 
@@ -59,9 +64,29 @@ export function loadCharacters(): Character[] {
         else delete char.timeZone;
         needsSave = true;
       }
-      // Sanitize avatars: only keep data-URLs and http(s) URLs
-      if (char.avatar && !char.avatar.startsWith("data:") && !char.avatar.startsWith("http://") && !char.avatar.startsWith("https://")) {
+      // Sanitize all character image URLs consistently.
+      if (char.avatar && !isSafeCharacterImageUrl(char.avatar)) {
         char.avatar = null;
+        needsSave = true;
+      }
+      if (char.archiveCover !== undefined) {
+        const normalized = normalizeCharacterImageDisplay(char.archiveCover);
+        if (JSON.stringify(normalized) !== JSON.stringify(char.archiveCover)) needsSave = true;
+        if (normalized) char.archiveCover = normalized;
+        else delete char.archiveCover;
+      }
+      if (char.archivePhoto !== undefined) {
+        const normalized = normalizeCharacterImageDisplay(char.archivePhoto);
+        if (JSON.stringify(normalized) !== JSON.stringify(char.archivePhoto)) needsSave = true;
+        if (normalized) char.archivePhoto = normalized;
+        else delete char.archivePhoto;
+      }
+      if (char.polaroidStyle !== undefined && (!Number.isFinite(char.polaroidStyle) || char.polaroidStyle < 0 || char.polaroidStyle > 4)) {
+        delete char.polaroidStyle;
+        needsSave = true;
+      }
+      if (char.polaroidSize !== undefined && !isCharacterPolaroidSize(char.polaroidSize)) {
+        delete char.polaroidSize;
         needsSave = true;
       }
       return char as Character;
@@ -140,11 +165,15 @@ export function createCharacter(
 export function exportCharacterAsJson(char: Character): void {
   const payload = {
     schema: "ai_phone_character",
-    schema_version: "1.0",
+    schema_version: "1.1",
     name: char.name,
     description: char.persona,
     personality: char.personality || "",
     avatar: char.avatar ?? "none",
+    archiveCover: char.archiveCover,
+    archivePhoto: char.archivePhoto,
+    polaroidStyle: char.polaroidStyle,
+    polaroidSize: char.polaroidSize,
     tags: char.tags || [],
     wechatID: char.wechatID || "",
     timeZone: char.timeZone || "",
@@ -166,13 +195,10 @@ export function parseCharacterFromJson(
   try {
     const obj = JSON.parse(text) as Record<string, unknown>;
 
-    // Helper: validate avatar — only accept data-URLs and http(s) URLs
+    // Helper: validate character images — only accept data-URLs and http(s) URLs.
     function validAvatar(v: unknown): string | null {
-      if (typeof v !== "string" || !v.trim()) return null;
-      const s = v.trim();
-      if (s === "none") return null;
-      if (s.startsWith("data:") || s.startsWith("http://") || s.startsWith("https://")) return s;
-      return null;
+      if (typeof v !== "string" || !v.trim() || v.trim() === "none") return null;
+      return isSafeCharacterImageUrl(v) ? v.trim() : null;
     }
 
     const src = (obj.schema === "ai_phone_character" && typeof obj.data === "object" && obj.data !== null)
@@ -187,6 +213,12 @@ export function parseCharacterFromJson(
       name: String(src.name ?? ""),
       persona: String(src.description ?? src.persona ?? ""),
       avatar: validAvatar(src.avatar),
+      archiveCover: normalizeCharacterImageDisplay(src.archiveCover),
+      archivePhoto: normalizeCharacterImageDisplay(src.archivePhoto),
+      polaroidStyle: typeof src.polaroidStyle === "number" && Number.isFinite(src.polaroidStyle)
+        ? Math.max(0, Math.min(4, Math.trunc(src.polaroidStyle)))
+        : undefined,
+      polaroidSize: isCharacterPolaroidSize(src.polaroidSize) ? src.polaroidSize : undefined,
       personality: typeof src.personality === "string" && src.personality.trim() ? src.personality : undefined,
       tags: Array.isArray(src.tags) ? src.tags.map(String) : [],
       wechatID: typeof src.wechatID === "string" && src.wechatID.trim() ? src.wechatID : undefined,
@@ -400,11 +432,15 @@ async function avatarToPngBytes(avatar: string | null, name: string): Promise<Ui
 export async function exportCharacterAsPng(char: Character): Promise<void> {
   const payload = {
     schema: "ai_phone_character",
-    schema_version: "1.0",
+    schema_version: "1.1",
     name: char.name,
     description: char.persona,
     personality: char.personality || "",
     avatar: "none",
+    archiveCover: char.archiveCover,
+    archivePhoto: char.archivePhoto,
+    polaroidStyle: char.polaroidStyle,
+    polaroidSize: char.polaroidSize,
     tags: char.tags || [],
     wechatID: char.wechatID || "",
     timeZone: char.timeZone || "",

--- a/lib/character-storage.ts
+++ b/lib/character-storage.ts
@@ -104,7 +104,9 @@ export function loadCharacters(): Character[] {
 
 export function saveCharacters(chars: Character[]): void {
   if (typeof window === "undefined") return;
-  kvSet(STORAGE_KEY, JSON.stringify(chars));
+  // archivePhoto is a legacy read-only field. Drop it whenever a character is saved again.
+  const sanitized = chars.map(({ archivePhoto: _legacyArchivePhoto, ...char }) => char);
+  kvSet(STORAGE_KEY, JSON.stringify(sanitized));
   _charsCache = null;
 }
 
@@ -150,8 +152,9 @@ export function createCharacter(
   data: Omit<Character, "id" | "createdAt" | "updatedAt" | "wechatID"> & { wechatID?: string }
 ): Character {
   const now = new Date().toISOString();
+  const { archivePhoto: _legacyArchivePhoto, ...cleanData } = data;
   return {
-    ...data,
+    ...cleanData,
     id: `char_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
     wechatID: data.wechatID || generateWechatID(),
     tags: data.tags || [],
@@ -171,7 +174,6 @@ export function exportCharacterAsJson(char: Character): void {
     personality: char.personality || "",
     avatar: char.avatar ?? "none",
     archiveCover: char.archiveCover,
-    archivePhoto: char.archivePhoto,
     polaroidStyle: char.polaroidStyle,
     polaroidSize: char.polaroidSize,
     tags: char.tags || [],
@@ -214,7 +216,7 @@ export function parseCharacterFromJson(
       persona: String(src.description ?? src.persona ?? ""),
       avatar: validAvatar(src.avatar),
       archiveCover: normalizeCharacterImageDisplay(src.archiveCover),
-      archivePhoto: normalizeCharacterImageDisplay(src.archivePhoto),
+      // Legacy archivePhoto is accepted in the input but intentionally not propagated.
       polaroidStyle: typeof src.polaroidStyle === "number" && Number.isFinite(src.polaroidStyle)
         ? Math.max(0, Math.min(4, Math.trunc(src.polaroidStyle)))
         : undefined,
@@ -438,7 +440,6 @@ export async function exportCharacterAsPng(char: Character): Promise<void> {
     personality: char.personality || "",
     avatar: "none",
     archiveCover: char.archiveCover,
-    archivePhoto: char.archivePhoto,
     polaroidStyle: char.polaroidStyle,
     polaroidSize: char.polaroidSize,
     tags: char.tags || [],

--- a/lib/character-types.ts
+++ b/lib/character-types.ts
@@ -29,7 +29,8 @@ export type Character = {
   polaroidStyle?: number; // 用户选择的拍立得样式索引
   polaroidSize?: CharacterPolaroidSize; // 未设置时沿用旧版散列自动宽度
   archiveCover?: CharacterImageDisplay; // 档案墙拍立得封面
-  archivePhoto?: CharacterImageDisplay; // 档案详情、剧情与漫卷主视觉
+  /** @deprecated 仅用于兼容旧存储/旧角色卡；新界面、保存和导出均不再使用。 */
+  archivePhoto?: CharacterImageDisplay;
 };
 
 export type CanvasBgItem = {

--- a/lib/character-types.ts
+++ b/lib/character-types.ts
@@ -1,3 +1,12 @@
+export type CharacterImageDisplay = {
+  image?: string | null;
+  positionX?: number; // 0-100
+  positionY?: number; // 0-100
+  scale?: number; // 1-3
+};
+
+export type CharacterPolaroidSize = "small" | "medium" | "large";
+
 export type Character = {
   id: string;
   name: string;
@@ -18,6 +27,9 @@ export type Character = {
   canvasRot?: number;
   canvasZIndex?: number;
   polaroidStyle?: number; // 用户选择的拍立得样式索引
+  polaroidSize?: CharacterPolaroidSize; // 未设置时沿用旧版散列自动宽度
+  archiveCover?: CharacterImageDisplay; // 档案墙拍立得封面
+  archivePhoto?: CharacterImageDisplay; // 档案详情、剧情与漫卷主视觉
 };
 
 export type CanvasBgItem = {

--- a/lib/character-version-storage.ts
+++ b/lib/character-version-storage.ts
@@ -25,7 +25,8 @@ type CharacterVersionState = {
 type CharacterVersionStore = Record<string, CharacterVersionState>;
 
 function cloneCharacter(character: Character): Character {
-  return JSON.parse(JSON.stringify(character)) as Character;
+  const { archivePhoto: _legacyArchivePhoto, ...cleanCharacter } = character;
+  return JSON.parse(JSON.stringify(cleanCharacter)) as Character;
 }
 
 function loadStore(): CharacterVersionStore {

--- a/styles/character.css
+++ b/styles/character.css
@@ -392,25 +392,6 @@
   perspective: 1200px;
 }
 
-.char-clear-transition {
-  position: fixed;
-  z-index: 100;
-  pointer-events: none;
-  will-change: top, left, width, height, opacity, transform;
-}
-
-.char-clear-transition .char-polaroid {
-  width: 100%;
-  height: 100%;
-  cursor: default;
-  box-sizing: border-box;
-}
-
-.char-clear-transition .char-polaroid-img-wrapper {
-  flex: 1 1 auto;
-  min-height: 0;
-}
-
 .char-flipper-inner {
   width: 100%;
   height: 100%;
@@ -1577,35 +1558,6 @@
 .wt-line-label-editable { cursor: pointer; }
 
 /* ═══ DIY 角色档案图片 ═══ */
-.char-edit-tools-stack {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 5px;
-}
-
-.char-animation-mode-control {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  min-height: 30px;
-  padding: 4px 6px;
-  border-radius: 6px;
-  background: rgba(0, 0, 0, 0.05);
-  color: #666;
-  font-size: calc(9px * var(--app-text-scale, 1));
-}
-
-.char-animation-mode-control select {
-  max-width: 82px;
-  border: 0;
-  outline: 0;
-  background: transparent;
-  color: inherit;
-  font: inherit;
-  cursor: pointer;
-}
-
 .char-reset-view-btn {
   display: flex;
   width: 34px;

--- a/styles/character.css
+++ b/styles/character.css
@@ -392,6 +392,25 @@
   perspective: 1200px;
 }
 
+.char-clear-transition {
+  position: fixed;
+  z-index: 100;
+  pointer-events: none;
+  will-change: top, left, width, height, opacity, transform;
+}
+
+.char-clear-transition .char-polaroid {
+  width: 100%;
+  height: 100%;
+  cursor: default;
+  box-sizing: border-box;
+}
+
+.char-clear-transition .char-polaroid-img-wrapper {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .char-flipper-inner {
   width: 100%;
   height: 100%;
@@ -1558,6 +1577,52 @@
 .wt-line-label-editable { cursor: pointer; }
 
 /* ═══ DIY 角色档案图片 ═══ */
+.char-edit-tools-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
+}
+
+.char-animation-mode-control {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 30px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.05);
+  color: #666;
+  font-size: calc(9px * var(--app-text-scale, 1));
+}
+
+.char-animation-mode-control select {
+  max-width: 82px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.char-reset-view-btn {
+  display: flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.05);
+  color: #666;
+  cursor: pointer;
+}
+
+.char-reset-view-btn:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+
 .char-avatar-crop-editor {
   position: absolute;
   z-index: 30;
@@ -1576,7 +1641,7 @@
 .char-avatar-crop-preview {
   position: relative;
   width: 100%;
-  aspect-ratio: 1;
+  aspect-ratio: 3 / 4;
   overflow: hidden;
   border: 1px solid var(--c-input-border);
   background: var(--c-input);
@@ -1630,21 +1695,22 @@
 
 .char-avatar-crop-actions {
   display: flex;
-  justify-content: flex-end;
+  flex-direction: column;
   gap: 6px;
 }
 
 .char-avatar-crop-actions button {
-  min-height: 30px;
-  padding: 5px 10px;
+  width: 100%;
+  min-height: 32px;
+  padding: 6px 10px;
   border: 1px solid var(--c-input-border);
-  border-radius: 3px;
+  border-radius: 6px;
   background: var(--c-panel);
   color: var(--c-text-title);
   cursor: pointer;
 }
 
-.char-avatar-crop-actions button:last-child {
+.char-avatar-crop-actions button:first-child {
   background: var(--c-text-title);
   color: var(--c-page-body-bg);
 }
@@ -1826,14 +1892,6 @@
     gap: 5px;
   }
 
-  .char-avatar-crop-actions {
-    flex-wrap: wrap;
-  }
-
-  .char-avatar-crop-actions button {
-    flex: 1;
-    min-width: 64px;
-  }
 
   .char-image-editor-layout {
     grid-template-columns: 88px minmax(0, 1fr);

--- a/styles/character.css
+++ b/styles/character.css
@@ -1647,13 +1647,14 @@
 }
 
 .char-avatar-crop-editor {
+  --char-image-control-blue: #1a73e8;
   position: absolute;
   z-index: 30;
   top: 116px;
   left: 12px;
   right: 12px;
   display: grid;
-  grid-template-columns: minmax(120px, 180px) minmax(0, 1fr);
+  grid-template-columns: minmax(120px, 160px) minmax(0, 1fr);
   gap: 12px;
   padding: 12px;
   border: 1px solid var(--c-panel-border);
@@ -1704,9 +1705,9 @@
 
 .char-avatar-crop-controls label {
   display: grid;
-  grid-template-columns: 36px minmax(0, 1fr);
+  grid-template-columns: 26px minmax(0, 1fr);
   align-items: center;
-  gap: 8px;
+  gap: 2px;
   color: var(--c-text);
   font-size: calc(10px * var(--app-text-scale, 1));
 }
@@ -1714,7 +1715,7 @@
 .char-avatar-crop-controls input[type="range"] {
   width: 100%;
   min-width: 0;
-  accent-color: #0b7fdc;
+  accent-color: var(--char-image-control-blue);
 }
 
 .char-avatar-crop-actions {
@@ -1729,10 +1730,10 @@
   height: 42px;
   min-height: 42px;
   padding: 6px 10px;
-  border: 2px solid #0b7fdc;
-  border-radius: 7px;
+  border: 2px solid var(--char-image-control-blue);
+  border-radius: 999px;
   background: #ffffff;
-  color: #0b7fdc;
+  color: var(--char-image-control-blue);
   font-family: inherit;
   font-size: calc(12px * var(--app-text-scale, 1));
   font-weight: 500;
@@ -1741,8 +1742,8 @@
 }
 
 .char-avatar-crop-actions button:first-child {
-  border-color: #0b7fdc;
-  background: #0b7fdc;
+  border-color: var(--char-image-control-blue);
+  background: var(--char-image-control-blue);
   color: #ffffff;
 }
 
@@ -1792,6 +1793,7 @@
 }
 
 .char-image-editor {
+  --char-image-control-blue: #1a73e8;
   padding: 10px 0;
   border-top: 1px dashed var(--c-panel-border);
 }
@@ -1901,6 +1903,7 @@
 .char-image-editor-controls input[type="range"] {
   width: 100%;
   min-width: 0;
+  accent-color: var(--char-image-control-blue);
 }
 
 .char-polaroid-options {

--- a/styles/character.css
+++ b/styles/character.css
@@ -425,7 +425,88 @@
 
 .char-flipper-back {
   transform: rotateY(180deg);
-  pointer-events: auto;
+  pointer-events: none;
+}
+
+.char-flipper-container,
+.char-flipper-inner,
+.char-flipper-front,
+.char-flipper-back {
+  -webkit-backface-visibility: hidden;
+}
+
+.char-flipper-paper {
+  position: relative;
+  overflow: hidden;
+  padding: 22px;
+  background: var(--c-page-body-bg);
+  color: var(--c-text-title);
+  font-family: "Courier New", monospace;
+  box-shadow: inset 0 0 0 1px var(--c-panel-border);
+}
+
+.char-flipper-paper-stamp {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  padding: 4px 8px;
+  border: 2px solid rgba(180, 45, 45, 0.65);
+  color: rgba(180, 45, 45, 0.72);
+  font-size: calc(12px * var(--app-text-scale, 1));
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  transform: rotate(8deg);
+}
+
+.char-flipper-paper-title {
+  padding: 10px 0 12px;
+  font-size: calc(18px * var(--app-text-scale, 1));
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+
+.char-flipper-paper-rule {
+  height: 2px;
+  margin-bottom: 18px;
+  background: var(--c-panel-border);
+}
+
+.char-flipper-paper-grid {
+  display: grid;
+  grid-template-columns: 90px minmax(0, 1fr);
+  gap: 14px;
+  align-items: center;
+}
+
+.char-flipper-paper-grid strong,
+.char-flipper-paper-grid span {
+  display: block;
+}
+
+.char-flipper-paper-grid strong {
+  font-size: calc(17px * var(--app-text-scale, 1));
+}
+
+.char-flipper-paper-grid span {
+  margin-top: 5px;
+  color: var(--c-text);
+  font-size: calc(9px * var(--app-text-scale, 1));
+  letter-spacing: 0.08em;
+}
+
+.char-flipper-paper-portrait {
+  width: 90px;
+  aspect-ratio: 1;
+  overflow: hidden;
+  border: 1px solid var(--c-panel-border);
+  background: var(--c-input);
+}
+
+.char-flipper-paper-portrait img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 /* ── 绝密档案详情页 (Archival Info) ── */
@@ -1477,6 +1558,116 @@
 .wt-line-label-editable { cursor: pointer; }
 
 /* ═══ DIY 角色档案图片 ═══ */
+.char-avatar-crop-editor {
+  position: absolute;
+  z-index: 30;
+  top: 116px;
+  left: 12px;
+  right: 12px;
+  display: grid;
+  grid-template-columns: minmax(120px, 180px) minmax(0, 1fr);
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--c-panel-border);
+  background: var(--c-panel);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.26);
+}
+
+.char-avatar-crop-preview {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1;
+  overflow: hidden;
+  border: 1px solid var(--c-input-border);
+  background: var(--c-input);
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+
+.char-avatar-crop-preview:active {
+  cursor: grabbing;
+}
+
+.char-avatar-crop-preview img {
+  display: block;
+  pointer-events: none;
+}
+
+.char-avatar-crop-preview > span {
+  position: absolute;
+  right: 5px;
+  bottom: 5px;
+  padding: 2px 5px;
+  border-radius: 2px;
+  background: rgba(0, 0, 0, 0.62);
+  color: #fff;
+  font-size: calc(8px * var(--app-text-scale, 1));
+  pointer-events: none;
+}
+
+.char-avatar-crop-controls {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+  gap: 8px;
+}
+
+.char-avatar-crop-controls label {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  align-items: center;
+  gap: 6px;
+  color: var(--c-text);
+  font-size: calc(10px * var(--app-text-scale, 1));
+}
+
+.char-avatar-crop-controls input[type="range"] {
+  width: 100%;
+  min-width: 0;
+}
+
+.char-avatar-crop-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.char-avatar-crop-actions button {
+  min-height: 30px;
+  padding: 5px 10px;
+  border: 1px solid var(--c-input-border);
+  border-radius: 3px;
+  background: var(--c-panel);
+  color: var(--c-text-title);
+  cursor: pointer;
+}
+
+.char-avatar-crop-actions button:last-child {
+  background: var(--c-text-title);
+  color: var(--c-page-body-bg);
+}
+
+.char-avatar-crop-actions button:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.char-avatar-crop-error {
+  position: absolute;
+  z-index: 31;
+  top: 108px;
+  left: 12px;
+  right: 12px;
+  padding: 7px 9px;
+  border: 1px solid var(--c-danger);
+  background: var(--c-panel);
+  color: var(--c-danger);
+  font-size: calc(9px * var(--app-text-scale, 1));
+  line-height: 1.45;
+}
+
 .char-image-diy-section {
   padding: 12px;
   border-bottom: 1px solid var(--c-panel-border);
@@ -1620,6 +1811,26 @@
 }
 
 @media (max-width: 360px) {
+  .char-avatar-crop-editor {
+    top: 104px;
+    grid-template-columns: 104px minmax(0, 1fr);
+    gap: 8px;
+    padding: 8px;
+  }
+
+  .char-avatar-crop-controls {
+    gap: 5px;
+  }
+
+  .char-avatar-crop-actions {
+    flex-wrap: wrap;
+  }
+
+  .char-avatar-crop-actions button {
+    flex: 1;
+    min-width: 64px;
+  }
+
   .char-image-editor-layout {
     grid-template-columns: 88px minmax(0, 1fr);
   }

--- a/styles/character.css
+++ b/styles/character.css
@@ -1475,3 +1475,156 @@
 
 /* 关系标签在编辑模式下可点（剪断关系） */
 .wt-line-label-editable { cursor: pointer; }
+
+/* ═══ DIY 角色档案图片 ═══ */
+.char-image-diy-section {
+  padding: 12px;
+  border-bottom: 1px solid var(--c-panel-border);
+  background: color-mix(in srgb, var(--c-input) 34%, transparent);
+}
+
+.char-image-diy-title {
+  font-family: "Courier New", monospace;
+  font-size: calc(12px * var(--app-text-scale, 1));
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: var(--c-text-title);
+}
+
+.char-image-diy-help {
+  margin: 4px 0 12px;
+  font-size: calc(10px * var(--app-text-scale, 1));
+  line-height: 1.5;
+  color: var(--c-text);
+  opacity: 0.72;
+}
+
+.char-image-editor {
+  padding: 10px 0;
+  border-top: 1px dashed var(--c-panel-border);
+}
+
+.char-image-diy-label {
+  display: block;
+  margin-bottom: 6px;
+  font-family: "Courier New", monospace;
+  font-size: calc(10px * var(--app-text-scale, 1));
+  font-weight: 700;
+  color: var(--c-text-title);
+}
+
+.char-image-editor-layout {
+  display: grid;
+  grid-template-columns: 104px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+}
+
+.char-image-editor-preview {
+  position: relative;
+  width: 104px;
+  aspect-ratio: 3 / 4;
+  overflow: hidden;
+  border: 1px solid var(--c-panel-border);
+  background: var(--c-input);
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+
+.char-image-editor-preview:active {
+  cursor: grabbing;
+}
+
+.char-image-editor-preview img {
+  display: block;
+  pointer-events: none;
+}
+
+.char-image-editor-preview > span {
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+  padding: 2px 4px;
+  border-radius: 2px;
+  background: rgba(0, 0, 0, 0.56);
+  color: #fff;
+  font-size: calc(8px * var(--app-text-scale, 1));
+  pointer-events: none;
+}
+
+.char-image-editor-controls {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.char-image-editor-buttons,
+.char-image-url-row,
+.char-image-choice-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.char-image-editor button,
+.char-image-choice-row button {
+  min-height: 28px;
+  padding: 4px 7px;
+  border: 1px solid var(--c-input-border);
+  border-radius: 3px;
+  background: var(--c-panel);
+  color: var(--c-text-title);
+  font-size: calc(9px * var(--app-text-scale, 1));
+  cursor: pointer;
+}
+
+.char-image-choice-row button.active {
+  border-color: var(--c-text-title);
+  background: var(--c-text-title);
+  color: var(--c-page-body-bg);
+}
+
+.char-image-url-row input {
+  flex: 1;
+  min-width: 80px;
+  padding: 5px 6px;
+  border: 1px solid var(--c-input-border);
+  border-radius: 3px;
+  background: var(--c-input);
+  color: var(--c-text-title);
+  font-size: calc(9px * var(--app-text-scale, 1));
+}
+
+.char-image-editor-controls label {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  align-items: center;
+  gap: 5px;
+  font-size: calc(9px * var(--app-text-scale, 1));
+  color: var(--c-text);
+}
+
+.char-image-editor-controls input[type="range"] {
+  width: 100%;
+  min-width: 0;
+}
+
+.char-polaroid-options {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+  padding-top: 10px;
+  border-top: 1px dashed var(--c-panel-border);
+}
+
+@media (max-width: 360px) {
+  .char-image-editor-layout {
+    grid-template-columns: 88px minmax(0, 1fr);
+  }
+
+  .char-image-editor-preview {
+    width: 88px;
+  }
+}

--- a/styles/character.css
+++ b/styles/character.css
@@ -1655,17 +1655,21 @@
 }
 
 .char-avatar-crop-error {
-  position: absolute;
-  z-index: 31;
-  top: 108px;
-  left: 12px;
-  right: 12px;
+  grid-column: 1 / -1;
   padding: 7px 9px;
   border: 1px solid var(--c-danger);
   background: var(--c-panel);
   color: var(--c-danger);
   font-size: calc(9px * var(--app-text-scale, 1));
   line-height: 1.45;
+}
+
+.char-avatar-crop-error-standalone {
+  position: absolute;
+  z-index: 31;
+  top: 108px;
+  left: 12px;
+  right: 12px;
 }
 
 .char-image-diy-section {

--- a/styles/character.css
+++ b/styles/character.css
@@ -1575,6 +1575,77 @@
   background: rgba(0, 0, 0, 0.1);
 }
 
+.char-move-world-dialog {
+  width: calc(100% - 40px);
+  max-width: 390px;
+  overflow: hidden;
+  border-radius: 18px;
+  background: #ffffff;
+  color: #292d35;
+  box-shadow: 0 20px 52px rgba(0, 0, 0, 0.22);
+}
+
+.char-move-world-title {
+  margin: 0;
+  padding: 32px 24px 28px;
+  text-align: center;
+  font-size: calc(18px * var(--app-text-scale, 1));
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.char-move-world-list {
+  max-height: 40dvh;
+  overflow-y: auto;
+  padding: 0 24px 26px;
+}
+
+.char-move-world-option {
+  display: flex;
+  width: 100%;
+  min-height: 52px;
+  align-items: center;
+  margin: 0 0 10px;
+  padding: 10px 20px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 10px;
+  background: #f7f7f7;
+  color: #333333;
+  font-family: inherit;
+  font-size: calc(15px * var(--app-text-scale, 1));
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+}
+
+.char-move-world-option:last-child {
+  margin-bottom: 0;
+}
+
+.char-move-world-empty {
+  padding: 18px 10px 28px;
+  color: #999999;
+  text-align: center;
+  font-size: calc(12px * var(--app-text-scale, 1));
+}
+
+.char-move-world-footer {
+  padding: 0 24px 24px;
+}
+
+.char-move-world-cancel {
+  width: 100%;
+  min-height: 52px;
+  border: 0;
+  border-radius: 10px;
+  background: #f6f6f6;
+  color: #292d35;
+  font-family: inherit;
+  font-size: calc(15px * var(--app-text-scale, 1));
+  font-weight: 600;
+  cursor: pointer;
+}
+
 .char-avatar-crop-editor {
   position: absolute;
   z-index: 30;
@@ -1628,14 +1699,14 @@
   min-width: 0;
   flex-direction: column;
   justify-content: center;
-  gap: 8px;
+  gap: 14px;
 }
 
 .char-avatar-crop-controls label {
   display: grid;
   grid-template-columns: 36px minmax(0, 1fr);
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   color: var(--c-text);
   font-size: calc(10px * var(--app-text-scale, 1));
 }
@@ -1643,28 +1714,36 @@
 .char-avatar-crop-controls input[type="range"] {
   width: 100%;
   min-width: 0;
+  accent-color: #0b7fdc;
 }
 
 .char-avatar-crop-actions {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 10px;
+  margin-top: 2px;
 }
 
 .char-avatar-crop-actions button {
   width: 100%;
-  min-height: 32px;
+  height: 42px;
+  min-height: 42px;
   padding: 6px 10px;
-  border: 1px solid var(--c-input-border);
-  border-radius: 6px;
-  background: var(--c-panel);
-  color: var(--c-text-title);
+  border: 2px solid #0b7fdc;
+  border-radius: 7px;
+  background: #ffffff;
+  color: #0b7fdc;
+  font-family: inherit;
+  font-size: calc(12px * var(--app-text-scale, 1));
+  font-weight: 500;
   cursor: pointer;
+  box-sizing: border-box;
 }
 
 .char-avatar-crop-actions button:first-child {
-  background: var(--c-text-title);
-  color: var(--c-page-body-bg);
+  border-color: #0b7fdc;
+  background: #0b7fdc;
+  color: #ffffff;
 }
 
 .char-avatar-crop-actions button:disabled {
@@ -1841,7 +1920,7 @@
   }
 
   .char-avatar-crop-controls {
-    gap: 5px;
+    gap: 10px;
   }
 
 

--- a/styles/character.css
+++ b/styles/character.css
@@ -108,6 +108,7 @@
   position: absolute;
   width: 130px;
   /* 固定尺寸，适合散落布局 */
+  transform-style: flat;
 }
 
 /* 设置不同的拍立得长宽比例 */


### PR DESCRIPTION
贡献者：什锦杂货铺（小红书）
功能入口：角色卡——具体角色——编辑。
档案墙封面仅作用于档案墙，不会替代基础头像的其他作用。
如果觉得角色卡页的DIY image profile描述过于冗杂，可以修改或者直接删掉。
如果觉得蓝色拉杆UI和选项卡不好看，可以换成别的颜色，或者重做UI交互。
更清晰的档案墙封面和基础头像，需要在装有该功能后新建角色，或者在旧角色卡上重新上传图片，才可以作用。
清晰的档案墙封面，主要体现在在档案墙封面展示，以及飞近翻页动画，这也是目前档案封面仅会出现的地方。
清晰的基础头像，将自然作用到角色卡基础头像，聊天头像（Avatar），剧情封面，漫卷封面等会调用到基础图像的地方。本人在此贡献上并没有额外修改基础头像的功能。
如果只上传档案墙封面，不上传基础头像，由于档案墙封面并不会代替基础头像，所以基础头像会自然地空着。
基础头像可以作用到档案封面，但档案封面无法作用基础头像。
以上内容经过六版改良与自测，内容属实。
（最后是关于表情包备注与改名功能的回复：由于增加了备注导致角色绑定和表情包整体往下移了，确实会有些麻烦，我接受官方后续调整，就我个人后续改进想法，大概会默认折叠起来，需要用户点击才能进入更改备注。当然如果老师你愿意帮我改，我也非常感谢！（？）