### PR TITLE
minimax语音新增音调调节功能

### DIFF
--- a/components/settings/voice-settings.tsx
+++ b/components/settings/voice-settings.tsx
@@ -729,7 +729,7 @@ export function VoiceSettings() {
                                             <>
                                                 <div className="flex flex-col gap-1">
                                                     <div className="flex items-center justify-between px-1">
-                                                        <label className="menu-desc">语速</label>
+                                                        <label className="menu-desc">语速 (Speed)</label>
                                                         <span className="menu-label font-medium">{(config.speechSpeed ?? DEFAULT_SPEECH_SPEED).toFixed(1)}×</span>
                                                     </div>
                                                     <input
@@ -742,13 +742,34 @@ export function VoiceSettings() {
                                                         className="w-full accent-black"
                                                         aria-label="Minimax 语速"
                                                     />
-                                                    <div className="relative mt-1 h-5 px-1 text-xs text-gray-500" aria-hidden="true">
+                                                    <div className="relative h-4 px-1 text-xs text-gray-500" aria-hidden="true">
                                                         <span className="absolute left-1 whitespace-nowrap">{MINIMAX_SPEED_MIN.toFixed(1)}×</span>
                                                         <span className="absolute whitespace-nowrap" style={{ left: "33.333%", transform: "translateX(-50%)" }}>1.0× 默认</span>
                                                         <span className="absolute right-1 whitespace-nowrap">{MINIMAX_SPEED_MAX.toFixed(1)}×</span>
                                                     </div>
                                                 </div>
-                                                <div className="flex flex-col gap-1">
+                                                <div className="flex flex-col gap-1 -mt-1">
+                                                    <div className="flex items-center justify-between px-1">
+                                                        <label className="menu-desc">音调 (Pitch)</label>
+                                                        <span className="menu-label font-medium">{config.speechPitch ?? DEFAULT_SPEECH_PITCH}</span>
+                                                    </div>
+                                                    <input
+                                                        type="range"
+                                                        min={MINIMAX_PITCH_MIN}
+                                                        max={MINIMAX_PITCH_MAX}
+                                                        step={MINIMAX_PITCH_STEP}
+                                                        value={config.speechPitch ?? DEFAULT_SPEECH_PITCH}
+                                                        onChange={(e) => updateConfig(config.id, { speechPitch: Number(e.target.value) })}
+                                                        className="w-full accent-black"
+                                                        aria-label="Minimax 音调"
+                                                    />
+                                                    <div className="relative h-4 px-1 text-xs text-gray-500" aria-hidden="true">
+                                                        <span className="absolute left-1 whitespace-nowrap">{MINIMAX_PITCH_MIN}</span>
+                                                        <span className="absolute whitespace-nowrap" style={{ left: "50%", transform: "translateX(-50%)" }}>0 默认</span>
+                                                        <span className="absolute right-1 whitespace-nowrap">+{MINIMAX_PITCH_MAX}</span>
+                                                    </div>
+                                                </div>
+                                                <div className="flex flex-col gap-1 mt-1">
                                                     <label className="menu-desc ml-1">朗读语言</label>
                                                     <select
                                                         value={config.languageBoost || ""}

--- a/components/settings/voice-settings.tsx
+++ b/components/settings/voice-settings.tsx
@@ -21,10 +21,6 @@ const MINIMAX_SPEED_MIN = 0.5;
 const MINIMAX_SPEED_MAX = 2.0;
 const MINIMAX_SPEED_STEP = 0.1;
 const DEFAULT_SPEECH_SPEED = 1.0;
-const MINIMAX_PITCH_MIN = -12;
-const MINIMAX_PITCH_MAX = 12;
-const MINIMAX_PITCH_STEP = 1;
-const DEFAULT_SPEECH_PITCH = 0;
 const VOICE_PROVIDER_OPTIONS = [
     { value: "OpenAI", label: "OpenAI TTS" },
     { value: "MinimaxCN", label: "Minimax 语音国内版" },
@@ -729,7 +725,7 @@ export function VoiceSettings() {
                                             <>
                                                 <div className="flex flex-col gap-1">
                                                     <div className="flex items-center justify-between px-1">
-                                                        <label className="menu-desc">语速</label>
+                                                        <label className="menu-desc">语速 (Speed)</label>
                                                         <span className="menu-label font-medium">{(config.speechSpeed ?? DEFAULT_SPEECH_SPEED).toFixed(1)}×</span>
                                                     </div>
                                                     <input
@@ -742,15 +738,15 @@ export function VoiceSettings() {
                                                         className="w-full accent-black"
                                                         aria-label="Minimax 语速"
                                                     />
-                                                    <div className="relative mt-1 h-5 px-1 text-xs text-gray-500" aria-hidden="true">
+                                                    <div className="relative h-4 px-1 text-xs text-gray-500" aria-hidden="true">
                                                         <span className="absolute left-1 whitespace-nowrap">{MINIMAX_SPEED_MIN.toFixed(1)}×</span>
                                                         <span className="absolute whitespace-nowrap" style={{ left: "33.333%", transform: "translateX(-50%)" }}>1.0× 默认</span>
                                                         <span className="absolute right-1 whitespace-nowrap">{MINIMAX_SPEED_MAX.toFixed(1)}×</span>
                                                     </div>
                                                 </div>
-                                                <div className="flex flex-col gap-1">
+                                                <div className="flex flex-col gap-1 -mt-1">
                                                     <div className="flex items-center justify-between px-1">
-                                                        <label className="menu-desc">音调</label>
+                                                        <label className="menu-desc">音调 (Pitch)</label>
                                                         <span className="menu-label font-medium">{config.speechPitch ?? DEFAULT_SPEECH_PITCH}</span>
                                                     </div>
                                                     <input
@@ -763,13 +759,13 @@ export function VoiceSettings() {
                                                         className="w-full accent-black"
                                                         aria-label="Minimax 音调"
                                                     />
-                                                    <div className="relative mt-1 h-5 px-1 text-xs text-gray-500" aria-hidden="true">
+                                                    <div className="relative h-4 px-1 text-xs text-gray-500" aria-hidden="true">
                                                         <span className="absolute left-1 whitespace-nowrap">{MINIMAX_PITCH_MIN}</span>
                                                         <span className="absolute whitespace-nowrap" style={{ left: "50%", transform: "translateX(-50%)" }}>0 默认</span>
                                                         <span className="absolute right-1 whitespace-nowrap">+{MINIMAX_PITCH_MAX}</span>
                                                     </div>
                                                 </div>
-                                                <div className="flex flex-col gap-1">
+                                                <div className="flex flex-col gap-1 mt-1">
                                                     <label className="menu-desc ml-1">朗读语言</label>
                                                     <select
                                                         value={config.languageBoost || ""}

--- a/components/settings/voice-settings.tsx
+++ b/components/settings/voice-settings.tsx
@@ -21,6 +21,10 @@ const MINIMAX_SPEED_MIN = 0.5;
 const MINIMAX_SPEED_MAX = 2.0;
 const MINIMAX_SPEED_STEP = 0.1;
 const DEFAULT_SPEECH_SPEED = 1.0;
+const MINIMAX_PITCH_MIN = -12;
+const MINIMAX_PITCH_MAX = 12;
+const MINIMAX_PITCH_STEP = 1;
+const DEFAULT_SPEECH_PITCH = 0;
 const VOICE_PROVIDER_OPTIONS = [
     { value: "OpenAI", label: "OpenAI TTS" },
     { value: "MinimaxCN", label: "Minimax 语音国内版" },
@@ -725,7 +729,7 @@ export function VoiceSettings() {
                                             <>
                                                 <div className="flex flex-col gap-1">
                                                     <div className="flex items-center justify-between px-1">
-                                                        <label className="menu-desc">语速 (Speed)</label>
+                                                        <label className="menu-desc">语速</label>
                                                         <span className="menu-label font-medium">{(config.speechSpeed ?? DEFAULT_SPEECH_SPEED).toFixed(1)}×</span>
                                                     </div>
                                                     <input
@@ -738,34 +742,13 @@ export function VoiceSettings() {
                                                         className="w-full accent-black"
                                                         aria-label="Minimax 语速"
                                                     />
-                                                    <div className="relative h-4 px-1 text-xs text-gray-500" aria-hidden="true">
+                                                    <div className="relative mt-1 h-5 px-1 text-xs text-gray-500" aria-hidden="true">
                                                         <span className="absolute left-1 whitespace-nowrap">{MINIMAX_SPEED_MIN.toFixed(1)}×</span>
                                                         <span className="absolute whitespace-nowrap" style={{ left: "33.333%", transform: "translateX(-50%)" }}>1.0× 默认</span>
                                                         <span className="absolute right-1 whitespace-nowrap">{MINIMAX_SPEED_MAX.toFixed(1)}×</span>
                                                     </div>
                                                 </div>
-                                                <div className="flex flex-col gap-1 -mt-1">
-                                                    <div className="flex items-center justify-between px-1">
-                                                        <label className="menu-desc">音调 (Pitch)</label>
-                                                        <span className="menu-label font-medium">{config.speechPitch ?? DEFAULT_SPEECH_PITCH}</span>
-                                                    </div>
-                                                    <input
-                                                        type="range"
-                                                        min={MINIMAX_PITCH_MIN}
-                                                        max={MINIMAX_PITCH_MAX}
-                                                        step={MINIMAX_PITCH_STEP}
-                                                        value={config.speechPitch ?? DEFAULT_SPEECH_PITCH}
-                                                        onChange={(e) => updateConfig(config.id, { speechPitch: Number(e.target.value) })}
-                                                        className="w-full accent-black"
-                                                        aria-label="Minimax 音调"
-                                                    />
-                                                    <div className="relative h-4 px-1 text-xs text-gray-500" aria-hidden="true">
-                                                        <span className="absolute left-1 whitespace-nowrap">{MINIMAX_PITCH_MIN}</span>
-                                                        <span className="absolute whitespace-nowrap" style={{ left: "50%", transform: "translateX(-50%)" }}>0 默认</span>
-                                                        <span className="absolute right-1 whitespace-nowrap">+{MINIMAX_PITCH_MAX}</span>
-                                                    </div>
-                                                </div>
-                                                <div className="flex flex-col gap-1 mt-1">
+                                                <div className="flex flex-col gap-1">
                                                     <label className="menu-desc ml-1">朗读语言</label>
                                                     <select
                                                         value={config.languageBoost || ""}

--- a/components/settings/voice-settings.tsx
+++ b/components/settings/voice-settings.tsx
@@ -21,6 +21,10 @@ const MINIMAX_SPEED_MIN = 0.5;
 const MINIMAX_SPEED_MAX = 2.0;
 const MINIMAX_SPEED_STEP = 0.1;
 const DEFAULT_SPEECH_SPEED = 1.0;
+const MINIMAX_PITCH_MIN = -12;
+const MINIMAX_PITCH_MAX = 12;
+const MINIMAX_PITCH_STEP = 1;
+const DEFAULT_SPEECH_PITCH = 0;
 const VOICE_PROVIDER_OPTIONS = [
     { value: "OpenAI", label: "OpenAI TTS" },
     { value: "MinimaxCN", label: "Minimax 语音国内版" },
@@ -742,6 +746,27 @@ export function VoiceSettings() {
                                                         <span className="absolute left-1 whitespace-nowrap">{MINIMAX_SPEED_MIN.toFixed(1)}×</span>
                                                         <span className="absolute whitespace-nowrap" style={{ left: "33.333%", transform: "translateX(-50%)" }}>1.0× 默认</span>
                                                         <span className="absolute right-1 whitespace-nowrap">{MINIMAX_SPEED_MAX.toFixed(1)}×</span>
+                                                    </div>
+                                                </div>
+                                                <div className="flex flex-col gap-1">
+                                                    <div className="flex items-center justify-between px-1">
+                                                        <label className="menu-desc">音调</label>
+                                                        <span className="menu-label font-medium">{config.speechPitch ?? DEFAULT_SPEECH_PITCH}</span>
+                                                    </div>
+                                                    <input
+                                                        type="range"
+                                                        min={MINIMAX_PITCH_MIN}
+                                                        max={MINIMAX_PITCH_MAX}
+                                                        step={MINIMAX_PITCH_STEP}
+                                                        value={config.speechPitch ?? DEFAULT_SPEECH_PITCH}
+                                                        onChange={(e) => updateConfig(config.id, { speechPitch: Number(e.target.value) })}
+                                                        className="w-full accent-black"
+                                                        aria-label="Minimax 音调"
+                                                    />
+                                                    <div className="relative mt-1 h-5 px-1 text-xs text-gray-500" aria-hidden="true">
+                                                        <span className="absolute left-1 whitespace-nowrap">{MINIMAX_PITCH_MIN}</span>
+                                                        <span className="absolute whitespace-nowrap" style={{ left: "50%", transform: "translateX(-50%)" }}>0 默认</span>
+                                                        <span className="absolute right-1 whitespace-nowrap">+{MINIMAX_PITCH_MAX}</span>
                                                     </div>
                                                 </div>
                                                 <div className="flex flex-col gap-1">

--- a/lib/settings-types.ts
+++ b/lib/settings-types.ts
@@ -139,6 +139,8 @@ export type VoiceApiConfig = {
     languageBoost?: string;
     /** Minimax voice_setting.speed. Missing values keep the legacy 1.0x behavior. */
     speechSpeed?: number;
+    /** Minimax voice_setting.pitch. Missing values keep the legacy 0 semitone behavior. */
+    speechPitch?: number;
     customVoices?: { id: string; name: string; createdAt?: number }[];
     enableSTT: boolean;
     enableTTS: boolean;

--- a/lib/tts-service.ts
+++ b/lib/tts-service.ts
@@ -76,10 +76,17 @@ const MINIMAX_EMOTIONS = new Set([
 
 const MINIMAX_SPEED_MIN = 0.5;
 const MINIMAX_SPEED_MAX = 2.0;
+const MINIMAX_PITCH_MIN = -12;
+const MINIMAX_PITCH_MAX = 12;
 
 function normalizeMinimaxSpeed(speed: number | undefined): number {
     if (typeof speed !== "number" || !Number.isFinite(speed)) return 1.0;
     return Math.min(MINIMAX_SPEED_MAX, Math.max(MINIMAX_SPEED_MIN, speed));
+}
+
+function normalizeMinimaxPitch(pitch: number | undefined): number {
+    if (typeof pitch !== "number" || !Number.isFinite(pitch)) return 0;
+    return Math.min(MINIMAX_PITCH_MAX, Math.max(MINIMAX_PITCH_MIN, Math.round(pitch)));
 }
 
 async function synthesizeMinimax(text: string, config: VoiceApiConfig, emotion?: string): Promise<Blob | null> {
@@ -90,7 +97,7 @@ async function synthesizeMinimax(text: string, config: VoiceApiConfig, emotion?:
         voice_id: config.defaultVoice || "male-qn-qingse",
         speed: normalizeMinimaxSpeed(config.speechSpeed),
         vol: 1.0,
-        pitch: 0,
+        pitch: normalizeMinimaxPitch(config.speechPitch),
     };
     const normalizedEmotion = emotion?.trim().toLowerCase();
     if (normalizedEmotion && MINIMAX_EMOTIONS.has(normalizedEmotion)) {


### PR DESCRIPTION
贡献者：什锦杂货铺。
微微微小之改动。顺便把语速调节的排版间距给微调了一下，以及加上括号英文名。期待采纳！
<img width="1264" height="2736" alt="Screenshot_20260820_115356_com_android_chrome_ChromeTabbedActivity" src="https://github.com/user-attachments/assets/4fbad7f7-7ce9-4157-949d-07ccd8b8e2fd" />
