### PR TITLE
V2优化版表情包改名+备注

### DIFF
--- a/components/chat/mascot-chat-room.tsx
+++ b/components/chat/mascot-chat-room.tsx
@@ -26,6 +26,7 @@ import {
     stopMascotGeneration,
     subscribeMascotChat,
     switchMascotSession,
+    toggleMascotSessionPin,
 } from "@/lib/mascot-chat-store";
 import type { MascotMsg } from "@/lib/mascot-engine";
 import { getMascotContext, subscribeMascotContext } from "@/lib/mascot-context";
@@ -145,6 +146,7 @@ function MascotInfoPanel({
     const [cssDraft, setCssDraft] = useState(settings.chatCustomCSS || "");
     const [showConfirmClearTools, setShowConfirmClearTools] = useState(false);
     const [showConfirmDelete, setShowConfirmDelete] = useState(false);
+    const [sessionContextMenu, setSessionContextMenu] = useState<{ id: string; x: number; y: number } | null>(null);
     const chat = useSyncExternalStore(subscribeMascotChat, getMascotChatSnapshot, getMascotChatSnapshot);
     const hasToolHistory = hasMascotToolHistoryMessages(chat.messages);
     const hasCustomAvatar = !!settings.avatarImage && settings.avatarImage !== DEFAULT_MASCOT_AVATAR;
@@ -312,30 +314,63 @@ function MascotInfoPanel({
                                     onClick={() => {
                                         if (switchMascotSession(session.id)) onClose();
                                     }}
+                                    onContextMenu={(e) => {
+                                        e.preventDefault();
+                                        setSessionContextMenu({ id: session.id, x: e.clientX, y: e.clientY });
+                                    }}
                                     style={{ opacity: chat.isThinking ? 0.55 : 1 }}
                                 >
-                                    <span className="menu-label truncate">{session.title}{active ? "（当前）" : ""}</span>
+                                    <span className="menu-label truncate">{session.pinned ? "📌 " : ""}{session.title}{active ? "（当前）" : ""}</span>
                                     <span className="menu-desc">{new Date(session.updatedAt).toLocaleString()}</span>
                                 </button>
-                                <button
-                                    type="button"
-                                    className="menu-desc shrink-0"
-                                    disabled={chat.isThinking}
-                                    onClick={() => {
-                                        const title = window.prompt("重命名对话", session.title);
-                                        if (title !== null) renameMascotSession(session.id, title);
-                                    }}
-                                >改名</button>
-                                <button
-                                    type="button"
-                                    className="menu-desc shrink-0 text-[var(--c-danger)]"
-                                    disabled={chat.isThinking}
-                                    onClick={() => {
-                                        if (window.confirm(`确定删除对话“${session.title}”吗？此操作不会删除角色卡，但无法恢复这段聊天记录。`)) {
-                                            deleteMascotSession(session.id);
-                                        }
-                                    }}
-                                >删除</button>
+                                {sessionContextMenu?.id === session.id && createPortal(
+                                    <div
+                                        className="fixed inset-0 z-[9999]"
+                                        onClick={() => setSessionContextMenu(null)}
+                                        onContextMenu={(e) => { e.preventDefault(); setSessionContextMenu(null); }}
+                                    >
+                                        <div
+                                            className="absolute bg-[var(--c-page-bg)] border border-[var(--c-border)] rounded shadow-lg py-1 w-32"
+                                            style={{
+                                                left: Math.min(sessionContextMenu.x, window.innerWidth - 128),
+                                                top: Math.min(sessionContextMenu.y, window.innerHeight - 150),
+                                            }}
+                                            onClick={(e) => e.stopPropagation()}
+                                        >
+                                            <button
+                                                className="w-full text-left px-4 py-2 ts-14 text-[var(--c-text)] hover:bg-[var(--c-page-body-bg)]"
+                                                onClick={() => {
+                                                    toggleMascotSessionPin(session.id);
+                                                    setSessionContextMenu(null);
+                                                }}
+                                            >
+                                                {session.pinned ? "取消置顶" : "置顶"}
+                                            </button>
+                                            <button
+                                                className="w-full text-left px-4 py-2 ts-14 text-[var(--c-text)] hover:bg-[var(--c-page-body-bg)]"
+                                                onClick={() => {
+                                                    const title = window.prompt("重命名对话", session.title);
+                                                    if (title !== null) renameMascotSession(session.id, title);
+                                                    setSessionContextMenu(null);
+                                                }}
+                                            >
+                                                改名
+                                            </button>
+                                            <button
+                                                className="w-full text-left px-4 py-2 ts-14 text-[var(--c-danger)] hover:bg-[var(--c-page-body-bg)]"
+                                                onClick={() => {
+                                                    if (window.confirm(`确定删除对话“${session.title}”吗？此操作不会删除角色卡，但无法恢复这段聊天记录。`)) {
+                                                        deleteMascotSession(session.id);
+                                                    }
+                                                    setSessionContextMenu(null);
+                                                }}
+                                            >
+                                                删除
+                                            </button>
+                                        </div>
+                                    </div>,
+                                    document.body
+                                )}
                             </div>
                         );
                     })}

--- a/components/chat/sticker-manager.tsx
+++ b/components/chat/sticker-manager.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useCallback, useState, useEffect, useRef, useMemo } from "react";
 import { createPortal } from "react-dom";
-import { Trash2, Plus, Smile, ImagePlus, ChevronRight, ChevronDown, Pencil, Check, Sticker, Layers } from "lucide-react";
+import { Trash2, Plus, Smile, ImagePlus, ChevronRight, ChevronDown, Pencil, Check, Sticker, Layers, Info } from "lucide-react";
 import { loadCharacters } from "@/lib/character-storage";
 import type { Character } from "@/lib/character-types";
 import {
@@ -164,6 +164,7 @@ function CreatePackDialog({
     onCancel: () => void;
 }) {
     const [name, setName] = useState("");
+    const [note, setNote] = useState("");
     const [selectedCharIds, setSelectedCharIds] = useState<string[]>([]);
 
     const handleToggle = (charId: string) => {
@@ -175,7 +176,7 @@ function CreatePackDialog({
     const handleCreate = () => {
         const trimmed = name.trim();
         if (!trimmed) return;
-        const pack = createStickerPack(trimmed);
+        const pack = createStickerPack(trimmed, note.trim());
         for (const charId of selectedCharIds) {
             togglePackAssignment(pack.id, charId);
         }
@@ -200,6 +201,17 @@ function CreatePackDialog({
                                 onChange={e => setName(e.target.value)}
                                 placeholder="例如：可爱猫猫"
                                 className="ui-input"
+                            />
+                        </div>
+
+                        <div className="flex flex-col gap-1">
+                            <label className="menu-desc ml-1">备注 (可选)</label>
+                            <textarea
+                                value={note}
+                                maxLength={STICKER_PACK_NOTE_MAX}
+                                onChange={e => setNote(e.target.value)}
+                                placeholder="例如：由某某老师整理分享，目前还差 20 个表情待整理"
+                                className="ui-input min-h-[64px] resize-none"
                             />
                         </div>
 
@@ -495,7 +507,19 @@ function PackEditor({ pack, onBack }: { pack: StickerPack; onBack: () => void })
                         aria-expanded={isNoteExpanded}
                         className="w-full flex items-center justify-between px-1 py-2 text-left text-[var(--c-text)]"
                     >
-                        <span className="text-[calc(12px*var(--app-text-scale,1))] font-bold opacity-60 uppercase tracking-[0.1em]">备注</span>
+                        <div className="flex items-center gap-1.5">
+                            <span className="text-[calc(12px*var(--app-text-scale,1))] font-bold opacity-60 uppercase tracking-[0.1em]">备注</span>
+                            <div
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    alert("备注仅供用户私人整理使用，角色和助手小卷暂无法查看。");
+                                }}
+                                className="flex items-center justify-center text-[var(--c-icon)] opacity-50 active:opacity-100 transition-opacity"
+                                aria-label="备注说明"
+                            >
+                                <Info size={14} />
+                            </div>
+                        </div>
                         {isNoteExpanded ? <ChevronDown size={17} /> : <ChevronRight size={17} />}
                     </button>
                     {isNoteExpanded && (

--- a/components/chat/sticker-manager.tsx
+++ b/components/chat/sticker-manager.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useCallback, useState, useEffect, useRef, useMemo } from "react";
 import { createPortal } from "react-dom";
-import { Trash2, Plus, Smile, ImagePlus, ChevronRight, Sticker, Layers } from "lucide-react";
+import { Trash2, Plus, Smile, ImagePlus, ChevronRight, ChevronDown, Pencil, Check, Sticker, Layers } from "lucide-react";
 import { loadCharacters } from "@/lib/character-storage";
 import type { Character } from "@/lib/character-types";
 import {
@@ -19,6 +19,9 @@ import {
     togglePackAssignment,
     resolvePackStickerMap,
     getCharacterPackIds,
+    updateStickerPackInfo,
+    STICKER_PACK_NAME_MAX,
+    STICKER_PACK_NOTE_MAX,
     type StickerItem,
     type StickerPack,
 } from "@/lib/custom-sticker-storage";
@@ -193,6 +196,7 @@ function CreatePackDialog({
                             <input
                                 type="text"
                                 value={name}
+                                maxLength={STICKER_PACK_NAME_MAX}
                                 onChange={e => setName(e.target.value)}
                                 placeholder="例如：可爱猫猫"
                                 className="ui-input"
@@ -329,6 +333,10 @@ function PackEditor({ pack, onBack }: { pack: StickerPack; onBack: () => void })
     const [assignedCharIds, setAssignedCharIds] = useState<string[]>([]);
     const [showAddDialog, setShowAddDialog] = useState(false);
     const [showBatchDialog, setShowBatchDialog] = useState(false);
+    const [isEditingPackName, setIsEditingPackName] = useState(false);
+    const [packNameDraft, setPackNameDraft] = useState(pack.name);
+    const [isNoteExpanded, setIsNoteExpanded] = useState(false);
+    const [packNoteDraft, setPackNoteDraft] = useState(pack.note ?? "");
 
     const refreshPack = useCallback(() => {
         const fresh = loadStickerPacks().find(p => p.id === pack.id);
@@ -399,8 +407,65 @@ function PackEditor({ pack, onBack }: { pack: StickerPack; onBack: () => void })
         refreshAssignments();
     };
 
+    const savePackInfo = useCallback((name: string, note: string) => {
+        const trimmedName = name.trim();
+        if (!trimmedName) return false;
+        updateStickerPackInfo(pack.id, {
+            name: trimmedName,
+            note: note.trim().slice(0, STICKER_PACK_NOTE_MAX),
+        });
+        refreshPack();
+        return true;
+    }, [pack.id, refreshPack]);
+
+    const handlePackNameSave = () => {
+        const trimmedName = packNameDraft.trim();
+        if (savePackInfo(trimmedName, currentPack.note ?? "")) {
+            setPackNameDraft(trimmedName);
+            setIsEditingPackName(false);
+        }
+    };
+
+    const handleNoteSave = () => {
+        const trimmedNote = packNoteDraft.trim().slice(0, STICKER_PACK_NOTE_MAX);
+        if (savePackInfo(currentPack.name, trimmedNote)) {
+            setPackNoteDraft(trimmedNote);
+        }
+    };
+
     return (
-        <PageShell title={currentPack.name} onBack={onBack} className="absolute inset-0 z-[100]">
+        <PageShell
+            title={isEditingPackName ? (
+                <input
+                    autoFocus
+                    type="text"
+                    value={packNameDraft}
+                    maxLength={STICKER_PACK_NAME_MAX}
+                    onChange={e => setPackNameDraft(e.target.value)}
+                    onKeyDown={e => {
+                        if (e.key === "Enter") handlePackNameSave();
+                        if (e.key === "Escape") {
+                            setPackNameDraft(currentPack.name);
+                            setIsEditingPackName(false);
+                        }
+                    }}
+                    className="ui-input h-9 w-full min-w-0 px-2 text-center font-bold"
+                    aria-label="表情包名称"
+                />
+            ) : currentPack.name}
+            onBack={onBack}
+            rightAction={
+                <button
+                    type="button"
+                    onClick={isEditingPackName ? handlePackNameSave : () => setIsEditingPackName(true)}
+                    aria-label={isEditingPackName ? "保存表情包名称" : "编辑表情包名称"}
+                    className="w-10 h-10 flex items-center justify-center rounded-full text-[var(--c-icon)] active:scale-95 transition-transform"
+                >
+                    {isEditingPackName ? <Check size={20} /> : <Pencil size={18} />}
+                </button>
+            }
+            className="absolute inset-0 z-[100]"
+        >
             <div className="flex flex-col h-full bg-[var(--c-page-body-bg)]">
                 {/* Character assignment section */}
                 <div className="px-6 pt-5 pb-2 shrink-0">
@@ -420,6 +485,34 @@ function PackEditor({ pack, onBack }: { pack: StickerPack; onBack: () => void })
                             );
                         })}
                     </div>
+                </div>
+
+                {/* Pack note section */}
+                <div className="px-6 pt-2 pb-4 shrink-0">
+                    <button
+                        type="button"
+                        onClick={() => setIsNoteExpanded(prev => !prev)}
+                        aria-expanded={isNoteExpanded}
+                        className="w-full flex items-center justify-between px-1 py-2 text-left text-[var(--c-text)]"
+                    >
+                        <span className="text-[calc(12px*var(--app-text-scale,1))] font-bold opacity-60 uppercase tracking-[0.1em]">备注</span>
+                        {isNoteExpanded ? <ChevronDown size={17} /> : <ChevronRight size={17} />}
+                    </button>
+                    {isNoteExpanded && (
+                        <div className="flex flex-col gap-2 px-1 pt-1">
+                            <textarea
+                                value={packNoteDraft}
+                                maxLength={STICKER_PACK_NOTE_MAX}
+                                onChange={e => setPackNoteDraft(e.target.value)}
+                                placeholder="为这个表情包添加备注"
+                                className="ui-input min-h-[88px] resize-none"
+                            />
+                            <div className="flex items-center justify-between">
+                                <span className="ts-11 text-[var(--c-text)] opacity-50">{packNoteDraft.length}/{STICKER_PACK_NOTE_MAX}</span>
+                                <button type="button" onClick={handleNoteSave} className="ui-btn ui-btn-primary ts-12">保存</button>
+                            </div>
+                        </div>
+                    )}
                 </div>
 
                 {/* Sticker grid canvas */}

--- a/components/chat/sticker-manager.tsx
+++ b/components/chat/sticker-manager.tsx
@@ -88,6 +88,9 @@ export function StickerManager({ onBack }: { onBack: () => void }) {
                                 <div className="flex flex-col w-full gap-0.5">
                                     <span className="ts-16 text-[var(--c-text-title)] font-bold truncate max-w-full leading-tight">{pack.name}</span>
                                     <span className="ts-12 text-[var(--c-text)] opacity-70">{pack.stickers.length === 0 ? "空相册" : `${pack.stickers.length} 个表情`}</span>
+                                    {pack.note && (
+                                        <span className="ts-11 text-[var(--c-text)] opacity-50 truncate max-w-full mt-0.5">{pack.note}</span>
+                                    )}
                                 </div>
 
                                 {assignedNames.length > 0 && (
@@ -349,6 +352,7 @@ function PackEditor({ pack, onBack }: { pack: StickerPack; onBack: () => void })
     const [packNameDraft, setPackNameDraft] = useState(pack.name);
     const [isNoteExpanded, setIsNoteExpanded] = useState(false);
     const [packNoteDraft, setPackNoteDraft] = useState(pack.note ?? "");
+    const [showNoteInfo, setShowNoteInfo] = useState(false);
 
     const refreshPack = useCallback(() => {
         const fresh = loadStickerPacks().find(p => p.id === pack.id);
@@ -512,7 +516,7 @@ function PackEditor({ pack, onBack }: { pack: StickerPack; onBack: () => void })
                             <div
                                 onClick={(e) => {
                                     e.stopPropagation();
-                                    alert("备注仅供用户私人整理使用，角色和助手小卷暂无法查看。");
+                                    setShowNoteInfo(true);
                                 }}
                                 className="flex items-center justify-center text-[var(--c-icon)] opacity-50 active:opacity-100 transition-opacity"
                                 aria-label="备注说明"
@@ -595,6 +599,18 @@ function PackEditor({ pack, onBack }: { pack: StickerPack; onBack: () => void })
                     packId={pack.id}
                     onDone={() => { setShowBatchDialog(false); refreshPack(); }}
                     onCancel={() => setShowBatchDialog(false)}
+                />,
+                document.querySelector(".phone-shell") ?? document.body
+            )}
+
+            {showNoteInfo && createPortal(
+                <ConfirmDialog
+                    title="备注说明"
+                    message="备注仅供用户私人整理使用，角色和助手小卷暂无法查看。"
+                    confirmLabel="我知道了"
+                    cancelLabel=""
+                    onConfirm={() => setShowNoteInfo(false)}
+                    onCancel={() => setShowNoteInfo(false)}
                 />,
                 document.querySelector(".phone-shell") ?? document.body
             )}

--- a/lib/custom-sticker-storage.ts
+++ b/lib/custom-sticker-storage.ts
@@ -31,6 +31,8 @@ export interface StickerItem {
 export interface StickerPack {
     id: string;
     name: string;
+    /** Optional note for the whole pack. Missing on legacy data. */
+    note?: string;
     stickers: StickerItem[];
     createdAt: string;
 }
@@ -72,10 +74,22 @@ export function loadStickerPacks(): StickerPack[] {
     return readPacks();
 }
 
-export function createStickerPack(name: string): StickerPack {
+export const STICKER_PACK_NAME_MAX = 40;
+export const STICKER_PACK_NOTE_MAX = 500;
+
+function cleanPackName(value: string): string {
+    return value.trim().slice(0, STICKER_PACK_NAME_MAX);
+}
+
+function cleanPackNote(value: string): string {
+    return value.trim().slice(0, STICKER_PACK_NOTE_MAX);
+}
+
+export function createStickerPack(name: string, note = ""): StickerPack {
     const pack: StickerPack = {
         id: `pack_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
-        name,
+        name: cleanPackName(name),
+        note: cleanPackNote(note),
         stickers: [],
         createdAt: new Date().toISOString(),
     };
@@ -101,11 +115,22 @@ export async function deleteStickerPack(packId: string): Promise<void> {
     writeAssignments(assignments);
 }
 
+export function updateStickerPackInfo(packId: string, info: { name: string; note?: string }): void {
+    const packs = readPacks();
+    const pack = packs.find(p => p.id === packId);
+    const name = cleanPackName(info.name);
+    if (!pack || !name) return;
+    pack.name = name;
+    pack.note = cleanPackNote(info.note ?? "");
+    writePacks(packs);
+}
+
 export function renameStickerPack(packId: string, newName: string): void {
     const packs = readPacks();
     const pack = packs.find(p => p.id === packId);
-    if (!pack) return;
-    pack.name = newName;
+    const name = cleanPackName(newName);
+    if (!pack || !name) return;
+    pack.name = name;
     writePacks(packs);
 }
 

--- a/lib/mascot-chat-store.ts
+++ b/lib/mascot-chat-store.ts
@@ -32,6 +32,7 @@ export type MascotSession = {
     createdAt: number;
     updatedAt: number;
     messages: MascotMsg[];
+    pinned?: boolean;
 };
 
 type PersistedMascotState = {
@@ -286,7 +287,10 @@ function publishMessages(nextMessages: MascotMsg[], options: { persist?: boolean
             .map((session) => session.id === active.id
                 ? { ...session, messages, updatedAt: now }
                 : session)
-            .sort((a, b) => b.updatedAt - a.updatedAt);
+            .sort((a, b) => {
+                if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+                return b.updatedAt - a.updatedAt;
+            });
     }
     if (options.persist !== false) persistState();
     emit();
@@ -346,6 +350,20 @@ export function renameMascotSession(sessionId: string, title: string): boolean {
     const nextTitle = title.replace(/\s+/g, " ").trim();
     if (!nextTitle || !hydrated || isThinking || !sessions.some((session) => session.id === sessionId)) return false;
     sessions = sessions.map((session) => session.id === sessionId ? { ...session, title: nextTitle } : session);
+    persistState();
+    emit();
+    return true;
+}
+
+export function toggleMascotSessionPin(sessionId: string): boolean {
+    if (!hydrated || isThinking) return false;
+    const index = sessions.findIndex((session) => session.id === sessionId);
+    if (index === -1) return false;
+    sessions[index] = { ...sessions[index], pinned: !sessions[index].pinned };
+    sessions.sort((a, b) => {
+        if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+        return b.updatedAt - a.updatedAt;
+    });
     persistState();
     emit();
     return true;


### PR DESCRIPTION
贡献者：什锦杂货铺

作者您好！昨天您采纳了表情包改名与备注的v1版本，这是我在您的修改的基础上重新弄的V2版本。优化了表情包改名称不占位，备注可折叠。附上截图参考（不知道截图能不能被看到），总之，期待被采纳，辛苦作者了！
<img width="2770" height="1500" alt="Collage_20260820_120219864" src="https://github.com/user-attachments/assets/4a3835e0-35d5-433b-b6ef-e3e24fd310a1"/>