### PR TITLE
工坊app侧边栏对话记录新增重命名对话+置顶功能

### DIFF
--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -4,7 +4,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExterna
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
-import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, Play, Plus, Square, Trash2, Wrench, X, MoreVertical, Pin, Pencil } from "lucide-react";
+import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, Play, Plus, Square, Trash2, Wrench, X, MoreVertical, Pin, PinOff, Pencil } from "lucide-react";
 import { QaFileCard } from "@/components/qa-file-card";
 import { parseQaFileMarker } from "@/lib/qa-computer-tools";
 import { mdiHammerWrench } from "@mdi/js";
@@ -29,11 +29,13 @@ import {
   QA_DEFAULT_CONTEXT_BUDGET_CHARS,
   setQaContextBudgetChars,
   retryQaMessage,
+  renameQaSession,
   revertQaAppliedCommit,
   sendQaMessage,
   stopQaGeneration,
   subscribeQaChat,
   switchQaSession,
+  toggleQaSessionPin,
   type QaMsg,
   type QaSession,
   type QaToolStatus,
@@ -391,8 +393,20 @@ function QaSessionDrawer({
   onOpenSettings: () => void;
 }) {
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editTitle, setEditTitle] = useState("");
+  const [renameTargetId, setRenameTargetId] = useState<string | null>(null);
+  const [renameTitle, setRenameTitle] = useState("");
+
+  const closeRenameDialog = () => {
+    setRenameTargetId(null);
+    setRenameTitle("");
+  };
+
+  const confirmRename = () => {
+    const title = renameTitle.trim();
+    if (!renameTargetId || !title) return;
+    renameQaSession(renameTargetId, title);
+    closeRenameDialog();
+  };
 
   const sortedSessions = useMemo(() => {
     return [...sessions].sort((a, b) => {
@@ -403,17 +417,14 @@ function QaSessionDrawer({
   }, [sessions]);
 
   return (
-    <aside className="qa-drawer">
+    <aside className="qa-drawer" style={{ position: "relative" }}>
       <div className="qa-drawer-head">
         <span className="qa-drawer-title">对话记录</span>
       </div>
-      <div className="qa-drawer-list hide-scrollbar"
+      <div
+        className="qa-drawer-list hide-scrollbar"
         onClick={() => {
           if (menuOpenId) setMenuOpenId(null);
-          if (editingId) {
-            if (editTitle.trim()) renameQaSession(editingId, editTitle.trim());
-            setEditingId(null);
-          }
         }}
       >
         {sortedSessions.length === 0 && <div className="qa-drawer-empty">还没有对话</div>}
@@ -421,38 +432,14 @@ function QaSessionDrawer({
           <div
             key={session.id}
             className={`qa-drawer-item ${session.id === activeId ? "is-active" : ""}`}
-            onClick={(e) => {
-              if (editingId === session.id) {
-                e.stopPropagation();
-                return;
-              }
-              onSelect(session.id);
-            }}
+            onClick={() => onSelect(session.id)}
             style={{ position: "relative", overflow: "visible" }}
           >
             <div className="qa-drawer-item-main">
-              {editingId === session.id ? (
-                <input
-                  autoFocus
-                  value={editTitle}
-                  onChange={(e) => setEditTitle(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      if (editTitle.trim()) renameQaSession(editingId, editTitle.trim());
-                      setEditingId(null);
-                    } else if (e.key === "Escape") {
-                      setEditingId(null);
-                    }
-                  }}
-                  className="qa-drawer-item-title-input"
-                  style={{ width: "100%", background: "transparent", border: "none", outline: "none", color: "inherit" }}
-                />
-              ) : (
-                <span className="qa-drawer-item-title">
-                  {session.isPinned && <span className="mr-1">📌</span>}
-                  {session.title}
-                </span>
-              )}
+              <span className="qa-drawer-item-title">
+                {session.isPinned && <Pin size={12} aria-hidden="true" />}
+                {session.title}
+              </span>
               <span className="qa-drawer-item-time">{formatRelativeTime(session.updatedAt)}</span>
             </div>
             <button
@@ -462,10 +449,6 @@ function QaSessionDrawer({
               onClick={(e) => {
                 e.stopPropagation();
                 setMenuOpenId(menuOpenId === session.id ? null : session.id);
-                if (editingId) {
-                  if (editTitle.trim()) renameQaSession(editingId, editTitle.trim());
-                  setEditingId(null);
-                }
               }}
             >
               <MoreVertical size={14} />
@@ -476,7 +459,7 @@ function QaSessionDrawer({
                 className="qa-drawer-item-menu"
                 style={{
                   position: "absolute", right: "10px", top: "35px", zIndex: 100, 
-                  background: "var(--c-surface)", borderRadius: "8px", 
+                  background: "#ffffff", borderRadius: "8px", opacity: 1,
                   boxShadow: "0 4px 12px rgba(0,0,0,0.15)", padding: "4px",
                   display: "flex", flexDirection: "column", minWidth: "100px"
                 }}
@@ -491,7 +474,8 @@ function QaSessionDrawer({
                     setMenuOpenId(null);
                   }}
                 >
-                  <Pin size={14} /> {session.isPinned ? "取消置顶" : "置顶"}
+                  {session.isPinned ? <PinOff size={14} /> : <Pin size={14} />}
+                  {session.isPinned ? "取消置顶" : "置顶"}
                 </button>
                 <button 
                   type="button" 
@@ -499,8 +483,8 @@ function QaSessionDrawer({
                   style={{ display: "flex", alignItems: "center", gap: "8px", padding: "8px 12px", textAlign: "left", borderRadius: "4px", fontSize: "13px" }}
                   onClick={(e) => {
                     e.stopPropagation();
-                    setEditTitle(session.title);
-                    setEditingId(session.id);
+                    setRenameTitle(session.title);
+                    setRenameTargetId(session.id);
                     setMenuOpenId(null);
                   }}
                 >
@@ -523,6 +507,89 @@ function QaSessionDrawer({
           </div>
         ))}
       </div>
+      {renameTargetId && (
+        <div
+          role="presentation"
+          onClick={closeRenameDialog}
+          style={{
+            position: "absolute",
+            inset: 0,
+            zIndex: 200,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "20px",
+            background: "rgba(0, 0, 0, 0.22)",
+          }}
+        >
+          <form
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="qa-rename-dialog-title"
+            onClick={(e) => e.stopPropagation()}
+            onSubmit={(e) => {
+              e.preventDefault();
+              confirmRename();
+            }}
+            style={{
+              width: "100%",
+              maxWidth: "280px",
+              padding: "18px",
+              borderRadius: "8px",
+              background: "#ffffff",
+              boxShadow: "0 12px 32px rgba(0, 0, 0, 0.2)",
+            }}
+          >
+            <div id="qa-rename-dialog-title" style={{ marginBottom: "12px", fontSize: "16px", fontWeight: 600 }}>
+              重命名对话
+            </div>
+            <input
+              autoFocus
+              value={renameTitle}
+              maxLength={80}
+              aria-label="新对话名称"
+              onChange={(e) => setRenameTitle(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") closeRenameDialog();
+              }}
+              style={{
+                width: "100%",
+                height: "40px",
+                padding: "0 10px",
+                border: "1px solid #d4d4d8",
+                borderRadius: "6px",
+                outline: "none",
+                background: "#ffffff",
+                color: "#18181b",
+                fontSize: "14px",
+              }}
+            />
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: "8px", marginTop: "16px" }}>
+              <button
+                type="button"
+                onClick={closeRenameDialog}
+                style={{ height: "36px", padding: "0 14px", borderRadius: "6px", color: "#52525b" }}
+              >
+                取消
+              </button>
+              <button
+                type="submit"
+                disabled={!renameTitle.trim()}
+                style={{
+                  height: "36px",
+                  padding: "0 14px",
+                  borderRadius: "6px",
+                  background: "#7452e8",
+                  color: "#ffffff",
+                  opacity: renameTitle.trim() ? 1 : 0.45,
+                }}
+              >
+                确认
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
       <div className="qa-drawer-foot">
         <button type="button" className="qa-drawer-new qa-drawer-settings" onClick={onOpenSettings}>
           <Wrench size={15} strokeWidth={2} />

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -4,7 +4,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExterna
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
-import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, Play, Plus, Square, Trash2, Wrench, X } from "lucide-react";
+import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, Play, Plus, Square, Trash2, Wrench, X, MoreVertical, Pin, Pencil } from "lucide-react";
 import { QaFileCard } from "@/components/qa-file-card";
 import { parseQaFileMarker } from "@/lib/qa-computer-tools";
 import { mdiHammerWrench } from "@mdi/js";
@@ -390,34 +390,136 @@ function QaSessionDrawer({
   onCreate: () => void;
   onOpenSettings: () => void;
 }) {
+  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState("");
+
+  const sortedSessions = useMemo(() => {
+    return [...sessions].sort((a, b) => {
+      if (a.isPinned && !b.isPinned) return -1;
+      if (!a.isPinned && b.isPinned) return 1;
+      return b.updatedAt - a.updatedAt;
+    });
+  }, [sessions]);
+
   return (
     <aside className="qa-drawer">
       <div className="qa-drawer-head">
         <span className="qa-drawer-title">对话记录</span>
       </div>
-      <div className="qa-drawer-list hide-scrollbar">
-        {sessions.length === 0 && <div className="qa-drawer-empty">还没有对话</div>}
-        {sessions.map((session) => (
+      <div className="qa-drawer-list hide-scrollbar"
+        onClick={() => {
+          if (menuOpenId) setMenuOpenId(null);
+          if (editingId) {
+            if (editTitle.trim()) renameQaSession(editingId, editTitle.trim());
+            setEditingId(null);
+          }
+        }}
+      >
+        {sortedSessions.length === 0 && <div className="qa-drawer-empty">还没有对话</div>}
+        {sortedSessions.map((session) => (
           <div
             key={session.id}
             className={`qa-drawer-item ${session.id === activeId ? "is-active" : ""}`}
-            onClick={() => onSelect(session.id)}
+            onClick={(e) => {
+              if (editingId === session.id) {
+                e.stopPropagation();
+                return;
+              }
+              onSelect(session.id);
+            }}
+            style={{ position: "relative", overflow: "visible" }}
           >
             <div className="qa-drawer-item-main">
-              <span className="qa-drawer-item-title">{session.title}</span>
+              {editingId === session.id ? (
+                <input
+                  autoFocus
+                  value={editTitle}
+                  onChange={(e) => setEditTitle(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      if (editTitle.trim()) renameQaSession(editingId, editTitle.trim());
+                      setEditingId(null);
+                    } else if (e.key === "Escape") {
+                      setEditingId(null);
+                    }
+                  }}
+                  className="qa-drawer-item-title-input"
+                  style={{ width: "100%", background: "transparent", border: "none", outline: "none", color: "inherit" }}
+                />
+              ) : (
+                <span className="qa-drawer-item-title">
+                  {session.isPinned && <span className="mr-1">📌</span>}
+                  {session.title}
+                </span>
+              )}
               <span className="qa-drawer-item-time">{formatRelativeTime(session.updatedAt)}</span>
             </div>
             <button
               type="button"
-              className="qa-icon-btn qa-drawer-item-delete"
-              aria-label="删除对话"
+              className="qa-icon-btn qa-drawer-item-more"
+              aria-label="更多操作"
               onClick={(e) => {
                 e.stopPropagation();
-                onDelete(session.id);
+                setMenuOpenId(menuOpenId === session.id ? null : session.id);
+                if (editingId) {
+                  if (editTitle.trim()) renameQaSession(editingId, editTitle.trim());
+                  setEditingId(null);
+                }
               }}
             >
-              <Trash2 size={14} />
+              <MoreVertical size={14} />
             </button>
+
+            {menuOpenId === session.id && (
+              <div 
+                className="qa-drawer-item-menu"
+                style={{
+                  position: "absolute", right: "10px", top: "35px", zIndex: 100, 
+                  background: "var(--c-surface)", borderRadius: "8px", 
+                  boxShadow: "0 4px 12px rgba(0,0,0,0.15)", padding: "4px",
+                  display: "flex", flexDirection: "column", minWidth: "100px"
+                }}
+              >
+                <button 
+                  type="button" 
+                  className="qa-drawer-menu-btn"
+                  style={{ display: "flex", alignItems: "center", gap: "8px", padding: "8px 12px", textAlign: "left", borderRadius: "4px", fontSize: "13px" }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleQaSessionPin(session.id);
+                    setMenuOpenId(null);
+                  }}
+                >
+                  <Pin size={14} /> {session.isPinned ? "取消置顶" : "置顶"}
+                </button>
+                <button 
+                  type="button" 
+                  className="qa-drawer-menu-btn"
+                  style={{ display: "flex", alignItems: "center", gap: "8px", padding: "8px 12px", textAlign: "left", borderRadius: "4px", fontSize: "13px" }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setEditTitle(session.title);
+                    setEditingId(session.id);
+                    setMenuOpenId(null);
+                  }}
+                >
+                  <Pencil size={14} /> 重命名
+                </button>
+                <button 
+                  type="button" 
+                  className="qa-drawer-menu-btn text-red-500"
+                  style={{ display: "flex", alignItems: "center", gap: "8px", padding: "8px 12px", textAlign: "left", borderRadius: "4px", fontSize: "13px", color: "#ef4444" }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete(session.id);
+                    setMenuOpenId(null);
+                  }}
+                >
+                  <Trash2 size={14} /> 删除
+                </button>
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -384,6 +384,7 @@ function QaSessionDrawer({
   onDelete,
   onCreate,
   onOpenSettings,
+  onRenameRequest,
 }: {
   sessions: QaSession[];
   activeId: string | null;
@@ -391,22 +392,9 @@ function QaSessionDrawer({
   onDelete: (id: string) => void;
   onCreate: () => void;
   onOpenSettings: () => void;
+  onRenameRequest: (id: string, title: string) => void;
 }) {
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
-  const [renameTargetId, setRenameTargetId] = useState<string | null>(null);
-  const [renameTitle, setRenameTitle] = useState("");
-
-  const closeRenameDialog = () => {
-    setRenameTargetId(null);
-    setRenameTitle("");
-  };
-
-  const confirmRename = () => {
-    const title = renameTitle.trim();
-    if (!renameTargetId || !title) return;
-    renameQaSession(renameTargetId, title);
-    closeRenameDialog();
-  };
 
   const sortedSessions = useMemo(() => {
     return [...sessions].sort((a, b) => {
@@ -417,7 +405,7 @@ function QaSessionDrawer({
   }, [sessions]);
 
   return (
-    <aside className="qa-drawer" style={{ position: "relative" }}>
+    <aside className="qa-drawer">
       <div className="qa-drawer-head">
         <span className="qa-drawer-title">对话记录</span>
       </div>
@@ -483,8 +471,7 @@ function QaSessionDrawer({
                   style={{ display: "flex", alignItems: "center", gap: "8px", padding: "8px 12px", textAlign: "left", borderRadius: "4px", fontSize: "13px" }}
                   onClick={(e) => {
                     e.stopPropagation();
-                    setRenameTitle(session.title);
-                    setRenameTargetId(session.id);
+                    onRenameRequest(session.id, session.title);
                     setMenuOpenId(null);
                   }}
                 >
@@ -507,89 +494,6 @@ function QaSessionDrawer({
           </div>
         ))}
       </div>
-      {renameTargetId && (
-        <div
-          role="presentation"
-          onClick={closeRenameDialog}
-          style={{
-            position: "absolute",
-            inset: 0,
-            zIndex: 200,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            padding: "20px",
-            background: "rgba(0, 0, 0, 0.22)",
-          }}
-        >
-          <form
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="qa-rename-dialog-title"
-            onClick={(e) => e.stopPropagation()}
-            onSubmit={(e) => {
-              e.preventDefault();
-              confirmRename();
-            }}
-            style={{
-              width: "100%",
-              maxWidth: "280px",
-              padding: "18px",
-              borderRadius: "8px",
-              background: "#ffffff",
-              boxShadow: "0 12px 32px rgba(0, 0, 0, 0.2)",
-            }}
-          >
-            <div id="qa-rename-dialog-title" style={{ marginBottom: "12px", fontSize: "16px", fontWeight: 600 }}>
-              重命名对话
-            </div>
-            <input
-              autoFocus
-              value={renameTitle}
-              maxLength={80}
-              aria-label="新对话名称"
-              onChange={(e) => setRenameTitle(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") closeRenameDialog();
-              }}
-              style={{
-                width: "100%",
-                height: "40px",
-                padding: "0 10px",
-                border: "1px solid #d4d4d8",
-                borderRadius: "6px",
-                outline: "none",
-                background: "#ffffff",
-                color: "#18181b",
-                fontSize: "14px",
-              }}
-            />
-            <div style={{ display: "flex", justifyContent: "flex-end", gap: "8px", marginTop: "16px" }}>
-              <button
-                type="button"
-                onClick={closeRenameDialog}
-                style={{ height: "36px", padding: "0 14px", borderRadius: "6px", color: "#52525b" }}
-              >
-                取消
-              </button>
-              <button
-                type="submit"
-                disabled={!renameTitle.trim()}
-                style={{
-                  height: "36px",
-                  padding: "0 14px",
-                  borderRadius: "6px",
-                  background: "#7452e8",
-                  color: "#ffffff",
-                  opacity: renameTitle.trim() ? 1 : 0.45,
-                }}
-              >
-                确认
-              </button>
-            </div>
-          </form>
-        </div>
-      )}
       <div className="qa-drawer-foot">
         <button type="button" className="qa-drawer-new qa-drawer-settings" onClick={onOpenSettings}>
           <Wrench size={15} strokeWidth={2} />
@@ -866,6 +770,8 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
   const [repoConnected, setRepoConnected] = useState(false);
   const [clearToolsOpen, setClearToolsOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
+  const [renameTitle, setRenameTitle] = useState("");
   const [pendingImages, setPendingImages] = useState<string[]>([]);
   const [viewerImage, setViewerImage] = useState<string | null>(null);
   const [visionEnabled, setVisionEnabled] = useState(false);
@@ -913,6 +819,18 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
       ? `已清理 ${result.removed} 条工具记录，整理 ${result.cleaned} 条消息。`
       : "没有可清理的工具调用历史。");
   }, [onNotice]);
+
+  const closeRenameDialog = useCallback(() => {
+    setRenameTarget(null);
+    setRenameTitle("");
+  }, []);
+
+  const confirmRename = useCallback(() => {
+    const title = renameTitle.trim();
+    if (!renameTarget || !title) return;
+    renameQaSession(renameTarget.id, title);
+    closeRenameDialog();
+  }, [renameTarget, renameTitle, closeRenameDialog]);
 
   const toggleWriteMode = useCallback(() => {
     const gh = loadQaGithubConfig();
@@ -1012,6 +930,10 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
         onOpenSettings={() => {
           setSettingsOpen(true);
           setDrawerOpen(false);
+        }}
+        onRenameRequest={(id, title) => {
+          setRenameTarget({ id, title });
+          setRenameTitle(title);
         }}
       />
       <div className={`qa-stage ${drawerOpen ? "is-pushed" : ""}`}>
@@ -1208,6 +1130,43 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
         />
       )}
       </div>
+
+      {renameTarget && (
+        <div className="qa-rename-backdrop" role="presentation" onClick={closeRenameDialog}>
+          <form
+            className="qa-rename-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="qa-rename-dialog-title"
+            onClick={(e) => e.stopPropagation()}
+            onSubmit={(e) => {
+              e.preventDefault();
+              confirmRename();
+            }}
+          >
+            <div id="qa-rename-dialog-title" className="qa-rename-title">重命名对话</div>
+            <input
+              className="qa-rename-input"
+              autoFocus
+              value={renameTitle}
+              maxLength={80}
+              aria-label="新对话名称"
+              onChange={(e) => setRenameTitle(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") closeRenameDialog();
+              }}
+            />
+            <div className="qa-rename-actions">
+              <button type="button" className="qa-rename-cancel" onClick={closeRenameDialog}>
+                取消
+              </button>
+              <button type="submit" className="qa-drawer-new qa-rename-confirm" disabled={!renameTitle.trim()}>
+                确认
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
 
       {clearToolsOpen && (
         <div className="qa-devnotice-backdrop" onClick={() => setClearToolsOpen(false)}>

--- a/lib/qa-chat-store.ts
+++ b/lib/qa-chat-store.ts
@@ -54,6 +54,7 @@ export type QaSession = {
     createdAt: number;
     updatedAt: number;
     messages: QaMsg[];
+    isPinned?: boolean;
     /** 模型侧完整上下文（含工具调用与结果），跨轮保留；触顶时压缩为摘要 */
     context?: QaContextEntry[];
     /** 本会话中 agent 创建/更新过的本机内容（APP/游戏/剧场），供工坊内预览直接打开 */
@@ -264,6 +265,14 @@ export function subscribeQaChat(listener: () => void): () => void {
 
 export function getQaChatSnapshot(): QaChatSnapshot {
     return snapshot;
+}
+
+export function renameQaSession(id: string, title: string) {
+    updateSession(id, (s) => ({ ...s, title }));
+}
+
+export function toggleQaSessionPin(id: string) {
+    updateSession(id, (s) => ({ ...s, isPinned: !s.isPinned }));
 }
 
 export async function hydrateQaChat(): Promise<void> {

--- a/styles/qa.css
+++ b/styles/qa.css
@@ -1344,6 +1344,75 @@
   to { opacity: 1; }
 }
 
+/* ── 会话重命名弹窗：挂在工坊根层，覆盖舞台和抽屉 ── */
+.qa-rename-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.38);
+  animation: qa-fade-in 0.18s ease;
+}
+.qa-rename-dialog {
+  width: min(100%, 320px);
+  padding: 20px;
+  border-radius: 12px;
+  background: #ffffff;
+  box-shadow: 0 12px 36px rgba(40, 34, 20, 0.22);
+}
+.qa-rename-title {
+  margin-bottom: 14px;
+  color: var(--qa-text-primary);
+  font-size: 16px;
+  font-weight: 600;
+}
+.qa-rename-input {
+  width: 100%;
+  height: 42px;
+  padding: 0 12px;
+  border: 1px solid rgba(60, 50, 90, 0.18);
+  border-radius: 10px;
+  outline: none;
+  background: #ffffff;
+  color: var(--qa-text-primary);
+  font: inherit;
+  font-size: 14px;
+}
+.qa-rename-input:focus {
+  border-color: var(--qa-accent);
+  box-shadow: 0 0 0 3px var(--qa-accent-subtle);
+}
+.qa-rename-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 18px;
+}
+.qa-rename-cancel {
+  height: 42px;
+  padding: 0 16px;
+  border: none;
+  border-radius: 9999px;
+  background: transparent;
+  color: var(--qa-text-secondary);
+  font-size: 14px;
+  cursor: pointer;
+}
+.qa-rename-confirm {
+  min-width: 88px;
+  height: 42px;
+  justify-content: center;
+  padding: 0 22px;
+}
+.qa-rename-confirm:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
 /* ── 会话抽屉（推挤式，白底，在舞台下方左侧）── */
 .qa-drawer {
   position: absolute;


### PR DESCRIPTION
贡献者：什锦杂货铺

如截图所示，将原本的垃圾桶UI变成了三个点，点击即可看到重命名、置顶、删除三项功能。期待被采纳！（这个重命名会话对我来说真的很重要……一旦重要对话超过5条，没有命名功能将很麻烦😭）
<img width="3462" height="1500" alt="Collage_20260820_174252697" src="https://github.com/user-attachments/assets/0b988cf2-8ccd-4d86-8c3a-e5224a2ca5eb"/>