### PR TITLE
Feature/新增工坊附件上传功能+优化编辑消息为修改消息

### DIFF
--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -953,7 +953,8 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
       // 新增：拦截非文本文件并动态提取后缀名提示
       if (!allowedExts.some(ext => fileName.endsWith(ext))) {
         const ext = fileName.includes('.') ? `.${fileName.split('.').pop()}` : '无后缀';
-        onNotice?.(`不支持阅读 ${ext} 文件，小坊目前只能读取纯文本或代码文件哦。`);
+        // 使用 \n 进行换行
+        onNotice?.(`不支持阅读 ${ext} 文件\n小坊目前只能读取纯文本或代码文件哦。`);
         continue;
       }
 

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -15,1455 +15,1458 @@ import { BlackMarketApp } from "@/components/shopping/black-market-app";
 import { getInstalledCustomApp } from "@/lib/custom-app-storage";
 import type { QaCreatedContent } from "@/lib/qa-agent-tools";
 import {
-applyQaCommit,
-cancelQaCommit,
-clearQaToolHistory,
-createQaSession,
-deleteQaSession,
-getQaActiveContextChars,
-getQaChatSnapshot,
-getQaContextBudgetChars,
-hasQaToolHistory,
-hydrateQaChat,
-QA_CONTEXT_BUDGET_MAX,
-QA_CONTEXT_BUDGET_MIN,
-QA_DEFAULT_CONTEXT_BUDGET_CHARS,
-setQaContextBudgetChars,
-retryQaMessage,
-renameQaSession,
-revertQaAppliedCommit,
-sendQaMessage,
-stopQaGeneration,
-subscribeQaChat,
-switchQaSession,
-toggleQaSessionPin,
-updateQaMessageContent,
-editAndResendQaMessage,
-type QaMsg,
-type QaSession,
-type QaToolStatus,
+  applyQaCommit,
+  cancelQaCommit,
+  clearQaToolHistory,
+  createQaSession,
+  deleteQaSession,
+  getQaActiveContextChars,
+  getQaChatSnapshot,
+  getQaContextBudgetChars,
+  hasQaToolHistory,
+  hydrateQaChat,
+  QA_CONTEXT_BUDGET_MAX,
+  QA_CONTEXT_BUDGET_MIN,
+  QA_DEFAULT_CONTEXT_BUDGET_CHARS,
+  setQaContextBudgetChars,
+  retryQaMessage,
+  renameQaSession,
+  revertQaAppliedCommit,
+  sendQaMessage,
+  stopQaGeneration,
+  subscribeQaChat,
+  switchQaSession,
+  toggleQaSessionPin,
+  updateQaMessageContent,
+  editAndResendQaMessage,
+  type QaMsg,
+  type QaSession,
+  type QaToolStatus,
 } from "@/lib/qa-chat-store";
 import {
-getQaPageChars,
-setQaPageChars,
-QA_DEFAULT_PAGE_CHARS,
-QA_PAGE_CHARS_MIN,
-QA_PAGE_CHARS_MAX,
-getQaMaxRounds,
-setQaMaxRounds,
-QA_DEFAULT_MAX_ROUNDS,
-QA_MAX_ROUNDS_MIN,
-QA_MAX_ROUNDS_MAX,
-getQaMaxOutputTokens,
-setQaMaxOutputTokens,
-QA_DEFAULT_MAX_OUTPUT_TOKENS,
-QA_MAX_OUTPUT_TOKENS_MIN,
-QA_MAX_OUTPUT_TOKENS_MAX,
+  getQaPageChars,
+  setQaPageChars,
+  QA_DEFAULT_PAGE_CHARS,
+  QA_PAGE_CHARS_MIN,
+  QA_PAGE_CHARS_MAX,
+  getQaMaxRounds,
+  setQaMaxRounds,
+  QA_DEFAULT_MAX_ROUNDS,
+  QA_MAX_ROUNDS_MIN,
+  QA_MAX_ROUNDS_MAX,
+  getQaMaxOutputTokens,
+  setQaMaxOutputTokens,
+  QA_DEFAULT_MAX_OUTPUT_TOKENS,
+  QA_MAX_OUTPUT_TOKENS_MIN,
+  QA_MAX_OUTPUT_TOKENS_MAX,
 } from "@/lib/qa-prefs";
 import { resolveQaApiConfig } from "@/lib/qa-agent-engine";
 import {
-loadQaGithubConfig,
-saveQaGithubConfig,
-clearQaGithubConfig,
-validateQaGithubConfig,
-type QaGithubConfig,
-type QaGithubValidation,
+  loadQaGithubConfig,
+  saveQaGithubConfig,
+  clearQaGithubConfig,
+  validateQaGithubConfig,
+  type QaGithubConfig,
+  type QaGithubValidation,
 } from "@/lib/qa-github";
 import "@/lib/qa-error-log";
 
 type PhoneQaAppProps = {
-onClose: () => void;
-onNotice?: (msg: string) => void;
+  onClose: () => void;
+  onNotice?: (msg: string) => void;
 };
 
 const SUGGESTIONS = [
-"怎么添加我的 API？",
-"聊天没有回复怎么排查？",
-"怎么部署到 Netlify / Vercel？",
-"数据存在哪里，怎么备份？",
-"帮我写个小游戏装到本机",
+  "怎么添加我的 API？",
+  "聊天没有回复怎么排查？",
+  "怎么部署到 Netlify / Vercel？",
+  "数据存在哪里，怎么备份？",
+  "帮我写个小游戏装到本机",
 ];
 
 function formatRelativeTime(ts: number): string {
-const diff = Date.now() - ts;
-if (diff < 60_000) return "刚刚";
-if (diff < 3_600_000) return ${Math.floor(diff / 60_000)} 分钟前;
-if (diff < 86_400_000) return ${Math.floor(diff / 3_600_000)} 小时前;
-return ${Math.floor(diff / 86_400_000)} 天前;
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return "刚刚";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟前`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前`;
+  return `${Math.floor(diff / 86_400_000)} 天前`;
 }
 
 // ── 代码块（语言标签 + 一键复制）─────────────────────
 
 function QaCodeBlock({ className, children }: { className?: string; children?: React.ReactNode }) {
-const [copied, setCopied] = useState(false);
-const language = /language-(\w+)/.exec(className || "")?.[1] ?? "";
-const code = String(children ?? "").replace(/\n$/, "");
+  const [copied, setCopied] = useState(false);
+  const language = /language-(\w+)/.exec(className || "")?.[1] ?? "";
+  const code = String(children ?? "").replace(/\n$/, "");
 
-const handleCopy = useCallback(() => {
-navigator.clipboard
-?.writeText(code)
-.then(() => {
-setCopied(true);
-setTimeout(() => setCopied(false), 1500);
-})
-.catch(() => {});
-}, [code]);
+  const handleCopy = useCallback(() => {
+    navigator.clipboard
+      ?.writeText(code)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {});
+  }, [code]);
 
-return (
-
-
-{language || "code"}
-
-{copied ?  : }
-
-
-
-{code}
-
-
-);
+  return (
+    <div className="qa-codeblock">
+      <div className="qa-codeblock-head">
+        <span className="qa-codeblock-lang">{language || "code"}</span>
+        <button type="button" className="qa-codeblock-copy" onClick={handleCopy} aria-label="复制代码">
+          {copied ? <Check size={13} /> : <Copy size={13} />}
+        </button>
+      </div>
+      <pre>
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
 }
 
 const QA_MARKDOWN_COMPONENTS = {
-pre({ children }: { children?: React.ReactNode }) {
-return <>{children}</>;
-},
-code(props: { className?: string; children?: React.ReactNode }) {
-const { className, children } = props;
-const isBlock = /language-/.test(className || "") || String(children ?? "").includes("\n");
-if (isBlock) return {children};
-return {children};
-},
-a({ href, children }: { href?: string; children?: React.ReactNode }) {
-return (
-
-{children}
-
-);
-},
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+  pre({ children }: { children?: React.ReactNode }) {
+    return <>{children}</>;
+  },
+  code(props: { className?: string; children?: React.ReactNode }) {
+    const { className, children } = props;
+    const isBlock = /language-/.test(className || "") || String(children ?? "").includes("\n");
+    if (isBlock) return <QaCodeBlock className={className}>{children}</QaCodeBlock>;
+    return <code className="qa-inline-code">{children}</code>;
+  },
+  a({ href, children }: { href?: string; children?: React.ReactNode }) {
+    return (
+      <a href={href} target="_blank" rel="noreferrer noopener">
+        {children}
+      </a>
+    );
+  },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any;
 
 // ── 提交提案卡片 ─────────────────────────────────────
 
 function QaCommitCard({ msg }: { msg: QaMsg }) {
-const pending = msg.pendingCommit;
-const [busy, setBusy] = useState(false);
-if (!pending) return null;
-const { proposal, status, result, error } = pending;
-const files = proposal.files;
+  const pending = msg.pendingCommit;
+  const [busy, setBusy] = useState(false);
+  if (!pending) return null;
+  const { proposal, status, result, error } = pending;
+  const files = proposal.files;
 
-const apply = async () => {
-setBusy(true);
-await applyQaCommit(msg.id);
-setBusy(false);
-};
-const revert = async () => {
-setBusy(true);
-await revertQaAppliedCommit(msg.id);
-setBusy(false);
-};
+  const apply = async () => {
+    setBusy(true);
+    await applyQaCommit(msg.id);
+    setBusy(false);
+  };
+  const revert = async () => {
+    setBusy(true);
+    await revertQaAppliedCommit(msg.id);
+    setBusy(false);
+  };
 
-return (
-<div className={qa-commit-card status-${status}}>
-
-
-{status === "applied" ? "已提交" : status === "reverted" ? "已撤销" : status === "canceled" ? "已取消" : "修改提案"}
-
-{proposal.branch || "默认分支"} · {files.length + (proposal.deletes?.length ?? 0)} 个文件
-
-{proposal.message}
-
-{files.map((f) => (
-{f.path}
-))}
-{(proposal.deletes ?? []).map((path) => (
-<li key={del-${path}} className="qa-commit-file-delete">− {path}（删除）
-))}
-
-{error && {error}}
-{status === "pending" && (
-
-
-{busy ?  : "应用"}
-
-<button type="button" className="qa-commit-btn" onClick={() => cancelQaCommit(msg.id)} disabled={busy}>
-取消
-
-
-)}
-{(status === "applying" || status === "reverting") && (
-
-
- {status === "applying" ? "提交中…" : "撤销中…"}
-
-
-)}
-{status === "applied" && result && (
-
-
-查看 commit {result.sha.slice(0, 7)}
-
-
-撤销
-
-
-)}
-
-);
+  return (
+    <div className={`qa-commit-card status-${status}`}>
+      <div className="qa-commit-head">
+        <span className="qa-commit-title">
+          {status === "applied" ? "已提交" : status === "reverted" ? "已撤销" : status === "canceled" ? "已取消" : "修改提案"}
+        </span>
+        <span className="qa-commit-branch">{proposal.branch || "默认分支"} · {files.length + (proposal.deletes?.length ?? 0)} 个文件</span>
+      </div>
+      <div className="qa-commit-msg">{proposal.message}</div>
+      <ul className="qa-commit-files">
+        {files.map((f) => (
+          <li key={f.path}>{f.path}</li>
+        ))}
+        {(proposal.deletes ?? []).map((path) => (
+          <li key={`del-${path}`} className="qa-commit-file-delete">− {path}（删除）</li>
+        ))}
+      </ul>
+      {error && <div className="qa-commit-error">{error}</div>}
+      {status === "pending" && (
+        <div className="qa-commit-actions">
+          <button type="button" className="qa-commit-btn is-primary" onClick={apply} disabled={busy}>
+            {busy ? <Loader2 size={13} className="qa-spin" /> : "应用"}
+          </button>
+          <button type="button" className="qa-commit-btn" onClick={() => cancelQaCommit(msg.id)} disabled={busy}>
+            取消
+          </button>
+        </div>
+      )}
+      {(status === "applying" || status === "reverting") && (
+        <div className="qa-commit-actions">
+          <span className="qa-commit-progress">
+            <Loader2 size={13} className="qa-spin" /> {status === "applying" ? "提交中…" : "撤销中…"}
+          </span>
+        </div>
+      )}
+      {status === "applied" && result && (
+        <div className="qa-commit-actions">
+          <a className="qa-commit-link" href={result.htmlUrl} target="_blank" rel="noreferrer noopener">
+            查看 commit {result.sha.slice(0, 7)}
+          </a>
+          <button type="button" className="qa-commit-btn is-danger" onClick={revert} disabled={busy}>
+            撤销
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }
 
 // ── 消息渲染 ─────────────────────────────────────────
 
 // 工具调用行：折叠的单行摘要，点开展开参数与结果（Claude Code 风格）
 function QaToolRow({ tool }: { tool: QaToolStatus }) {
-const [open, setOpen] = useState(false);
-// 「电脑文件 op=send」的结果里带文件卡标记：卡片常显，标记从结果文本中剥离
-const { text: resultText, file } = parseQaFileMarker(tool.result || "");
-const hasDetail = Boolean(tool.detail || resultText);
-const summary = tool.running ? 正在${tool.name}… : tool.success === false ? ${tool.name}失败 : tool.name;
-return (
-<div className={qa-tool-row ${tool.running ? "is-running" : tool.success === false ? "is-fail" : "is-done"}}>
-<button
-type="button"
-className="qa-tool-row-head"
-onClick={() => hasDetail && setOpen((v) => !v)}
-disabled={!hasDetail}
->
-{tool.running ?  : }
-
-{summary}
-{tool.subtitle && {tool.subtitle}}
-
-{hasDetail && <ChevronRight size={14} className={qa-tool-row-chevron ${open ? "is-open" : ""}} />}
-
-{open && hasDetail && (
-
-{tool.detail && (
-<>
-参数
-{tool.detail}
-</>
-)}
-{resultText && (
-<>
-结果
-{resultText}
-</>
-)}
-
-)}
-{file && }
-
-);
+  const [open, setOpen] = useState(false);
+  // 「电脑文件 op=send」的结果里带文件卡标记：卡片常显，标记从结果文本中剥离
+  const { text: resultText, file } = parseQaFileMarker(tool.result || "");
+  const hasDetail = Boolean(tool.detail || resultText);
+  const summary = tool.running ? `正在${tool.name}…` : tool.success === false ? `${tool.name}失败` : tool.name;
+  return (
+    <div className={`qa-tool-row ${tool.running ? "is-running" : tool.success === false ? "is-fail" : "is-done"}`}>
+      <button
+        type="button"
+        className="qa-tool-row-head"
+        onClick={() => hasDetail && setOpen((v) => !v)}
+        disabled={!hasDetail}
+      >
+        {tool.running ? <Loader2 size={13} className="qa-spin" /> : <Wrench size={13} />}
+        <span className="qa-tool-row-summary">
+          {summary}
+          {tool.subtitle && <span className="qa-tool-row-sub">{tool.subtitle}</span>}
+        </span>
+        {hasDetail && <ChevronRight size={14} className={`qa-tool-row-chevron ${open ? "is-open" : ""}`} />}
+      </button>
+      {open && hasDetail && (
+        <div className="qa-tool-row-body">
+          {tool.detail && (
+            <>
+              <div className="qa-tool-row-label">参数</div>
+              <pre className="qa-tool-row-pre">{tool.detail}</pre>
+            </>
+          )}
+          {resultText && (
+            <>
+              <div className="qa-tool-row-label">结果</div>
+              <pre className="qa-tool-row-pre">{resultText}</pre>
+            </>
+          )}
+        </div>
+      )}
+      {file && <QaFileCard file={file} />}
+    </div>
+  );
 }
 
 // 已完成文本的 Markdown 渲染：memo 缓存——流式期间每次增量都全文重排 remark 是
 // 低端机 WebView OOM 崩溃的主因（几万字 × 每秒多次解析）。文本不变就不重渲。
 const QaMarkdownBlock = memo(function QaMarkdownBlock({ text }: { text: string }) {
-return (
-<ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={QA_MARKDOWN_COMPONENTS}>
-{text}
-
-);
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={QA_MARKDOWN_COMPONENTS}>
+      {text}
+    </ReactMarkdown>
+  );
 });
 
 // 正在生长的活跃段：纯文本渲染（零解析成本），生成结束后换回完整 Markdown
 function QaStreamingText({ text }: { text: string }) {
-return (
-<>
-{text}
-
-</>
-);
+  return (
+    <>
+      <div className="qa-stream-text">{text}</div>
+      <span className="qa-cursor" />
+    </>
+  );
 }
 
 const QaMessageItem = memo(function QaMessageItem({
-msg,
-isStreaming,
-onRetry,
-onViewImage,
-onCopy,
-onEdit,
+  msg,
+  isStreaming,
+  onRetry,
+  onViewImage,
+  onCopy,
+  onEdit,
 }: {
-msg: QaMsg;
-isStreaming: boolean;
-onRetry: (id: string) => void;
-onViewImage: (url: string) => void;
-onCopy: (content: string) => void;
-onEdit: (msg: QaMsg) => void;
+  msg: QaMsg;
+  isStreaming: boolean;
+  onRetry: (id: string) => void;
+  onViewImage: (url: string) => void;
+  onCopy: (content: string) => void;
+  onEdit: (msg: QaMsg) => void;
 }) {
-const thinkingOnly = isStreaming && !msg.content && (!msg.tools || msg.tools.length === 0);
-const showActions = !isStreaming && !thinkingOnly;
-const msgWrap = (node: ReactNode) => (
+  const thinkingOnly = isStreaming && !msg.content && (!msg.tools || msg.tools.length === 0);
+  const showActions = !isStreaming && !thinkingOnly;
+  const msgWrap = (node: ReactNode) => (
+    <div className="qa-msg-wrap">
+      {node}
+      {showActions && (
+        <div className="qa-msg-actions" data-role={msg.role}>
+          <button type="button" className="qa-msg-action" aria-label="复制原始内容" title="复制" onClick={() => onCopy(msg.content)}>
+            <Copy size={14} strokeWidth={2} />
+          </button>
+          <button type="button" className="qa-msg-action" aria-label="修改消息" title="修改" onClick={() => onEdit(msg)}>
+            <Pencil size={14} strokeWidth={2} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+  
+  const segmentBlocks = useMemo(() => {
+    if (!msg.segments?.length) return null;
+    const blocks: Array<{ kind: "text"; text: string } | { kind: "tools"; tools: QaToolStatus[] }> = [];
+    for (const seg of msg.segments) {
+      const last = blocks[blocks.length - 1];
+      if (seg.kind === "tool") {
+        if (last?.kind === "tools") last.tools.push(seg.tool);
+        else blocks.push({ kind: "tools", tools: [seg.tool] });
+      } else if (seg.text.trim()) {
+        if (last?.kind === "text") last.text += seg.text;
+        else blocks.push({ kind: "text", text: seg.text });
+      }
+    }
+    return blocks.length ? blocks : null;
+  }, [msg.segments]);
 
-{node}
-{showActions && (
+  if (msg.role === "user") {
+    return msgWrap(
+      <div className="qa-msg-user-row">
+        <div className="qa-msg-user">
+          {msg.images && msg.images.length > 0 && (
+            <div className="qa-msg-images">
+              {msg.images.map((url, i) => (
+                <button key={i} type="button" className="qa-msg-image" onClick={() => onViewImage(url)} aria-label="查看图片">
+                  <img src={url} alt="" />
+                </button>
+              ))}
+            </div>
+          )}
+          {msg.files && msg.files.length > 0 && (
+            <div className="qa-msg-files" style={{ display: "flex", flexDirection: "column", gap: "4px", marginBottom: "8px" }}>
+              {msg.files.map((f, i) => (
+                <div key={i} style={{ display: "flex", alignItems: "center", gap: "6px", background: "rgba(255,255,255,0.1)", padding: "4px 8px", borderRadius: "6px", fontSize: "12px", border: "1px solid rgba(255,255,255,0.2)" }}>
+                   <FileText size={14} />
+                   <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: "150px" }}>{f.name}</span>
+                </div>
+              ))}
+            </div>
+          )}
+          {msg.content}
+        </div>
+      </div>,
+    );
+  }
 
-<button type="button" className="qa-msg-action" aria-label="复制原始内容" title="复制" onClick={() => onCopy(msg.content)}>
-
-
-<button type="button" className="qa-msg-action" aria-label="修改消息" title="修改" onClick={() => onEdit(msg)}>
-
-
-
-)}
-
-);
-
-const segmentBlocks = useMemo(() => {
-if (!msg.segments?.length) return null;
-const blocks: Array<{ kind: "text"; text: string } | { kind: "tools"; tools: QaToolStatus[] }> = [];
-for (const seg of msg.segments) {
-const last = blocks[blocks.length - 1];
-if (seg.kind === "tool") {
-if (last?.kind === "tools") last.tools.push(seg.tool);
-else blocks.push({ kind: "tools", tools: [seg.tool] });
-} else if (seg.text.trim()) {
-if (last?.kind === "text") last.text += seg.text;
-else blocks.push({ kind: "text", text: seg.text });
-}
-}
-return blocks.length ? blocks : null;
-}, [msg.segments]);
-
-if (msg.role === "user") {
-return msgWrap(
-
-
-{msg.images && msg.images.length > 0 && (
-
-{msg.images.map((url, i) => (
-<button key={i} type="button" className="qa-msg-image" onClick={() => onViewImage(url)} aria-label="查看图片">
-
-
-))}
-
-)}
-{msg.files && msg.files.length > 0 && (
-<div className="qa-msg-files" style={{ display: "flex", flexDirection: "column", gap: "4px", marginBottom: "8px" }}>
-{msg.files.map((f, i) => (
-<div key={i} style={{ display: "flex", alignItems: "center", gap: "6px", background: "rgba(255,255,255,0.1)", padding: "4px 8px", borderRadius: "6px", fontSize: "12px", border: "1px solid rgba(255,255,255,0.2)" }}>
-
-<span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: "150px" }}>{f.name}
-
-))}
-
-)}
-{msg.content}
-
-,
-);
-}
-
-return msgWrap(
-
-{segmentBlocks ? (
-segmentBlocks.map((block, i) =>
-block.kind === "tools" ? (
-
-{block.tools.map((tool, j) => (
-<QaToolRow key={${tool.name}-${j}} tool={tool} />
-))}
-
-) : isStreaming && i === segmentBlocks.length - 1 ? (
-
-
-
-) : (
-
-
-
-),
-)
-) : (
-<>
-{msg.tools && msg.tools.length > 0 && (
-
-{msg.tools.map((tool, i) => (
-<QaToolRow key={${tool.name}-${i}} tool={tool} />
-))}
-
-)}
-{thinkingOnly ? (
-{msg.toolDrafting ? "正在编写工具调用…" : msg.reasoning ? "正在思考…" : "正在生成…"}
-) : isStreaming ? (
-
-
-
-) : (
-
-
-
-)}
-</>
-)}
-{isStreaming && msg.toolDrafting && !thinkingOnly && (
-正在编写工具调用…
-)}
-{msg.streamNote && {msg.streamNote}}
-{msg.pendingCommit && }
-{msg.aborted && 已停止生成}
-{msg.error && (
-
-{msg.error}
-<button type="button" className="qa-retry-btn" onClick={() => onRetry(msg.id)}>
-重试
-
-
-)}
-,
-);
+  return msgWrap(
+    <div className="qa-msg-assistant">
+      {segmentBlocks ? (
+        segmentBlocks.map((block, i) =>
+          block.kind === "tools" ? (
+            <div className="qa-tools" key={i}>
+              {block.tools.map((tool, j) => (
+                <QaToolRow key={`${tool.name}-${j}`} tool={tool} />
+              ))}
+            </div>
+          ) : isStreaming && i === segmentBlocks.length - 1 ? (
+            <div className="qa-markdown" key={i}>
+              <QaStreamingText text={block.text} />
+            </div>
+          ) : (
+            <div className="qa-markdown" key={i}>
+              <QaMarkdownBlock text={block.text} />
+            </div>
+          ),
+        )
+      ) : (
+        <>
+          {msg.tools && msg.tools.length > 0 && (
+            <div className="qa-tools">
+              {msg.tools.map((tool, i) => (
+                <QaToolRow key={`${tool.name}-${i}`} tool={tool} />
+              ))}
+            </div>
+          )}
+          {thinkingOnly ? (
+            <div className="qa-thinking">{msg.toolDrafting ? "正在编写工具调用…" : msg.reasoning ? "正在思考…" : "正在生成…"}</div>
+          ) : isStreaming ? (
+            <div className="qa-markdown">
+              <QaStreamingText text={msg.content} />
+            </div>
+          ) : (
+            <div className="qa-markdown">
+              <QaMarkdownBlock text={msg.content} />
+            </div>
+          )}
+        </>
+      )}
+      {isStreaming && msg.toolDrafting && !thinkingOnly && (
+        <div className="qa-thinking qa-tool-drafting">正在编写工具调用…</div>
+      )}
+      {msg.streamNote && <div className="qa-msg-note">{msg.streamNote}</div>}
+      {msg.pendingCommit && <QaCommitCard msg={msg} />}
+      {msg.aborted && <div className="qa-msg-note">已停止生成</div>}
+      {msg.error && (
+        <div className="qa-msg-error">
+          <div className="qa-msg-error-text">{msg.error}</div>
+          <button type="button" className="qa-retry-btn" onClick={() => onRetry(msg.id)}>
+            重试
+          </button>
+        </div>
+      )}
+    </div>,
+  );
 });
 
 // ── 会话抽屉 ─────────────────────────────────────────
 
 function QaSessionDrawer({
-sessions,
-activeId,
-onSelect,
-onDelete,
-onCreate,
-onOpenSettings,
-onRenameRequest,
+  sessions,
+  activeId,
+  onSelect,
+  onDelete,
+  onCreate,
+  onOpenSettings,
+  onRenameRequest,
 }: {
-sessions: QaSession[];
-activeId: string | null;
-onSelect: (id: string) => void;
-onDelete: (id: string) => void;
-onCreate: () => void;
-onOpenSettings: () => void;
-onRenameRequest: (id: string, title: string) => void;
+  sessions: QaSession[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
+  onCreate: () => void;
+  onOpenSettings: () => void;
+  onRenameRequest: (id: string, title: string) => void;
 }) {
-const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 
-// 置顶的排最前，其余保持时间序。只在渲染层排，存储顺序不动
-const sortedSessions = useMemo(() => {
-return [...sessions].sort((a, b) => {
-if (Boolean(a.isPinned) !== Boolean(b.isPinned)) return a.isPinned ? -1 : 1;
-return b.updatedAt - a.updatedAt;
-});
-}, [sessions]);
+  // 置顶的排最前，其余保持时间序。只在渲染层排，存储顺序不动
+  const sortedSessions = useMemo(() => {
+    return [...sessions].sort((a, b) => {
+      if (Boolean(a.isPinned) !== Boolean(b.isPinned)) return a.isPinned ? -1 : 1;
+      return b.updatedAt - a.updatedAt;
+    });
+  }, [sessions]);
 
-return (
-
-
-对话记录
-
-<div
-className="qa-drawer-list hide-scrollbar"
-onClick={() => { if (menuOpenId) setMenuOpenId(null); }}
->
-{sortedSessions.length === 0 && 还没有对话}
-{sortedSessions.map((session) => (
-<div
-key={session.id}
-className={qa-drawer-item ${session.id === activeId ? "is-active" : ""}}
-onClick={() => onSelect(session.id)}
->
-
-
-{session.isPinned && }
-{session.title}
-
-{formatRelativeTime(session.updatedAt)}
-
-<button
-type="button"
-className="qa-icon-btn qa-drawer-item-more"
-aria-label="更多操作"
-aria-expanded={menuOpenId === session.id}
-onClick={(e) => {
-e.stopPropagation();
-setMenuOpenId(menuOpenId === session.id ? null : session.id);
-}}
->
-
-
-
-        {menuOpenId === session.id && (
-          <div className="qa-drawer-item-menu" role="menu">
-            <button
-              type="button"
-              role="menuitem"
-              className="qa-drawer-menu-btn"
-              onClick={(e) => {
-                e.stopPropagation();
-                toggleQaSessionPin(session.id);
-                setMenuOpenId(null);
-              }}
-            >
-              {session.isPinned ? <PinOff size={14} /> : <Pin size={14} />}
-              {session.isPinned ? "取消置顶" : "置顶"}
-            </button>
-            <button
-              type="button"
-              role="menuitem"
-              className="qa-drawer-menu-btn"
-              onClick={(e) => {
-                e.stopPropagation();
-                onRenameRequest(session.id, session.title);
-                setMenuOpenId(null);
-              }}
-            >
-              <Pencil size={14} /> 重命名
-            </button>
-            <button
-              type="button"
-              role="menuitem"
-              className="qa-drawer-menu-btn is-danger"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(session.id);
-                setMenuOpenId(null);
-              }}
-            >
-              <Trash2 size={14} /> 删除
-            </button>
-          </div>
-        )}
+  return (
+    <aside className="qa-drawer">
+      <div className="qa-drawer-head">
+        <span className="qa-drawer-title">对话记录</span>
       </div>
-    ))}
-  </div>
-  <div className="qa-drawer-foot">
-    <button type="button" className="qa-drawer-new qa-drawer-settings" onClick={onOpenSettings}>
-      <Wrench size={15} strokeWidth={2} />
-      <span>工坊配置</span>
-    </button>
-    <button type="button" className="qa-drawer-new" onClick={onCreate}>
-      <Plus size={16} strokeWidth={2} />
-      <span>新对话</span>
-    </button>
-  </div>
-</aside>
+      <div
+        className="qa-drawer-list hide-scrollbar"
+        onClick={() => { if (menuOpenId) setMenuOpenId(null); }}
+      >
+        {sortedSessions.length === 0 && <div className="qa-drawer-empty">还没有对话</div>}
+        {sortedSessions.map((session) => (
+          <div
+            key={session.id}
+            className={`qa-drawer-item ${session.id === activeId ? "is-active" : ""}`}
+            onClick={() => onSelect(session.id)}
+          >
+            <div className="qa-drawer-item-main">
+              <span className="qa-drawer-item-title">
+                {session.isPinned && <Pin size={12} className="qa-drawer-pin-mark" aria-label="已置顶" />}
+                {session.title}
+              </span>
+              <span className="qa-drawer-item-time">{formatRelativeTime(session.updatedAt)}</span>
+            </div>
+            <button
+              type="button"
+              className="qa-icon-btn qa-drawer-item-more"
+              aria-label="更多操作"
+              aria-expanded={menuOpenId === session.id}
+              onClick={(e) => {
+                e.stopPropagation();
+                setMenuOpenId(menuOpenId === session.id ? null : session.id);
+              }}
+            >
+              <MoreVertical size={14} />
+            </button>
 
-
-);
+            {menuOpenId === session.id && (
+              <div className="qa-drawer-item-menu" role="menu">
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="qa-drawer-menu-btn"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleQaSessionPin(session.id);
+                    setMenuOpenId(null);
+                  }}
+                >
+                  {session.isPinned ? <PinOff size={14} /> : <Pin size={14} />}
+                  {session.isPinned ? "取消置顶" : "置顶"}
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="qa-drawer-menu-btn"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRenameRequest(session.id, session.title);
+                    setMenuOpenId(null);
+                  }}
+                >
+                  <Pencil size={14} /> 重命名
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="qa-drawer-menu-btn is-danger"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete(session.id);
+                    setMenuOpenId(null);
+                  }}
+                >
+                  <Trash2 size={14} /> 删除
+                </button>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="qa-drawer-foot">
+        <button type="button" className="qa-drawer-new qa-drawer-settings" onClick={onOpenSettings}>
+          <Wrench size={15} strokeWidth={2} />
+          <span>工坊配置</span>
+        </button>
+        <button type="button" className="qa-drawer-new" onClick={onCreate}>
+          <Plus size={16} strokeWidth={2} />
+          <span>新对话</span>
+        </button>
+      </div>
+    </aside>
+  );
 }
 
 // ── 工坊配置面板 ─────────────────────────────────────
 
 function QaSettingsSheet({ onClose, onNotice }: { onClose: () => void; onNotice?: (msg: string) => void }) {
-const [budget, setBudget] = useState(() => String(getQaContextBudgetChars()));
-const [pageChars, setPageChars] = useState(() => String(getQaPageChars()));
-const [maxRounds, setMaxRounds] = useState(() => String(getQaMaxRounds()));
-const [maxOutTokens, setMaxOutTokens] = useState(() => {
-const v = getQaMaxOutputTokens();
-return v == null ? "" : String(v);
-});
-const usedChars = getQaActiveContextChars();
-const pct = Math.round((usedChars / getQaContextBudgetChars()) * 100);
+  const [budget, setBudget] = useState(() => String(getQaContextBudgetChars()));
+  const [pageChars, setPageChars] = useState(() => String(getQaPageChars()));
+  const [maxRounds, setMaxRounds] = useState(() => String(getQaMaxRounds()));
+  const [maxOutTokens, setMaxOutTokens] = useState(() => {
+    const v = getQaMaxOutputTokens();
+    return v == null ? "" : String(v);
+  });
+  const usedChars = getQaActiveContextChars();
+  const pct = Math.round((usedChars / getQaContextBudgetChars()) * 100);
 
-const save = () => {
-const parsed = Number(budget);
-if (!Number.isFinite(parsed) || parsed < QA_CONTEXT_BUDGET_MIN || parsed > QA_CONTEXT_BUDGET_MAX) {
-onNotice?.(预算需为 ${QA_CONTEXT_BUDGET_MIN.toLocaleString()} - ${QA_CONTEXT_BUDGET_MAX.toLocaleString()} 之间的数字。);
-return;
-}
-const parsedPage = Number(pageChars);
-if (!Number.isFinite(parsedPage) || parsedPage < QA_PAGE_CHARS_MIN || parsedPage > QA_PAGE_CHARS_MAX) {
-onNotice?.(单页字符数需为 ${QA_PAGE_CHARS_MIN.toLocaleString()} - ${QA_PAGE_CHARS_MAX.toLocaleString()} 之间的数字。);
-return;
-}
-const parsedRounds = Number(maxRounds);
-if (!Number.isFinite(parsedRounds) || parsedRounds < QA_MAX_ROUNDS_MIN || parsedRounds > QA_MAX_ROUNDS_MAX) {
-onNotice?.(工具调用上限需为 ${QA_MAX_ROUNDS_MIN} - ${QA_MAX_ROUNDS_MAX} 之间的数字。);
-return;
-}
-const trimmedTokens = maxOutTokens.trim();
-const parsedTokens = trimmedTokens ? Number(trimmedTokens) : null;
-if (parsedTokens != null && (!Number.isFinite(parsedTokens) || parsedTokens < QA_MAX_OUTPUT_TOKENS_MIN || parsedTokens > QA_MAX_OUTPUT_TOKENS_MAX)) {
-onNotice?.(单次最大输出 token 需留空或为 ${QA_MAX_OUTPUT_TOKENS_MIN.toLocaleString()} - ${QA_MAX_OUTPUT_TOKENS_MAX.toLocaleString()} 之间的数字。);
-return;
-}
-setQaContextBudgetChars(parsed);
-setQaPageChars(parsedPage);
-setQaMaxRounds(parsedRounds);
-setQaMaxOutputTokens(trimmedTokens ? parsedTokens : 0);
-onNotice?.("已保存工坊配置。");
-onClose();
-};
+  const save = () => {
+    const parsed = Number(budget);
+    if (!Number.isFinite(parsed) || parsed < QA_CONTEXT_BUDGET_MIN || parsed > QA_CONTEXT_BUDGET_MAX) {
+      onNotice?.(`预算需为 ${QA_CONTEXT_BUDGET_MIN.toLocaleString()} - ${QA_CONTEXT_BUDGET_MAX.toLocaleString()} 之间的数字。`);
+      return;
+    }
+    const parsedPage = Number(pageChars);
+    if (!Number.isFinite(parsedPage) || parsedPage < QA_PAGE_CHARS_MIN || parsedPage > QA_PAGE_CHARS_MAX) {
+      onNotice?.(`单页字符数需为 ${QA_PAGE_CHARS_MIN.toLocaleString()} - ${QA_PAGE_CHARS_MAX.toLocaleString()} 之间的数字。`);
+      return;
+    }
+    const parsedRounds = Number(maxRounds);
+    if (!Number.isFinite(parsedRounds) || parsedRounds < QA_MAX_ROUNDS_MIN || parsedRounds > QA_MAX_ROUNDS_MAX) {
+      onNotice?.(`工具调用上限需为 ${QA_MAX_ROUNDS_MIN} - ${QA_MAX_ROUNDS_MAX} 之间的数字。`);
+      return;
+    }
+    const trimmedTokens = maxOutTokens.trim();
+    const parsedTokens = trimmedTokens ? Number(trimmedTokens) : null;
+    if (parsedTokens != null && (!Number.isFinite(parsedTokens) || parsedTokens < QA_MAX_OUTPUT_TOKENS_MIN || parsedTokens > QA_MAX_OUTPUT_TOKENS_MAX)) {
+      onNotice?.(`单次最大输出 token 需留空或为 ${QA_MAX_OUTPUT_TOKENS_MIN.toLocaleString()} - ${QA_MAX_OUTPUT_TOKENS_MAX.toLocaleString()} 之间的数字。`);
+      return;
+    }
+    setQaContextBudgetChars(parsed);
+    setQaPageChars(parsedPage);
+    setQaMaxRounds(parsedRounds);
+    setQaMaxOutputTokens(trimmedTokens ? parsedTokens : 0);
+    onNotice?.("已保存工坊配置。");
+    onClose();
+  };
 
-const reset = () => {
-setQaContextBudgetChars(null);
-setQaPageChars(null);
-setQaMaxRounds(null);
-setQaMaxOutputTokens(null);
-setBudget(String(QA_DEFAULT_CONTEXT_BUDGET_CHARS));
-setPageChars(String(QA_DEFAULT_PAGE_CHARS));
-setMaxRounds(String(QA_DEFAULT_MAX_ROUNDS));
-setMaxOutTokens(String(QA_DEFAULT_MAX_OUTPUT_TOKENS));
-onNotice?.("已恢复默认配置。");
-};
+  const reset = () => {
+    setQaContextBudgetChars(null);
+    setQaPageChars(null);
+    setQaMaxRounds(null);
+    setQaMaxOutputTokens(null);
+    setBudget(String(QA_DEFAULT_CONTEXT_BUDGET_CHARS));
+    setPageChars(String(QA_DEFAULT_PAGE_CHARS));
+    setMaxRounds(String(QA_DEFAULT_MAX_ROUNDS));
+    setMaxOutTokens(String(QA_DEFAULT_MAX_OUTPUT_TOKENS));
+    onNotice?.("已恢复默认配置。");
+  };
 
-return (
-
-<div className="qa-devnotice" role="dialog" aria-label="工坊配置" onClick={(e) => e.stopPropagation()}>
-工坊配置
-
-上下文预算（字符）
-<input
-type="number"
-inputMode="numeric"
-min={QA_CONTEXT_BUDGET_MIN}
-max={QA_CONTEXT_BUDGET_MAX}
-step={1000}
-value={budget}
-onChange={(e) => setBudget(e.target.value)}
-/>
-
-
-上下文满 100% 时自动压缩成摘要并重新累计。中文约 1 字符 ≈ 1 token；默认 {QA_DEFAULT_CONTEXT_BUDGET_CHARS.toLocaleString()}，小上下文（32k）模型建议 30000–50000。
-
-当前会话已用 {usedChars.toLocaleString()} 字符（约 {pct}%）。
-
-单页读取字符数
-<input
-type="number"
-inputMode="numeric"
-min={QA_PAGE_CHARS_MIN}
-max={QA_PAGE_CHARS_MAX}
-step={1000}
-value={pageChars}
-onChange={(e) => setPageChars(e.target.value)}
-/>
-
-
-小坊翻页读答疑文档 / 本机内容 / 仓库源码时，每页返回的字符数。默认 {QA_DEFAULT_PAGE_CHARS.toLocaleString()}；调大读得快但更占上下文，小上下文模型建议调小。
-
-
-单轮工具调用上限（次）
-<input
-type="number"
-inputMode="numeric"
-min={QA_MAX_ROUNDS_MIN}
-max={QA_MAX_ROUNDS_MAX}
-step={1}
-value={maxRounds}
-onChange={(e) => setMaxRounds(e.target.value)}
-/>
-
-
-一次提问里小坊最多连续执行多少轮工具，用完会提示「回复继续」。默认 {QA_DEFAULT_MAX_ROUNDS}；复杂任务（写游戏、改代码）可调大，想控制 token 消耗可调小。
-
-
-单次最大输出 token
-<input
-type="number"
-inputMode="numeric"
-min={QA_MAX_OUTPUT_TOKENS_MIN}
-max={QA_MAX_OUTPUT_TOKENS_MAX}
-step={1000}
-placeholder="留空 = 不传"
-value={maxOutTokens}
-onChange={(e) => setMaxOutTokens(e.target.value)}
-/>
-
-
-输出长度护栏：每次请求带 max_tokens，小坊会按该预算分段写大文件，写超被安全截断后自动续接，不再整轮报废。默认 {QA_DEFAULT_MAX_OUTPUT_TOKENS.toLocaleString()}；留空 = 不传该参数（部分模型/中转不支持 max_tokens 时请留空）。
-
-
-恢复默认
-保存
-
-
-
-);
+  return (
+    <div className="qa-devnotice-backdrop" onClick={onClose}>
+      <div className="qa-devnotice" role="dialog" aria-label="工坊配置" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-devnotice-title">工坊配置</div>
+        <label className="qa-settings-field">
+          <span>上下文预算（字符）</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={QA_CONTEXT_BUDGET_MIN}
+            max={QA_CONTEXT_BUDGET_MAX}
+            step={1000}
+            value={budget}
+            onChange={(e) => setBudget(e.target.value)}
+          />
+        </label>
+        <div className="qa-settings-hint">
+          上下文满 100% 时自动压缩成摘要并重新累计。中文约 1 字符 ≈ 1 token；默认 {QA_DEFAULT_CONTEXT_BUDGET_CHARS.toLocaleString()}，小上下文（32k）模型建议 30000–50000。
+        </div>
+        <div className="qa-settings-hint">当前会话已用 {usedChars.toLocaleString()} 字符（约 {pct}%）。</div>
+        <label className="qa-settings-field">
+          <span>单页读取字符数</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={QA_PAGE_CHARS_MIN}
+            max={QA_PAGE_CHARS_MAX}
+            step={1000}
+            value={pageChars}
+            onChange={(e) => setPageChars(e.target.value)}
+          />
+        </label>
+        <div className="qa-settings-hint">
+          小坊翻页读答疑文档 / 本机内容 / 仓库源码时，每页返回的字符数。默认 {QA_DEFAULT_PAGE_CHARS.toLocaleString()}；调大读得快但更占上下文，小上下文模型建议调小。
+        </div>
+        <label className="qa-settings-field">
+          <span>单轮工具调用上限（次）</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={QA_MAX_ROUNDS_MIN}
+            max={QA_MAX_ROUNDS_MAX}
+            step={1}
+            value={maxRounds}
+            onChange={(e) => setMaxRounds(e.target.value)}
+          />
+        </label>
+        <div className="qa-settings-hint">
+          一次提问里小坊最多连续执行多少轮工具，用完会提示「回复继续」。默认 {QA_DEFAULT_MAX_ROUNDS}；复杂任务（写游戏、改代码）可调大，想控制 token 消耗可调小。
+        </div>
+        <label className="qa-settings-field">
+          <span>单次最大输出 token</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={QA_MAX_OUTPUT_TOKENS_MIN}
+            max={QA_MAX_OUTPUT_TOKENS_MAX}
+            step={1000}
+            placeholder="留空 = 不传"
+            value={maxOutTokens}
+            onChange={(e) => setMaxOutTokens(e.target.value)}
+          />
+        </label>
+        <div className="qa-settings-hint">
+          输出长度护栏：每次请求带 max_tokens，小坊会按该预算分段写大文件，写超被安全截断后自动续接，不再整轮报废。默认 {QA_DEFAULT_MAX_OUTPUT_TOKENS.toLocaleString()}；留空 = 不传该参数（部分模型/中转不支持 max_tokens 时请留空）。
+        </div>
+        <div className="qa-devnotice-actions is-row">
+          <button type="button" className="qa-devnotice-btn" onClick={reset}>恢复默认</button>
+          <button type="button" className="qa-devnotice-btn is-primary" onClick={save}>保存</button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 // ── GitHub 仓库配置面板 ──────────────────────────────
 
 function QaRepoSheet({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
-const existing = useMemo(() => loadQaGithubConfig(), []);
-const [owner, setOwner] = useState(existing?.owner ?? "");
-const [repo, setRepo] = useState(existing?.repo ?? "");
-const [branch, setBranch] = useState(existing?.branch ?? "");
-const [token, setToken] = useState(existing?.token ?? "");
-const [writeMode, setWriteMode] = useState<"confirm" | "auto">(existing?.writeMode ?? "confirm");
-const [checking, setChecking] = useState(false);
-const [result, setResult] = useState<QaGithubValidation | null>(null);
+  const existing = useMemo(() => loadQaGithubConfig(), []);
+  const [owner, setOwner] = useState(existing?.owner ?? "");
+  const [repo, setRepo] = useState(existing?.repo ?? "");
+  const [branch, setBranch] = useState(existing?.branch ?? "");
+  const [token, setToken] = useState(existing?.token ?? "");
+  const [writeMode, setWriteMode] = useState<"confirm" | "auto">(existing?.writeMode ?? "confirm");
+  const [checking, setChecking] = useState(false);
+  const [result, setResult] = useState<QaGithubValidation | null>(null);
 
-const buildConfig = useCallback((): QaGithubConfig => {
-const cfg: QaGithubConfig = { owner: owner.trim(), repo: repo.trim(), writeMode };
-if (branch.trim()) cfg.branch = branch.trim();
-if (token.trim()) cfg.token = token.trim();
-if (existing?.apiBase) cfg.apiBase = existing.apiBase;
-return cfg;
-}, [owner, repo, branch, token, writeMode, existing]);
+  const buildConfig = useCallback((): QaGithubConfig => {
+    const cfg: QaGithubConfig = { owner: owner.trim(), repo: repo.trim(), writeMode };
+    if (branch.trim()) cfg.branch = branch.trim();
+    if (token.trim()) cfg.token = token.trim();
+    if (existing?.apiBase) cfg.apiBase = existing.apiBase;
+    return cfg;
+  }, [owner, repo, branch, token, writeMode, existing]);
 
-const handleVerify = useCallback(async () => {
-if (!owner.trim() || !repo.trim()) {
-setResult({ ok: false, error: "请填写 owner 和 repo。" });
-return;
-}
-setChecking(true);
-setResult(null);
-const validation = await validateQaGithubConfig(buildConfig());
-setResult(validation);
-setChecking(false);
-}, [owner, repo, buildConfig]);
+  const handleVerify = useCallback(async () => {
+    if (!owner.trim() || !repo.trim()) {
+      setResult({ ok: false, error: "请填写 owner 和 repo。" });
+      return;
+    }
+    setChecking(true);
+    setResult(null);
+    const validation = await validateQaGithubConfig(buildConfig());
+    setResult(validation);
+    setChecking(false);
+  }, [owner, repo, buildConfig]);
 
-const handleSave = useCallback(() => {
-if (!owner.trim() || !repo.trim()) return;
-saveQaGithubConfig(buildConfig());
-onSaved();
-onClose();
-}, [owner, repo, buildConfig, onSaved, onClose]);
+  const handleSave = useCallback(() => {
+    if (!owner.trim() || !repo.trim()) return;
+    saveQaGithubConfig(buildConfig());
+    onSaved();
+    onClose();
+  }, [owner, repo, buildConfig, onSaved, onClose]);
 
-const handleDisconnect = useCallback(() => {
-clearQaGithubConfig();
-onSaved();
-onClose();
-}, [onSaved, onClose]);
+  const handleDisconnect = useCallback(() => {
+    clearQaGithubConfig();
+    onSaved();
+    onClose();
+  }, [onSaved, onClose]);
 
-return (
-
-<div className="qa-sheet" onClick={(e) => e.stopPropagation()}>
-
-
- 连接 GitHub 仓库
-
-
-
-
-
-
-
-连接后可以让工坊查阅这个仓库的代码来回答问题。配置只保存在你的浏览器本地，不会上传。公开仓库可不填 PAT。
-
-
-Owner（用户名 / 组织）
-<input className="qa-input" value={owner} onChange={(e) => setOwner(e.target.value)} placeholder="例：octocat" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-
-
-Repo（仓库名）
-<input className="qa-input" value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="例：hello-world" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-
-
-分支（可选，默认仓库默认分支）
-<input className="qa-input" value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="main" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-
-
-Fine-grained PAT（私有仓库或搜索代码需要）
-<input className="qa-input" type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="github_pat_…" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-
-GitHub → Settings → Menu 按钮 → Developer settings → Personal access tokens → Fine-grained tokens。创建时 Repository access 记得勾选目标仓库；Permissions 里：Contents——只查代码选 Read-only，要让工坊改代码选 Read and write；要用「创建PR」再加 Pull requests 的 Read and write（Metadata 会自动带上，其余权限都不用勾）。
-
-
-
-改代码时的模式
-
-<button type="button" className={qa-segment-btn ${writeMode === "confirm" ? "is-active" : ""}} onClick={() => setWriteMode("confirm")}>
-确认后提交
-
-<button type="button" className={qa-segment-btn ${writeMode === "auto" ? "is-active" : ""}} onClick={() => setWriteMode("auto")}>
-全自动
-
-
-
-{writeMode === "confirm"
-? "工坊改代码前会先展示改动，你点「应用」才真正提交。推荐。"
-: "工坊说完直接提交推送，不再逐次确认。仍可事后一键撤销。仅在信任后开启。"}
-
-
-{result && (
-<div className={qa-verify ${result.ok ? "is-ok" : "is-fail"}}>
-{result.ok
-? ✓ 已连接 ${result.fullName}（${result.private ? "私有" : "公开"}，默认分支 ${result.defaultBranch}）
-: ✗ ${result.error}}
-
-)}
-
-
-{existing && (
-
-断开
-
-)}
-
-{checking ?  : "验证"}
-
-<button type="button" className="qa-sheet-btn is-primary" onClick={handleSave} disabled={!owner.trim() || !repo.trim()}>
-保存
-
-
-
-
-);
+  return (
+    <div className="qa-sheet-backdrop" onClick={onClose}>
+      <div className="qa-sheet" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-sheet-head">
+          <span className="qa-sheet-title">
+            <Github size={16} /> 连接 GitHub 仓库
+          </span>
+          <button type="button" className="qa-icon-btn" onClick={onClose} aria-label="关闭">
+            <X size={16} />
+          </button>
+        </div>
+        <div className="qa-sheet-body hide-scrollbar">
+          <p className="qa-sheet-note">
+            连接后可以让工坊查阅这个仓库的代码来回答问题。配置只保存在你的浏览器本地，不会上传。公开仓库可不填 PAT。
+          </p>
+          <label className="qa-field">
+            <span className="qa-field-label">Owner（用户名 / 组织）</span>
+            <input className="qa-input" value={owner} onChange={(e) => setOwner(e.target.value)} placeholder="例：octocat" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+          </label>
+          <label className="qa-field">
+            <span className="qa-field-label">Repo（仓库名）</span>
+            <input className="qa-input" value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="例：hello-world" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+          </label>
+          <label className="qa-field">
+            <span className="qa-field-label">分支（可选，默认仓库默认分支）</span>
+            <input className="qa-input" value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="main" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+          </label>
+          <label className="qa-field">
+            <span className="qa-field-label">Fine-grained PAT（私有仓库或搜索代码需要）</span>
+            <input className="qa-input" type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="github_pat_…" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+            <span className="qa-field-hint">
+              GitHub → Settings → Menu 按钮 → Developer settings → Personal access tokens → Fine-grained tokens。创建时 Repository access 记得勾选目标仓库；Permissions 里：Contents——只查代码选 Read-only，要让工坊改代码选 Read and write；要用「创建PR」再加 Pull requests 的 Read and write（Metadata 会自动带上，其余权限都不用勾）。
+            </span>
+          </label>
+          <div className="qa-field">
+            <span className="qa-field-label">改代码时的模式</span>
+            <div className="qa-segment">
+              <button type="button" className={`qa-segment-btn ${writeMode === "confirm" ? "is-active" : ""}`} onClick={() => setWriteMode("confirm")}>
+                确认后提交
+              </button>
+              <button type="button" className={`qa-segment-btn ${writeMode === "auto" ? "is-active" : ""}`} onClick={() => setWriteMode("auto")}>
+                全自动
+              </button>
+            </div>
+            <span className="qa-field-hint">
+              {writeMode === "confirm"
+                ? "工坊改代码前会先展示改动，你点「应用」才真正提交。推荐。"
+                : "工坊说完直接提交推送，不再逐次确认。仍可事后一键撤销。仅在信任后开启。"}
+            </span>
+          </div>
+          {result && (
+            <div className={`qa-verify ${result.ok ? "is-ok" : "is-fail"}`}>
+              {result.ok
+                ? `✓ 已连接 ${result.fullName}（${result.private ? "私有" : "公开"}，默认分支 ${result.defaultBranch}）`
+                : `✗ ${result.error}`}
+            </div>
+          )}
+        </div>
+        <div className="qa-sheet-actions">
+          {existing && (
+            <button type="button" className="qa-sheet-btn is-danger" onClick={handleDisconnect}>
+              断开
+            </button>
+          )}
+          <button type="button" className="qa-sheet-btn" onClick={handleVerify} disabled={checking}>
+            {checking ? <Loader2 size={14} className="qa-spin" /> : "验证"}
+          </button>
+          <button type="button" className="qa-sheet-btn is-primary" onClick={handleSave} disabled={!owner.trim() || !repo.trim()}>
+            保存
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 // ── App 本体 ─────────────────────────────────────────
 
 export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
-const snapshot = useSyncExternalStore(subscribeQaChat, getQaChatSnapshot, getQaChatSnapshot);
-const [input, setInput] = useState("");
-const [drawerOpen, setDrawerOpen] = useState(false);
-const [repoSheetOpen, setRepoSheetOpen] = useState(false);
-const [repoConnected, setRepoConnected] = useState(false);
-const [clearToolsOpen, setClearToolsOpen] = useState(false);
-const [settingsOpen, setSettingsOpen] = useState(false);
-/ 会话重命名弹窗：抽屉菜单里点「重命名」打开 */
-const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
-const [renameTitle, setRenameTitle] = useState("");
-const [pendingImages, setPendingImages] = useState<string[]>([]);
-const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
+  const snapshot = useSyncExternalStore(subscribeQaChat, getQaChatSnapshot, getQaChatSnapshot);
+  const [input, setInput] = useState("");
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [repoSheetOpen, setRepoSheetOpen] = useState(false);
+  const [repoConnected, setRepoConnected] = useState(false);
+  const [clearToolsOpen, setClearToolsOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  /** 会话重命名弹窗：抽屉菜单里点「重命名」打开 */
+  const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
+  const [renameTitle, setRenameTitle] = useState("");
+  const [pendingImages, setPendingImages] = useState<string[]>([]);
+  const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
+  
+  const [viewerImage, setViewerImage] = useState<string | null>(null);
+  const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
+  const [editText, setEditText] = useState("");
+  const [editImages, setEditImages] = useState<string[]>([]);
+  const [editFiles, setEditFiles] = useState<{name: string, content: string}[]>([]);
+  
+  const [visionEnabled, setVisionEnabled] = useState(false);
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  
+  const [apiReady, setApiReady] = useState(true);
+  const [modelName, setModelName] = useState("");
+  const [repoWritable, setRepoWritable] = useState(false);
+  const [writeMode, setWriteMode] = useState<"confirm" | "auto">("confirm");
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const stickToBottomRef = useRef(true);
 
-const [viewerImage, setViewerImage] = useState<string | null>(null);
-const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
-const [editText, setEditText] = useState("");
-const [editImages, setEditImages] = useState<string[]>([]);
-const [editFiles, setEditFiles] = useState<{name: string, content: string}[]>([]);
+  const refreshComposerMeta = useCallback(() => {
+    setApiReady(resolveQaApiConfig() != null);
+    setModelName(resolveQaApiConfig()?.defaultModel ?? "");
+    setVisionEnabled(resolveQaApiConfig()?.enableImageRecognition === true);
+    const gh = loadQaGithubConfig();
+    setRepoConnected(gh != null);
+    setRepoWritable(Boolean(gh?.token));
+    setWriteMode(gh?.writeMode ?? "confirm");
+  }, []);
 
-const [visionEnabled, setVisionEnabled] = useState(false);
-const imageInputRef = useRef<HTMLInputElement | null>(null);
-const fileInputRef = useRef<HTMLInputElement | null>(null);
+  useEffect(() => {
+    void hydrateQaChat();
+    refreshComposerMeta();
+  }, [refreshComposerMeta]);
 
-const [apiReady, setApiReady] = useState(true);
-const [modelName, setModelName] = useState("");
-const [repoWritable, setRepoWritable] = useState(false);
-const [writeMode, setWriteMode] = useState<"confirm" | "auto">("confirm");
-const bodyRef = useRef<HTMLDivElement | null>(null);
-const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-const stickToBottomRef = useRef(true);
+  // 清理原生 tool 调用历史（防报错）：与小卷同款——移除上下文里的工具记录与原生元数据
+  const handleClearToolHistory = useCallback(() => {
+    if (snapshot.isGenerating) {
+      onNotice?.("小坊正在执行，完成后再清理。");
+      return;
+    }
+    if (!hasQaToolHistory()) {
+      onNotice?.("没有可清理的工具调用历史。");
+      return;
+    }
+    setClearToolsOpen(true);
+  }, [snapshot.isGenerating, onNotice]);
 
-const refreshComposerMeta = useCallback(() => {
-setApiReady(resolveQaApiConfig() != null);
-setModelName(resolveQaApiConfig()?.defaultModel ?? "");
-setVisionEnabled(resolveQaApiConfig()?.enableImageRecognition === true);
-const gh = loadQaGithubConfig();
-setRepoConnected(gh != null);
-setRepoWritable(Boolean(gh?.token));
-setWriteMode(gh?.writeMode ?? "confirm");
-}, []);
+  const confirmClearToolHistory = useCallback(() => {
+    setClearToolsOpen(false);
+    const result = clearQaToolHistory();
+    onNotice?.(result && result.removed + result.cleaned > 0
+      ? `已清理 ${result.removed} 条工具记录，整理 ${result.cleaned} 条消息。`
+      : "没有可清理的工具调用历史。");
+  }, [onNotice]);
 
-useEffect(() => {
-void hydrateQaChat();
-refreshComposerMeta();
-}, [refreshComposerMeta]);
+  const toggleWriteMode = useCallback(() => {
+    const gh = loadQaGithubConfig();
+    if (!gh) return;
+    const next = gh.writeMode === "auto" ? "confirm" : "auto";
+    saveQaGithubConfig({ ...gh, writeMode: next });
+    setWriteMode(next);
+  }, []);
 
-// 清理原生 tool 调用历史（防报错）：与小卷同款——移除上下文里的工具记录与原生元数据
-const handleClearToolHistory = useCallback(() => {
-if (snapshot.isGenerating) {
-onNotice?.("小坊正在执行，完成后再清理。");
-return;
-}
-if (!hasQaToolHistory()) {
-onNotice?.("没有可清理的工具调用历史。");
-return;
-}
-setClearToolsOpen(true);
-}, [snapshot.isGenerating, onNotice]);
+  const activeSession = useMemo(
+    () => snapshot.sessions.find((s) => s.id === snapshot.activeSessionId) ?? null,
+    [snapshot.sessions, snapshot.activeSessionId],
+  );
+  const messages = useMemo(() => activeSession?.messages ?? [], [activeSession]);
+  const createdContent = useMemo(() => activeSession?.createdContent ?? [], [activeSession]);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewItem, setPreviewItem] = useState<QaCreatedContent | null>(null);
+  const previewApp = useMemo(
+    () => (previewItem?.type === "app" ? getInstalledCustomApp(previewItem.refId) : null),
+    [previewItem],
+  );
 
-const confirmClearToolHistory = useCallback(() => {
-setClearToolsOpen(false);
-const result = clearQaToolHistory();
-onNotice?.(result && result.removed + result.cleaned > 0
-? 已清理 ${result.removed} 条工具记录，整理 ${result.cleaned} 条消息。
-: "没有可清理的工具调用历史。");
-}, [onNotice]);
+  // 自动滚动：用户上滚阅读时不拉回底部
+  const handleScroll = useCallback(() => {
+    const el = bodyRef.current;
+    if (!el) return;
+    stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  }, []);
 
-const toggleWriteMode = useCallback(() => {
-const gh = loadQaGithubConfig();
-if (!gh) return;
-const next = gh.writeMode === "auto" ? "confirm" : "auto";
-saveQaGithubConfig({ ...gh, writeMode: next });
-setWriteMode(next);
-}, []);
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (el && stickToBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [messages]);
 
-const activeSession = useMemo(
-() => snapshot.sessions.find((s) => s.id === snapshot.activeSessionId) ?? null,
-[snapshot.sessions, snapshot.activeSessionId],
-);
-const messages = useMemo(() => activeSession?.messages ?? [], [activeSession]);
-const createdContent = useMemo(() => activeSession?.createdContent ?? [], [activeSession]);
-const [previewOpen, setPreviewOpen] = useState(false);
-const [previewItem, setPreviewItem] = useState<QaCreatedContent | null>(null);
-const previewApp = useMemo(
-() => (previewItem?.type === "app" ? getInstalledCustomApp(previewItem.refId) : null),
-[previewItem],
-);
+  const autoGrow = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+  }, []);
 
-// 自动滚动：用户上滚阅读时不拉回底部
-const handleScroll = useCallback(() => {
-const el = bodyRef.current;
-if (!el) return;
-stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
-}, []);
+  const handleSend = useCallback(() => {
+    const text = input.trim();
+    if ((!text && pendingImages.length === 0 && pendingFiles.length === 0) || snapshot.isGenerating) return;
+    setInput("");
+    const images = pendingImages;
+    const files = pendingFiles;
+    setPendingImages([]);
+    setPendingFiles([]);
+    stickToBottomRef.current = true;
+    requestAnimationFrame(autoGrow);
+    void sendQaMessage(text, images.length ? images : undefined, files.length ? files : undefined);
+  }, [input, pendingImages, pendingFiles, snapshot.isGenerating, autoGrow]);
 
-useEffect(() => {
-const el = bodyRef.current;
-if (el && stickToBottomRef.current) {
-el.scrollTop = el.scrollHeight;
-}
-}, [messages]);
+  // 附加图片：仅识图已开启的 API 显示入口；读为 dataURL，单张限 4MB
+  const handlePickImages = useCallback((files: FileList | null, isEditMode = false) => {
+    if (!files?.length) return;
+    const setter = isEditMode ? setEditImages : setPendingImages;
+    for (const file of Array.from(files).slice(0, 6)) {
+      if (file.size > 4 * 1024 * 1024) {
+        onNotice?.(`「${file.name}」超过 4MB，已跳过。`);
+        continue;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        const url = typeof reader.result === "string" ? reader.result : "";
+        if (url) setter((current) => (current.length >= 6 ? current : [...current, url]));
+      };
+      reader.readAsDataURL(file);
+    }
+    if (imageInputRef.current) imageInputRef.current.value = "";
+  }, [onNotice]);
 
-const autoGrow = useCallback(() => {
-const el = textareaRef.current;
-if (!el) return;
-el.style.height = "auto";
-el.style.height = ${Math.min(el.scrollHeight, 120)}px;
-}, []);
+  // 附加文本文件
+  const handlePickFiles = useCallback((files: FileList | null, isEditMode = false) => {
+    if (!files?.length) return;
+    const setter = isEditMode ? setEditFiles : setPendingFiles;
+    for (const file of Array.from(files).slice(0, 6)) {
+      if (file.size > 1024 * 1024) { // 纯文本文件限 1MB
+        onNotice?.(`「${file.name}」太大（超过 1MB），请直接粘贴内容。`);
+        continue;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        const content = typeof reader.result === "string" ? reader.result : "";
+        if (content) setter((current) => {
+            if (current.length >= 6 || current.some(f => f.name === file.name)) return current;
+            return [...current, { name: file.name, content }];
+        });
+      };
+      reader.readAsText(file);
+    }
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }, [onNotice]);
 
-const handleSend = useCallback(() => {
-const text = input.trim();
-if ((!text && pendingImages.length === 0 && pendingFiles.length === 0) || snapshot.isGenerating) return;
-setInput("");
-const images = pendingImages;
-const files = pendingFiles;
-setPendingImages([]);
-setPendingFiles([]);
-stickToBottomRef.current = true;
-requestAnimationFrame(autoGrow);
-void sendQaMessage(text, images.length ? images : undefined, files.length ? files : undefined);
-}, [input, pendingImages, pendingFiles, snapshot.isGenerating, autoGrow]);
+  const handleRetry = useCallback((assistantMsgId: string) => {
+    stickToBottomRef.current = true;
+    void retryQaMessage(assistantMsgId);
+  }, []);
 
-// 附加图片：仅识图已开启的 API 显示入口；读为 dataURL，单张限 4MB
-const handlePickImages = useCallback((files: FileList | null, isEditMode = false) => {
-if (!files?.length) return;
-const setter = isEditMode ? setEditImages : setPendingImages;
-for (const file of Array.from(files).slice(0, 6)) {
-if (file.size > 4 * 1024 * 1024) {
-onNotice?.(「${file.name}」超过 4MB，已跳过。);
-continue;
-}
-const reader = new FileReader();
-reader.onload = () => {
-const url = typeof reader.result === "string" ? reader.result : "";
-if (url) setter((current) => (current.length >= 6 ? current : [...current, url]));
-};
-reader.readAsDataURL(file);
-}
-if (imageInputRef.current) imageInputRef.current.value = "";
-}, [onNotice]);
+  const handleCopyMessage = useCallback((content: string) => {
+    void navigator.clipboard?.writeText(content).then(
+      () => onNotice?.("已复制原始内容"),
+      () => onNotice?.("复制失败"),
+    );
+  }, [onNotice]);
 
-// 附加文本文件
-const handlePickFiles = useCallback((files: FileList | null, isEditMode = false) => {
-if (!files?.length) return;
-const setter = isEditMode ? setEditFiles : setPendingFiles;
-for (const file of Array.from(files).slice(0, 6)) {
-if (file.size > 1024 * 1024) { // 纯文本文件限 1MB
-onNotice?.(「${file.name}」太大（超过 1MB），请直接粘贴内容。);
-continue;
-}
-const reader = new FileReader();
-reader.onload = () => {
-const content = typeof reader.result === "string" ? reader.result : "";
-if (content) setter((current) => {
-if (current.length >= 6 || current.some(f => f.name === file.name)) return current;
-return [...current, { name: file.name, content }];
-});
-};
-reader.readAsText(file);
-}
-if (fileInputRef.current) fileInputRef.current.value = "";
-}, [onNotice]);
+  const handleEditMessage = useCallback((msg: QaMsg) => {
+    setEditingMsg(msg);
+    setEditText(msg.content);
+    setEditImages(msg.images || []);
+    setEditFiles(msg.files || []);
+  }, []);
 
-const handleRetry = useCallback((assistantMsgId: string) => {
-stickToBottomRef.current = true;
-void retryQaMessage(assistantMsgId);
-}, []);
+  const handleSaveEdit = useCallback((andResend: boolean) => {
+    if (!editingMsg || !snapshot.activeSessionId) return;
+    if (andResend) {
+        editAndResendQaMessage(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
+    } else {
+        updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
+    }
+    setEditingMsg(null);
+    onNotice?.(andResend ? "已提交修改" : "已保存消息内容");
+  }, [editingMsg, editText, editImages, editFiles, snapshot.activeSessionId, onNotice]);
 
-const handleCopyMessage = useCallback((content: string) => {
-void navigator.clipboard?.writeText(content).then(
-() => onNotice?.("已复制原始内容"),
-() => onNotice?.("复制失败"),
-);
-}, [onNotice]);
+  const streamingMsgId =
+    snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
+      ? messages[messages.length - 1].id
+      : null;
 
-const handleEditMessage = useCallback((msg: QaMsg) => {
-setEditingMsg(msg);
-setEditText(msg.content);
-setEditImages(msg.images || []);
-setEditFiles(msg.files || []);
-}, []);
-
-const handleSaveEdit = useCallback((andResend: boolean) => {
-if (!editingMsg || !snapshot.activeSessionId) return;
-if (andResend) {
-editAndResendQaMessage(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
-} else {
-updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
-}
-setEditingMsg(null);
-onNotice?.(andResend ? "已提交修改" : "已保存消息内容");
-}, [editingMsg, editText, editImages, editFiles, snapshot.activeSessionId, onNotice]);
-
-const streamingMsgId =
-snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
-? messages[messages.length - 1].id
-: null;
-
-return (
-
-<QaSessionDrawer
-sessions={snapshot.sessions}
-activeId={snapshot.activeSessionId}
-onSelect={(id) => {
-switchQaSession(id);
-setDrawerOpen(false);
-}}
-onDelete={deleteQaSession}
-onCreate={() => {
-createQaSession();
-setDrawerOpen(false);
-}}
-onOpenSettings={() => {
-setSettingsOpen(true);
-setDrawerOpen(false);
-}}
-onRenameRequest={(id, title) => {
-setRenameTarget({ id, title });
-setRenameTitle(title);
-}}
-/>
-<div className={qa-stage ${drawerOpen ? "is-pushed" : ""}}>
-
-
-
-
-
-
-
-
-工坊
-{repoConnected && 已连接仓库}
-
-
-
-
-
-<button type="button" className="qa-icon-btn" onClick={() => setDrawerOpen((v) => !v)} aria-label="对话记录">
-
-
-
-
-
-  <div className="qa-body hide-scrollbar" ref={bodyRef} onScroll={handleScroll}>
-    {messages.length === 0 ? (
-      <div className="qa-welcome">
-        <div className="qa-welcome-badge" aria-hidden>
-          <svg viewBox="0 0 24 24" width="26" height="26">
-            <path d={mdiHammerWrench} fill="currentColor" />
-          </svg>
-        </div>
-        <div className="qa-welcome-title">有什么问题？</div>
-        <div className="qa-welcome-sub">
-          我是小坊，工坊的驻场工程师。使用问题、报错排查、部署配置，都可以问我。
-          <br />
-          我还能动手：写小游戏 / APP / 剧场直接装进本机试玩；连接仓库后我会查源码答疑，填了有写权限的 PAT 还能帮你改代码。
-          <br />
-          想创作角色、世界书或美化桌面，找桌面上的小卷更合适。
-        </div>
-        {!apiReady && (
-          <div className="qa-welcome-warn">还没有可用的 API：请先到「设置 → API 设置」添加 LLM API。</div>
-        )}
-        <div className="qa-suggestions">
-          {SUGGESTIONS.map((text) => (
-            <button
-              key={text}
-              type="button"
-              className="qa-suggestion"
-              onClick={() => {
-                stickToBottomRef.current = true;
-                void sendQaMessage(text);
-              }}
-            >
-              {text}
-            </button>
-          ))}
-        </div>
-      </div>
-    ) : (
-      <div className="qa-messages">
-        {messages.map((msg) => (
-          <QaMessageItem key={msg.id} msg={msg} isStreaming={msg.id === streamingMsgId} onRetry={handleRetry} onViewImage={setViewerImage} onCopy={handleCopyMessage} onEdit={handleEditMessage} />
-        ))}
-      </div>
-    )}
-  </div>
-
-  <footer className="qa-composer-wrap">
-    <div className={`qa-composer ${snapshot.isGenerating ? "is-generating" : ""}`}>
-      {(pendingImages.length > 0 || pendingFiles.length > 0) && (
-        <div className="qa-attach-strip">
-          {pendingImages.map((url, i) => (
-            <div key={`img-${i}`} className="qa-attach-thumb">
-              <button type="button" className="qa-attach-view" onClick={() => setViewerImage(url)} aria-label="查看图片">
-                <img src={url} alt="" />
-              </button>
-              <button
-                type="button"
-                className="qa-attach-remove"
-                onClick={() => setPendingImages((current) => current.filter((_, idx) => idx !== i))}
-                aria-label="移除图片"
-              >
-                <X size={11} strokeWidth={2.4} />
-              </button>
-            </div>
-          ))}
-          {pendingFiles.map((file, i) => (
-            <div key={`file-${i}`} className="qa-attach-thumb" style={{ background: "rgba(128,128,128,0.2)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px" }}>
-              <FileText size={16} style={{ minWidth: "16px", marginRight: "4px" }}/>
-              <span style={{ fontSize: "11px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{file.name}</span>
-              <button
-                type="button"
-                className="qa-attach-remove"
-                onClick={() => setPendingFiles((current) => current.filter((_, idx) => idx !== i))}
-                aria-label="移除附件"
-              >
-                <X size={11} strokeWidth={2.4} />
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
-      <textarea
-        ref={textareaRef}
-        className="qa-composer-input hide-scrollbar"
-        placeholder="输入你的问题…"
-        rows={1}
-        value={input}
-        onChange={(e) => {
-          setInput(e.target.value);
-          autoGrow();
+  return (
+    <div className="qa-app-shell">
+      <QaSessionDrawer
+        sessions={snapshot.sessions}
+        activeId={snapshot.activeSessionId}
+        onSelect={(id) => {
+          switchQaSession(id);
+          setDrawerOpen(false);
+        }}
+        onDelete={deleteQaSession}
+        onCreate={() => {
+          createQaSession();
+          setDrawerOpen(false);
+        }}
+        onOpenSettings={() => {
+          setSettingsOpen(true);
+          setDrawerOpen(false);
+        }}
+        onRenameRequest={(id, title) => {
+          setRenameTarget({ id, title });
+          setRenameTitle(title);
         }}
       />
-      <div className="qa-composer-toolbar">
-        <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
-            style={{ display: "none" }}
-            onChange={(e) => handlePickFiles(e.target.files)}
-        />
-        <button
-            type="button"
-            className="qa-circle-btn qa-attach-btn"
-            onClick={() => fileInputRef.current?.click()}
-            aria-label="添加附件"
-        >
-            <Paperclip size={17} strokeWidth={2.2} />
-        </button>
-
-        {visionEnabled && (
-          <>
-            <input
-              ref={imageInputRef}
-              type="file"
-              accept="image/*"
-              multiple
-              style={{ display: "none" }}
-              onChange={(e) => handlePickImages(e.target.files)}
-            />
-            <button
-              type="button"
-              className="qa-circle-btn qa-attach-btn"
-              onClick={() => imageInputRef.current?.click()}
-              aria-label="发送图片"
-            >
-              <Plus size={17} strokeWidth={2.2} />
-            </button>
-          </>
-        )}
-        {modelName && <span className="qa-model-pill">{modelName}</span>}
-
-        {repoWritable && (
-          <button type="button" className="qa-mode-pill" onClick={toggleWriteMode}>
-            {writeMode === "auto" ? "全自动" : "确认后提交"}
+      <div className={`qa-stage ${drawerOpen ? "is-pushed" : ""}`}>
+      <div className="qa-ambient" aria-hidden />
+      <header className="qa-header">
+        <div className="qa-header-left">
+          <button type="button" className="qa-icon-btn" onClick={onClose} aria-label="返回">
+            <ChevronLeft size={22} strokeWidth={1.75} />
           </button>
-        )}
-
-        <div className="qa-composer-spacer" />
-
-        {createdContent.length > 0 && (
+        </div>
+        <div className="qa-header-center">
+          <span className="qa-header-title">工坊</span>
+          {repoConnected && <span className="qa-header-sub">已连接仓库</span>}
+        </div>
+        <div className="qa-header-right">
           <button
             type="button"
-            className="qa-circle-btn qa-preview-btn"
-            onClick={() => setPreviewOpen(true)}
-            aria-label="预览本轮创建的内容"
+            className="qa-icon-btn"
+            onClick={handleClearToolHistory}
+            aria-label="清理原生tool调用历史（防报错）"
+            title="清理原生tool调用历史——防报错"
           >
-            <Play size={16} />
+            <BrushCleaning size={17} strokeWidth={1.75} />
           </button>
-        )}
+          <button type="button" className="qa-icon-btn" onClick={() => setDrawerOpen((v) => !v)} aria-label="对话记录">
+            <Menu size={18} strokeWidth={1.75} />
+          </button>
+        </div>
+      </header>
 
+      <div className="qa-body hide-scrollbar" ref={bodyRef} onScroll={handleScroll}>
+        {messages.length === 0 ? (
+          <div className="qa-welcome">
+            <div className="qa-welcome-badge" aria-hidden>
+              <svg viewBox="0 0 24 24" width="26" height="26">
+                <path d={mdiHammerWrench} fill="currentColor" />
+              </svg>
+            </div>
+            <div className="qa-welcome-title">有什么问题？</div>
+            <div className="qa-welcome-sub">
+              我是小坊，工坊的驻场工程师。使用问题、报错排查、部署配置，都可以问我。
+              <br />
+              我还能动手：写小游戏 / APP / 剧场直接装进本机试玩；连接仓库后我会查源码答疑，填了有写权限的 PAT 还能帮你改代码。
+              <br />
+              想创作角色、世界书或美化桌面，找桌面上的小卷更合适。
+            </div>
+            {!apiReady && (
+              <div className="qa-welcome-warn">还没有可用的 API：请先到「设置 → API 设置」添加 LLM API。</div>
+            )}
+            <div className="qa-suggestions">
+              {SUGGESTIONS.map((text) => (
+                <button
+                  key={text}
+                  type="button"
+                  className="qa-suggestion"
+                  onClick={() => {
+                    stickToBottomRef.current = true;
+                    void sendQaMessage(text);
+                  }}
+                >
+                  {text}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="qa-messages">
+            {messages.map((msg) => (
+              <QaMessageItem key={msg.id} msg={msg} isStreaming={msg.id === streamingMsgId} onRetry={handleRetry} onViewImage={setViewerImage} onCopy={handleCopyMessage} onEdit={handleEditMessage} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <footer className="qa-composer-wrap">
+        <div className={`qa-composer ${snapshot.isGenerating ? "is-generating" : ""}`}>
+          {(pendingImages.length > 0 || pendingFiles.length > 0) && (
+            <div className="qa-attach-strip">
+              {pendingImages.map((url, i) => (
+                <div key={`img-${i}`} className="qa-attach-thumb">
+                  <button type="button" className="qa-attach-view" onClick={() => setViewerImage(url)} aria-label="查看图片">
+                    <img src={url} alt="" />
+                  </button>
+                  <button
+                    type="button"
+                    className="qa-attach-remove"
+                    onClick={() => setPendingImages((current) => current.filter((_, idx) => idx !== i))}
+                    aria-label="移除图片"
+                  >
+                    <X size={11} strokeWidth={2.4} />
+                  </button>
+                </div>
+              ))}
+              {pendingFiles.map((file, i) => (
+                <div key={`file-${i}`} className="qa-attach-thumb" style={{ background: "rgba(128,128,128,0.2)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px" }}>
+                  <FileText size={16} style={{ minWidth: "16px", marginRight: "4px" }}/>
+                  <span style={{ fontSize: "11px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{file.name}</span>
+                  <button
+                    type="button"
+                    className="qa-attach-remove"
+                    onClick={() => setPendingFiles((current) => current.filter((_, idx) => idx !== i))}
+                    aria-label="移除附件"
+                  >
+                    <X size={11} strokeWidth={2.4} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+          <textarea
+            ref={textareaRef}
+            className="qa-composer-input hide-scrollbar"
+            placeholder="输入你的问题…"
+            rows={1}
+            value={input}
+            onChange={(e) => {
+              setInput(e.target.value);
+              autoGrow();
+            }}
+          />
+          <div className="qa-composer-toolbar">
+            <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
+                style={{ display: "none" }}
+                onChange={(e) => handlePickFiles(e.target.files)}
+            />
+            <button
+                type="button"
+                className="qa-circle-btn qa-attach-btn"
+                onClick={() => fileInputRef.current?.click()}
+                aria-label="添加附件"
+            >
+                <Paperclip size={17} strokeWidth={2.2} />
+            </button>
+
+            {visionEnabled && (
+              <>
+                <input
+                  ref={imageInputRef}
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  style={{ display: "none" }}
+                  onChange={(e) => handlePickImages(e.target.files)}
+                />
+                <button
+                  type="button"
+                  className="qa-circle-btn qa-attach-btn"
+                  onClick={() => imageInputRef.current?.click()}
+                  aria-label="发送图片"
+                >
+                  <Plus size={17} strokeWidth={2.2} />
+                </button>
+              </>
+            )}
+            {modelName && <span className="qa-model-pill">{modelName}</span>}
+
+            {repoWritable && (
+              <button type="button" className="qa-mode-pill" onClick={toggleWriteMode}>
+                {writeMode === "auto" ? "全自动" : "确认后提交"}
+              </button>
+            )}
+
+            <div className="qa-composer-spacer" />
+
+            {createdContent.length > 0 && (
+              <button
+                type="button"
+                className="qa-circle-btn qa-preview-btn"
+                onClick={() => setPreviewOpen(true)}
+                aria-label="预览本轮创建的内容"
+              >
+                <Play size={16} />
+              </button>
+            )}
+
+            <button
+              type="button"
+              className={`qa-circle-btn qa-github-btn ${repoConnected ? "is-active" : ""}`}
+              onClick={() => setRepoSheetOpen(true)}
+              aria-label="连接仓库"
+            >
+              <Github size={16} strokeWidth={1.75} />
+            </button>
+
+            {snapshot.isGenerating ? (
+              <button type="button" className="qa-circle-btn qa-send-btn is-stop" onClick={stopQaGeneration} aria-label="停止生成">
+                <Square size={14} fill="currentColor" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="qa-circle-btn qa-send-btn"
+                onClick={handleSend}
+                disabled={!input.trim() && pendingImages.length === 0 && pendingFiles.length === 0}
+                aria-label="发送"
+              >
+                <ArrowUp size={20} strokeWidth={2.4} />
+              </button>
+            )}
+          </div>
+          <div
+            className={`qa-context-meter ${snapshot.isCompacting ? "is-compacting" : ""}`}
+            title="上下文用量：满 100% 时自动压缩成摘要并从头累计"
+          >
+            <div className="qa-context-meter-track" aria-hidden>
+              <i style={{ width: `${Math.min(100, Math.round(snapshot.contextUsage * 100))}%` }} />
+            </div>
+            <span className="qa-context-meter-label">
+              {snapshot.isCompacting ? "压缩中" : `${Math.min(999, Math.round(snapshot.contextUsage * 100))}%`}
+            </span>
+          </div>
+        </div>
+      </footer>
+
+      {drawerOpen && (
         <button
           type="button"
-          className={`qa-circle-btn qa-github-btn ${repoConnected ? "is-active" : ""}`}
-          onClick={() => setRepoSheetOpen(true)}
-          aria-label="连接仓库"
-        >
-          <Github size={16} strokeWidth={1.75} />
-        </button>
-
-        {snapshot.isGenerating ? (
-          <button type="button" className="qa-circle-btn qa-send-btn is-stop" onClick={stopQaGeneration} aria-label="停止生成">
-            <Square size={14} fill="currentColor" />
-          </button>
-        ) : (
-          <button
-            type="button"
-            className="qa-circle-btn qa-send-btn"
-            onClick={handleSend}
-            disabled={!input.trim() && pendingImages.length === 0 && pendingFiles.length === 0}
-            aria-label="发送"
-          >
-            <ArrowUp size={20} strokeWidth={2.4} />
-          </button>
-        )}
-      </div>
-      <div
-        className={`qa-context-meter ${snapshot.isCompacting ? "is-compacting" : ""}`}
-        title="上下文用量：满 100% 时自动压缩成摘要并从头累计"
-      >
-        <div className="qa-context-meter-track" aria-hidden>
-          <i style={{ width: `${Math.min(100, Math.round(snapshot.contextUsage * 100))}%` }} />
-        </div>
-        <span className="qa-context-meter-label">
-          {snapshot.isCompacting ? "压缩中" : `${Math.min(999, Math.round(snapshot.contextUsage * 100))}%`}
-        </span>
-      </div>
-    </div>
-  </footer>
-
-  {drawerOpen && (
-    <button
-      type="button"
-      className="qa-stage-scrim"
-      aria-label="关闭对话列表"
-      onClick={() => setDrawerOpen(false)}
-    />
-  )}
-  </div>
-
-  {renameTarget && (
-    <div className="qa-rename-backdrop" role="presentation" onClick={() => setRenameTarget(null)}>
-      <form
-        className="qa-rename-dialog"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="qa-rename-dialog-title"
-        onClick={(e) => e.stopPropagation()}
-        onSubmit={(e) => {
-          e.preventDefault();
-          const title = renameTitle.trim();
-          if (!title) return;
-          renameQaSession(renameTarget.id, title);
-          setRenameTarget(null);
-        }}
-      >
-        <div id="qa-rename-dialog-title" className="qa-rename-title">重命名对话</div>
-        <input
-          className="qa-rename-input"
-          autoFocus
-          value={renameTitle}
-          maxLength={80}
-          aria-label="新对话名称"
-          onChange={(e) => setRenameTitle(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Escape") setRenameTarget(null); }}
+          className="qa-stage-scrim"
+          aria-label="关闭对话列表"
+          onClick={() => setDrawerOpen(false)}
         />
-        <div className="qa-rename-actions">
-          <button type="button" className="qa-rename-cancel" onClick={() => setRenameTarget(null)}>取消</button>
-          <button type="submit" className="qa-drawer-new qa-rename-confirm" disabled={!renameTitle.trim()}>确认</button>
-        </div>
-      </form>
-    </div>
-  )}
-
-  {clearToolsOpen && (
-    <div className="qa-devnotice-backdrop" onClick={() => setClearToolsOpen(false)}>
-      <div className="qa-devnotice" role="alertdialog" aria-label="清理工具历史确认" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-devnotice-title">清理工具调用历史？</div>
-        <div className="qa-devnotice-text">
-          将移除本会话上下文中的工具调用与工具结果记录，用于修复原生工具协议的报错。普通对话内容不会删除，之前的工具结论仍保留在小坊的回复文字里。
-        </div>
-        <div className="qa-devnotice-actions is-row">
-          <button type="button" className="qa-devnotice-btn" onClick={() => setClearToolsOpen(false)}>
-            取消
-          </button>
-          <button type="button" className="qa-devnotice-btn is-primary" onClick={confirmClearToolHistory}>
-            清理
-          </button>
-        </div>
+      )}
       </div>
-    </div>
-  )}
 
-  {viewerImage && (
-    <div className="qa-image-viewer" role="presentation" onClick={() => setViewerImage(null)}>
-      <img src={viewerImage} alt="" />
-      <button type="button" className="qa-image-viewer-close" aria-label="关闭" onClick={() => setViewerImage(null)}>
-        <X size={20} />
-      </button>
-    </div>
-  )}
-
-  {editingMsg && (
-    <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
-      <div className="qa-edit-dialog" role="dialog" aria-label="修改消息" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-edit-head">
-          <span className="qa-edit-title">修改消息</span>
-          <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
-            <X size={16} />
-          </button>
-        </div>
-        
-        <div style={{ padding: "0 16px 8px 16px" }}>
-            <textarea
-              className="qa-edit-textarea"
-              value={editText}
-              onChange={(e) => setEditText(e.target.value)}
-              spellCheck={false}
-              autoFocus
-              style={{ minHeight: "120px", marginBottom: "8px" }}
-            />
-            
-            <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "8px" }}>
-                {editImages.map((url, i) => (
-                    <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "4px", overflow: "hidden", border: "1px solid rgba(255,255,255,0.1)" }}>
-                        <img src={url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
-                        <button
-                            type="button"
-                            style={{ position: "absolute", top: 0, right: 0, background: "rgba(0,0,0,0.5)", color: "white", border: "none", borderRadius: "0 0 0 4px", cursor: "pointer", padding: "2px" }}
-                            onClick={() => setEditImages(current => current.filter((_, idx) => idx !== i))}
-                        >
-                            <X size={10} />
-                        </button>
-                    </div>
-                ))}
-                {editFiles.map((f, i) => (
-                     <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "rgba(255,255,255,0.1)", padding: "4px 20px 4px 8px", borderRadius: "4px", fontSize: "11px", border: "1px solid rgba(255,255,255,0.2)" }}>
-                        <FileText size={12} style={{ marginRight: "4px" }} />
-                        <span style={{ maxWidth: "80px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
-                        <button
-                            type="button"
-                            style={{ position: "absolute", right: "2px", background: "transparent", color: "inherit", border: "none", cursor: "pointer", display: "flex", alignItems: "center" }}
-                            onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}
-                        >
-                            <X size={12} />
-                        </button>
-                    </div>
-                ))}
-            </div>
-
-            <div style={{ display: "flex", gap: "8px" }}>
-                <button type="button" className="qa-devnotice-btn" onClick={() => fileInputRef.current?.click()} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
-                    <Paperclip size={12} /> 添加附件
-                </button>
-                <button type="button" className="qa-devnotice-btn" onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); }} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
-                    <Plus size={12} /> 添加图片
-                </button>
-                 <input
-                    ref={imageInputRef}
-                    type="file"
-                    accept="image/*"
-                    multiple
-                    style={{ display: "none" }}
-                    onChange={(e) => {
-                        const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
-                        handlePickImages(e.target.files, isEditMode);
-                        e.target.removeAttribute('data-edit-mode');
-                    }}
-                />
-                <input
-                    ref={fileInputRef}
-                    type="file"
-                    multiple
-                    accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
-                    style={{ display: "none" }}
-                    onChange={(e) => handlePickFiles(e.target.files, true)}
-                />
-            </div>
-        </div>
-        
-        <div className="qa-edit-actions">
-          <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
-            取消
-          </button>
-          <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
-            仅保存
-          </button>
-          <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
-            保存并发送
-          </button>
-        </div>
-      </div>
-    </div>
-  )}
-
-  {settingsOpen && (
-    <QaSettingsSheet onClose={() => setSettingsOpen(false)} onNotice={onNotice} />
-  )}
-
-  {repoSheetOpen && (
-    <QaRepoSheet onClose={() => setRepoSheetOpen(false)} onSaved={refreshComposerMeta} />
-  )}
-
-  {previewOpen && !previewItem && (
-    <div className="qa-sheet-backdrop" onClick={() => setPreviewOpen(false)}>
-      <div className="qa-sheet qa-preview-sheet" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-sheet-head">
-          <span className="qa-sheet-title">
-            <Play size={16} /> 预览本轮创建
-          </span>
-          <button type="button" className="qa-icon-btn" onClick={() => setPreviewOpen(false)} aria-label="关闭">
-            <X size={16} />
-          </button>
-        </div>
-        <div className="qa-sheet-body">
-          <p className="qa-sheet-note">本次对话里创建/更新的内容，点开直接测试，返回后回到聊天。</p>
-          {createdContent.map((item) => (
-            <button
-              key={`${item.type}-${item.refId}`}
-              type="button"
-              className="qa-preview-item"
-              onClick={() => setPreviewItem(item)}
-            >
-              {item.type === "app" ? <AppWindow size={17} /> : item.type === "game" ? <Gamepad2 size={17} /> : <Drama size={17} />}
-              <span className="qa-preview-item-title">{item.title}</span>
-              <span className="qa-preview-item-type">
-                {item.type === "app" ? "应用" : item.type === "game" ? "游戏" : "剧场"}
-              </span>
-              <ChevronRight size={15} />
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
-  )}
-
-  {previewItem && (
-    <div className="qa-preview-runtime">
-      {previewItem.type === "app" ? (
-        previewApp ? (
-          <CustomAppForegroundBoundary
-            key={previewApp.id}
-            appName={previewApp.name}
-            appId={previewApp.id}
-            appVersion={previewApp.version}
-            manifestId={previewApp.manifest?.id}
-            closeLabel="返回"
-            onClose={() => setPreviewItem(null)}
+      {renameTarget && (
+        <div className="qa-rename-backdrop" role="presentation" onClick={() => setRenameTarget(null)}>
+          <form
+            className="qa-rename-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="qa-rename-dialog-title"
+            onClick={(e) => e.stopPropagation()}
+            onSubmit={(e) => {
+              e.preventDefault();
+              const title = renameTitle.trim();
+              if (!title) return;
+              renameQaSession(renameTarget.id, title);
+              setRenameTarget(null);
+            }}
           >
-            <CustomAppRunner app={previewApp} onClose={() => setPreviewItem(null)} />
-          </CustomAppForegroundBoundary>
-        ) : (
-          <div className="qa-preview-missing">
-            <p>这个应用已被卸载或找不到了。</p>
-            <button type="button" className="qa-sheet-btn is-primary" onClick={() => setPreviewItem(null)}>
-              返回
-            </button>
+            <div id="qa-rename-dialog-title" className="qa-rename-title">重命名对话</div>
+            <input
+              className="qa-rename-input"
+              autoFocus
+              value={renameTitle}
+              maxLength={80}
+              aria-label="新对话名称"
+              onChange={(e) => setRenameTitle(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Escape") setRenameTarget(null); }}
+            />
+            <div className="qa-rename-actions">
+              <button type="button" className="qa-rename-cancel" onClick={() => setRenameTarget(null)}>取消</button>
+              <button type="submit" className="qa-drawer-new qa-rename-confirm" disabled={!renameTitle.trim()}>确认</button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {clearToolsOpen && (
+        <div className="qa-devnotice-backdrop" onClick={() => setClearToolsOpen(false)}>
+          <div className="qa-devnotice" role="alertdialog" aria-label="清理工具历史确认" onClick={(e) => e.stopPropagation()}>
+            <div className="qa-devnotice-title">清理工具调用历史？</div>
+            <div className="qa-devnotice-text">
+              将移除本会话上下文中的工具调用与工具结果记录，用于修复原生工具协议的报错。普通对话内容不会删除，之前的工具结论仍保留在小坊的回复文字里。
+            </div>
+            <div className="qa-devnotice-actions is-row">
+              <button type="button" className="qa-devnotice-btn" onClick={() => setClearToolsOpen(false)}>
+                取消
+              </button>
+              <button type="button" className="qa-devnotice-btn is-primary" onClick={confirmClearToolHistory}>
+                清理
+              </button>
+            </div>
           </div>
-        )
-      ) : previewItem.type === "game" ? (
-        <GameHubApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
-      ) : (
-        <BlackMarketApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
+        </div>
+      )}
+
+      {viewerImage && (
+        <div className="qa-image-viewer" role="presentation" onClick={() => setViewerImage(null)}>
+          <img src={viewerImage} alt="" />
+          <button type="button" className="qa-image-viewer-close" aria-label="关闭" onClick={() => setViewerImage(null)}>
+            <X size={20} />
+          </button>
+        </div>
+      )}
+
+      {editingMsg && (
+        <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
+          <div className="qa-edit-dialog" role="dialog" aria-label="修改消息" onClick={(e) => e.stopPropagation()}>
+            <div className="qa-edit-head">
+              <span className="qa-edit-title">修改消息</span>
+              <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
+                <X size={16} />
+              </button>
+            </div>
+            
+            <div style={{ padding: "0 16px 8px 16px" }}>
+                <textarea
+                  className="qa-edit-textarea"
+                  value={editText}
+                  onChange={(e) => setEditText(e.target.value)}
+                  spellCheck={false}
+                  autoFocus
+                  style={{ minHeight: "120px", marginBottom: "8px" }}
+                />
+                
+                <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "8px" }}>
+                    {editImages.map((url, i) => (
+                        <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "4px", overflow: "hidden", border: "1px solid rgba(255,255,255,0.1)" }}>
+                            <img src={url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+                            <button
+                                type="button"
+                                style={{ position: "absolute", top: 0, right: 0, background: "rgba(0,0,0,0.5)", color: "white", border: "none", borderRadius: "0 0 0 4px", cursor: "pointer", padding: "2px" }}
+                                onClick={() => setEditImages(current => current.filter((_, idx) => idx !== i))}
+                            >
+                                <X size={10} />
+                            </button>
+                        </div>
+                    ))}
+                    {editFiles.map((f, i) => (
+                         <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "rgba(255,255,255,0.1)", padding: "4px 20px 4px 8px", borderRadius: "4px", fontSize: "11px", border: "1px solid rgba(255,255,255,0.2)" }}>
+                            <FileText size={12} style={{ marginRight: "4px" }} />
+                            <span style={{ maxWidth: "80px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
+                            <button
+                                type="button"
+                                style={{ position: "absolute", right: "2px", background: "transparent", color: "inherit", border: "none", cursor: "pointer", display: "flex", alignItems: "center" }}
+                                onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}
+                            >
+                                <X size={12} />
+                            </button>
+                        </div>
+                    ))}
+                </div>
+
+                <div style={{ display: "flex", gap: "8px" }}>
+                    <button type="button" className="qa-devnotice-btn" onClick={() => fileInputRef.current?.click()} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
+                        <Paperclip size={12} /> 添加附件
+                    </button>
+                    <button type="button" className="qa-devnotice-btn" onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); }} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
+                        <Plus size={12} /> 添加图片
+                    </button>
+                     <input
+                        ref={imageInputRef}
+                        type="file"
+                        accept="image/*"
+                        multiple
+                        style={{ display: "none" }}
+                        onChange={(e) => {
+                            const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
+                            handlePickImages(e.target.files, isEditMode);
+                            e.target.removeAttribute('data-edit-mode');
+                        }}
+                    />
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
+                        style={{ display: "none" }}
+                        onChange={(e) => handlePickFiles(e.target.files, true)}
+                    />
+                </div>
+            </div>
+            
+            <div className="qa-edit-actions">
+              <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
+                取消
+              </button>
+              <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
+                仅保存
+              </button>
+              <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
+                保存并发送
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {settingsOpen && (
+        <QaSettingsSheet onClose={() => setSettingsOpen(false)} onNotice={onNotice} />
+      )}
+
+      {repoSheetOpen && (
+        <QaRepoSheet onClose={() => setRepoSheetOpen(false)} onSaved={refreshComposerMeta} />
+      )}
+
+      {previewOpen && !previewItem && (
+        <div className="qa-sheet-backdrop" onClick={() => setPreviewOpen(false)}>
+          <div className="qa-sheet qa-preview-sheet" onClick={(e) => e.stopPropagation()}>
+            <div className="qa-sheet-head">
+              <span className="qa-sheet-title">
+                <Play size={16} /> 预览本轮创建
+              </span>
+              <button type="button" className="qa-icon-btn" onClick={() => setPreviewOpen(false)} aria-label="关闭">
+                <X size={16} />
+              </button>
+            </div>
+            <div className="qa-sheet-body">
+              <p className="qa-sheet-note">本次对话里创建/更新的内容，点开直接测试，返回后回到聊天。</p>
+              {createdContent.map((item) => (
+                <button
+                  key={`${item.type}-${item.refId}`}
+                  type="button"
+                  className="qa-preview-item"
+                  onClick={() => setPreviewItem(item)}
+                >
+                  {item.type === "app" ? <AppWindow size={17} /> : item.type === "game" ? <Gamepad2 size={17} /> : <Drama size={17} />}
+                  <span className="qa-preview-item-title">{item.title}</span>
+                  <span className="qa-preview-item-type">
+                    {item.type === "app" ? "应用" : item.type === "game" ? "游戏" : "剧场"}
+                  </span>
+                  <ChevronRight size={15} />
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {previewItem && (
+        <div className="qa-preview-runtime">
+          {previewItem.type === "app" ? (
+            previewApp ? (
+              <CustomAppForegroundBoundary
+                key={previewApp.id}
+                appName={previewApp.name}
+                appId={previewApp.id}
+                appVersion={previewApp.version}
+                manifestId={previewApp.manifest?.id}
+                closeLabel="返回"
+                onClose={() => setPreviewItem(null)}
+              >
+                <CustomAppRunner app={previewApp} onClose={() => setPreviewItem(null)} />
+              </CustomAppForegroundBoundary>
+            ) : (
+              <div className="qa-preview-missing">
+                <p>这个应用已被卸载或找不到了。</p>
+                <button type="button" className="qa-sheet-btn is-primary" onClick={() => setPreviewItem(null)}>
+                  返回
+                </button>
+              </div>
+            )
+          ) : previewItem.type === "game" ? (
+            <GameHubApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
+          ) : (
+            <BlackMarketApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
+          )}
+        </div>
       )}
     </div>
-  )}
-</div>
-
-
-);
+  );
 }
+```eof

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -1,3 +1,4 @@
+
 "use client";
 
 import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
@@ -15,1477 +16,1479 @@ import { BlackMarketApp } from "@/components/shopping/black-market-app";
 import { getInstalledCustomApp } from "@/lib/custom-app-storage";
 import type { QaCreatedContent } from "@/lib/qa-agent-tools";
 import {
-applyQaCommit,
-cancelQaCommit,
-clearQaToolHistory,
-createQaSession,
-deleteQaSession,
-getQaActiveContextChars,
-getQaChatSnapshot,
-getQaContextBudgetChars,
-hasQaToolHistory,
-hydrateQaChat,
-QA_CONTEXT_BUDGET_MAX,
-QA_CONTEXT_BUDGET_MIN,
-QA_DEFAULT_CONTEXT_BUDGET_CHARS,
-setQaContextBudgetChars,
-retryQaMessage,
-renameQaSession,
-revertQaAppliedCommit,
-sendQaMessage,
-stopQaGeneration,
-subscribeQaChat,
-switchQaSession,
-toggleQaSessionPin,
-updateQaMessageContent,
-editAndResendQaMessage,
-type QaMsg,
-type QaSession,
-type QaToolStatus,
+  applyQaCommit,
+  cancelQaCommit,
+  clearQaToolHistory,
+  createQaSession,
+  deleteQaSession,
+  getQaActiveContextChars,
+  getQaChatSnapshot,
+  getQaContextBudgetChars,
+  hasQaToolHistory,
+  hydrateQaChat,
+  QA_CONTEXT_BUDGET_MAX,
+  QA_CONTEXT_BUDGET_MIN,
+  QA_DEFAULT_CONTEXT_BUDGET_CHARS,
+  setQaContextBudgetChars,
+  retryQaMessage,
+  renameQaSession,
+  revertQaAppliedCommit,
+  sendQaMessage,
+  stopQaGeneration,
+  subscribeQaChat,
+  switchQaSession,
+  toggleQaSessionPin,
+  updateQaMessageContent,
+  editAndResendQaMessage,
+  type QaMsg,
+  type QaSession,
+  type QaToolStatus,
 } from "@/lib/qa-chat-store";
 import {
-getQaPageChars,
-setQaPageChars,
-QA_DEFAULT_PAGE_CHARS,
-QA_PAGE_CHARS_MIN,
-QA_PAGE_CHARS_MAX,
-getQaMaxRounds,
-setQaMaxRounds,
-QA_DEFAULT_MAX_ROUNDS,
-QA_MAX_ROUNDS_MIN,
-QA_MAX_ROUNDS_MAX,
-getQaMaxOutputTokens,
-setQaMaxOutputTokens,
-QA_DEFAULT_MAX_OUTPUT_TOKENS,
-QA_MAX_OUTPUT_TOKENS_MIN,
-QA_MAX_OUTPUT_TOKENS_MAX,
+  getQaPageChars,
+  setQaPageChars,
+  QA_DEFAULT_PAGE_CHARS,
+  QA_PAGE_CHARS_MIN,
+  QA_PAGE_CHARS_MAX,
+  getQaMaxRounds,
+  setQaMaxRounds,
+  QA_DEFAULT_MAX_ROUNDS,
+  QA_MAX_ROUNDS_MIN,
+  QA_MAX_ROUNDS_MAX,
+  getQaMaxOutputTokens,
+  setQaMaxOutputTokens,
+  QA_DEFAULT_MAX_OUTPUT_TOKENS,
+  QA_MAX_OUTPUT_TOKENS_MIN,
+  QA_MAX_OUTPUT_TOKENS_MAX,
 } from "@/lib/qa-prefs";
 import { resolveQaApiConfig } from "@/lib/qa-agent-engine";
 import {
-loadQaGithubConfig,
-saveQaGithubConfig,
-clearQaGithubConfig,
-validateQaGithubConfig,
-type QaGithubConfig,
-type QaGithubValidation,
+  loadQaGithubConfig,
+  saveQaGithubConfig,
+  clearQaGithubConfig,
+  validateQaGithubConfig,
+  type QaGithubConfig,
+  type QaGithubValidation,
 } from "@/lib/qa-github";
 import "@/lib/qa-error-log";
 
 type PhoneQaAppProps = {
-onClose: () => void;
-onNotice?: (msg: string) => void;
+  onClose: () => void;
+  onNotice?: (msg: string) => void;
 };
 
 const SUGGESTIONS = [
-"怎么添加我的 API？",
-"聊天没有回复怎么排查？",
-"怎么部署到 Netlify / Vercel？",
-"数据存在哪里，怎么备份？",
-"帮我写个小游戏装到本机",
+  "怎么添加我的 API？",
+  "聊天没有回复怎么排查？",
+  "怎么部署到 Netlify / Vercel？",
+  "数据存在哪里，怎么备份？",
+  "帮我写个小游戏装到本机",
 ];
 
 function formatRelativeTime(ts: number): string {
-const diff = Date.now() - ts;
-if (diff < 60_000) return "刚刚";
-if (diff < 3_600_000) return ${Math.floor(diff / 60_000)} 分钟前;
-if (diff < 86_400_000) return ${Math.floor(diff / 3_600_000)} 小时前;
-return ${Math.floor(diff / 86_400_000)} 天前;
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return "刚刚";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟前`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前`;
+  return `${Math.floor(diff / 86_400_000)} 天前`;
 }
 
 // ── 代码块（语言标签 + 一键复制）─────────────────────
 
 function QaCodeBlock({ className, children }: { className?: string; children?: React.ReactNode }) {
-const [copied, setCopied] = useState(false);
-const language = /language-(\w+)/.exec(className || "")?.[1] ?? "";
-const code = String(children ?? "").replace(/\n$/, "");
+  const [copied, setCopied] = useState(false);
+  const language = /language-(\w+)/.exec(className || "")?.[1] ?? "";
+  const code = String(children ?? "").replace(/\n$/, "");
 
-const handleCopy = useCallback(() => {
-navigator.clipboard
-?.writeText(code)
-.then(() => {
-setCopied(true);
-setTimeout(() => setCopied(false), 1500);
-})
-.catch(() => {});
-}, [code]);
+  const handleCopy = useCallback(() => {
+    navigator.clipboard
+      ?.writeText(code)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {});
+  }, [code]);
 
-return (
-
-
-{language || "code"}
-
-{copied ?  : }
-
-
-
-{code}
-
-
-);
+  return (
+    <div className="qa-codeblock">
+      <div className="qa-codeblock-head">
+        <span className="qa-codeblock-lang">{language || "code"}</span>
+        <button type="button" className="qa-codeblock-copy" onClick={handleCopy} aria-label="复制代码">
+          {copied ? <Check size={13} /> : <Copy size={13} />}
+        </button>
+      </div>
+      <pre>
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
 }
 
 const QA_MARKDOWN_COMPONENTS = {
-pre({ children }: { children?: React.ReactNode }) {
-return <>{children}</>;
-},
-code(props: { className?: string; children?: React.ReactNode }) {
-const { className, children } = props;
-const isBlock = /language-/.test(className || "") || String(children ?? "").includes("\n");
-if (isBlock) return {children};
-return {children};
-},
-a({ href, children }: { href?: string; children?: React.ReactNode }) {
-return (
-
-{children}
-
-);
-},
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+  pre({ children }: { children?: React.ReactNode }) {
+    return <>{children}</>;
+  },
+  code(props: { className?: string; children?: React.ReactNode }) {
+    const { className, children } = props;
+    const isBlock = /language-/.test(className || "") || String(children ?? "").includes("\n");
+    if (isBlock) return <QaCodeBlock className={className}>{children}</QaCodeBlock>;
+    return <code className="qa-inline-code">{children}</code>;
+  },
+  a({ href, children }: { href?: string; children?: React.ReactNode }) {
+    return (
+      <a href={href} target="_blank" rel="noreferrer noopener">
+        {children}
+      </a>
+    );
+  },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any;
 
 // ── 提交提案卡片 ─────────────────────────────────────
 
 function QaCommitCard({ msg }: { msg: QaMsg }) {
-const pending = msg.pendingCommit;
-const [busy, setBusy] = useState(false);
-if (!pending) return null;
-const { proposal, status, result, error } = pending;
-const files = proposal.files;
+  const pending = msg.pendingCommit;
+  const [busy, setBusy] = useState(false);
+  if (!pending) return null;
+  const { proposal, status, result, error } = pending;
+  const files = proposal.files;
 
-const apply = async () => {
-setBusy(true);
-await applyQaCommit(msg.id);
-setBusy(false);
-};
-const revert = async () => {
-setBusy(true);
-await revertQaAppliedCommit(msg.id);
-setBusy(false);
-};
+  const apply = async () => {
+    setBusy(true);
+    await applyQaCommit(msg.id);
+    setBusy(false);
+  };
+  const revert = async () => {
+    setBusy(true);
+    await revertQaAppliedCommit(msg.id);
+    setBusy(false);
+  };
 
-return (
-<div className={qa-commit-card status-${status}}>
-
-
-{status === "applied" ? "已提交" : status === "reverted" ? "已撤销" : status === "canceled" ? "已取消" : "修改提案"}
-
-{proposal.branch || "默认分支"} · {files.length + (proposal.deletes?.length ?? 0)} 个文件
-
-{proposal.message}
-
-{files.map((f) => (
-{f.path}
-))}
-{(proposal.deletes ?? []).map((path) => (
-<li key={del-${path}} className="qa-commit-file-delete">− {path}（删除）
-))}
-
-{error && {error}}
-{status === "pending" && (
-
-
-{busy ?  : "应用"}
-
-<button type="button" className="qa-commit-btn" onClick={() => cancelQaCommit(msg.id)} disabled={busy}>
-取消
-
-
-)}
-{(status === "applying" || status === "reverting") && (
-
-
- {status === "applying" ? "提交中…" : "撤销中…"}
-
-
-)}
-{status === "applied" && result && (
-
-
-查看 commit {result.sha.slice(0, 7)}
-
-
-撤销
-
-
-)}
-
-);
+  return (
+    <div className={`qa-commit-card status-${status}`}>
+      <div className="qa-commit-head">
+        <span className="qa-commit-title">
+          {status === "applied" ? "已提交" : status === "reverted" ? "已撤销" : status === "canceled" ? "已取消" : "修改提案"}
+        </span>
+        <span className="qa-commit-branch">{proposal.branch || "默认分支"} · {files.length + (proposal.deletes?.length ?? 0)} 个文件</span>
+      </div>
+      <div className="qa-commit-msg">{proposal.message}</div>
+      <ul className="qa-commit-files">
+        {files.map((f) => (
+          <li key={f.path}>{f.path}</li>
+        ))}
+        {(proposal.deletes ?? []).map((path) => (
+          <li key={`del-${path}`} className="qa-commit-file-delete">− {path}（删除）</li>
+        ))}
+      </ul>
+      {error && <div className="qa-commit-error">{error}</div>}
+      {status === "pending" && (
+        <div className="qa-commit-actions">
+          <button type="button" className="qa-commit-btn is-primary" onClick={apply} disabled={busy}>
+            {busy ? <Loader2 size={13} className="qa-spin" /> : "应用"}
+          </button>
+          <button type="button" className="qa-commit-btn" onClick={() => cancelQaCommit(msg.id)} disabled={busy}>
+            取消
+          </button>
+        </div>
+      )}
+      {(status === "applying" || status === "reverting") && (
+        <div className="qa-commit-actions">
+          <span className="qa-commit-progress">
+            <Loader2 size={13} className="qa-spin" /> {status === "applying" ? "提交中…" : "撤销中…"}
+          </span>
+        </div>
+      )}
+      {status === "applied" && result && (
+        <div className="qa-commit-actions">
+          <a className="qa-commit-link" href={result.htmlUrl} target="_blank" rel="noreferrer noopener">
+            查看 commit {result.sha.slice(0, 7)}
+          </a>
+          <button type="button" className="qa-commit-btn is-danger" onClick={revert} disabled={busy}>
+            撤销
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }
 
 // ── 消息渲染 ─────────────────────────────────────────
 
 // 工具调用行：折叠的单行摘要，点开展开参数与结果（Claude Code 风格）
 function QaToolRow({ tool }: { tool: QaToolStatus }) {
-const [open, setOpen] = useState(false);
-// 「电脑文件 op=send」的结果里带文件卡标记：卡片常显，标记从结果文本中剥离
-const { text: resultText, file } = parseQaFileMarker(tool.result || "");
-const hasDetail = Boolean(tool.detail || resultText);
-const summary = tool.running ? 正在${tool.name}… : tool.success === false ? ${tool.name}失败 : tool.name;
-return (
-<div className={qa-tool-row ${tool.running ? "is-running" : tool.success === false ? "is-fail" : "is-done"}}>
-<button
-type="button"
-className="qa-tool-row-head"
-onClick={() => hasDetail && setOpen((v) => !v)}
-disabled={!hasDetail}
->
-{tool.running ?  : }
-
-{summary}
-{tool.subtitle && {tool.subtitle}}
-
-{hasDetail && <ChevronRight size={14} className={qa-tool-row-chevron ${open ? "is-open" : ""}} />}
-
-{open && hasDetail && (
-
-{tool.detail && (
-<>
-参数
-{tool.detail}
-</>
-)}
-{resultText && (
-<>
-结果
-{resultText}
-</>
-)}
-
-)}
-{file && }
-
-);
+  const [open, setOpen] = useState(false);
+  // 「电脑文件 op=send」的结果里带文件卡标记：卡片常显，标记从结果文本中剥离
+  const { text: resultText, file } = parseQaFileMarker(tool.result || "");
+  const hasDetail = Boolean(tool.detail || resultText);
+  const summary = tool.running ? `正在${tool.name}…` : tool.success === false ? `${tool.name}失败` : tool.name;
+  return (
+    <div className={`qa-tool-row ${tool.running ? "is-running" : tool.success === false ? "is-fail" : "is-done"}`}>
+      <button
+        type="button"
+        className="qa-tool-row-head"
+        onClick={() => hasDetail && setOpen((v) => !v)}
+        disabled={!hasDetail}
+      >
+        {tool.running ? <Loader2 size={13} className="qa-spin" /> : <Wrench size={13} />}
+        <span className="qa-tool-row-summary">
+          {summary}
+          {tool.subtitle && <span className="qa-tool-row-sub">{tool.subtitle}</span>}
+        </span>
+        {hasDetail && <ChevronRight size={14} className={`qa-tool-row-chevron ${open ? "is-open" : ""}`} />}
+      </button>
+      {open && hasDetail && (
+        <div className="qa-tool-row-body">
+          {tool.detail && (
+            <>
+              <div className="qa-tool-row-label">参数</div>
+              <pre className="qa-tool-row-pre">{tool.detail}</pre>
+            </>
+          )}
+          {resultText && (
+            <>
+              <div className="qa-tool-row-label">结果</div>
+              <pre className="qa-tool-row-pre">{resultText}</pre>
+            </>
+          )}
+        </div>
+      )}
+      {file && <QaFileCard file={file} />}
+    </div>
+  );
 }
 
 // 已完成文本的 Markdown 渲染：memo 缓存——流式期间每次增量都全文重排 remark 是
 // 低端机 WebView OOM 崩溃的主因（几万字 × 每秒多次解析）。文本不变就不重渲。
 const QaMarkdownBlock = memo(function QaMarkdownBlock({ text }: { text: string }) {
-return (
-<ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={QA_MARKDOWN_COMPONENTS}>
-{text}
-
-);
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={QA_MARKDOWN_COMPONENTS}>
+      {text}
+    </ReactMarkdown>
+  );
 });
 
 // 正在生长的活跃段：纯文本渲染（零解析成本），生成结束后换回完整 Markdown
 function QaStreamingText({ text }: { text: string }) {
-return (
-<>
-{text}
-
-</>
-);
+  return (
+    <>
+      <div className="qa-stream-text">{text}</div>
+      <span className="qa-cursor" />
+    </>
+  );
 }
 
 const QaMessageItem = memo(function QaMessageItem({
-msg,
-isStreaming,
-onRetry,
-onViewImage,
-onCopy,
-onEdit,
+  msg,
+  isStreaming,
+  onRetry,
+  onViewImage,
+  onCopy,
+  onEdit,
 }: {
-msg: QaMsg;
-isStreaming: boolean;
-onRetry: (id: string) => void;
-onViewImage: (url: string) => void;
-onCopy: (content: string) => void;
-onEdit: (msg: QaMsg) => void;
+  msg: QaMsg;
+  isStreaming: boolean;
+  onRetry: (id: string) => void;
+  onViewImage: (url: string) => void;
+  onCopy: (content: string) => void;
+  onEdit: (msg: QaMsg) => void;
 }) {
-const thinkingOnly = isStreaming && !msg.content && (!msg.tools || msg.tools.length === 0);
-const showActions = !isStreaming && !thinkingOnly;
-const msgWrap = (node: ReactNode) => (
+  const thinkingOnly = isStreaming && !msg.content && (!msg.tools || msg.tools.length === 0);
+  const showActions = !isStreaming && !thinkingOnly;
+  const msgWrap = (node: ReactNode) => (
+    <div className="qa-msg-wrap">
+      {node}
+      {showActions && (
+        <div className="qa-msg-actions" data-role={msg.role}>
+          <button type="button" className="qa-msg-action" aria-label="复制原始内容" title="复制" onClick={() => onCopy(msg.content)}>
+            <Copy size={14} strokeWidth={2} />
+          </button>
+          <button type="button" className="qa-msg-action" aria-label="修改消息" title="修改" onClick={() => onEdit(msg)}>
+            <Pencil size={14} strokeWidth={2} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+  
+  const segmentBlocks = useMemo(() => {
+    if (!msg.segments?.length) return null;
+    const blocks: Array<{ kind: "text"; text: string } | { kind: "tools"; tools: QaToolStatus[] }> = [];
+    for (const seg of msg.segments) {
+      const last = blocks[blocks.length - 1];
+      if (seg.kind === "tool") {
+        if (last?.kind === "tools") last.tools.push(seg.tool);
+        else blocks.push({ kind: "tools", tools: [seg.tool] });
+      } else if (seg.text.trim()) {
+        if (last?.kind === "text") last.text += seg.text;
+        else blocks.push({ kind: "text", text: seg.text });
+      }
+    }
+    return blocks.length ? blocks : null;
+  }, [msg.segments]);
 
-{node}
-{showActions && (
+  if (msg.role === "user") {
+    return msgWrap(
+      <div className="qa-msg-user-row">
+        <div className="qa-msg-user">
+          {msg.images && msg.images.length > 0 && (
+            <div className="qa-msg-images">
+              {msg.images.map((url, i) => (
+                <button key={i} type="button" className="qa-msg-image" onClick={() => onViewImage(url)} aria-label="查看图片">
+                  <img src={url} alt="" />
+                </button>
+              ))}
+            </div>
+          )}
+          {msg.files && msg.files.length > 0 && (
+            <div className="qa-msg-files" style={{ display: "flex", flexDirection: "column", gap: "4px", marginBottom: "8px" }}>
+              {msg.files.map((f, i) => (
+                <div key={i} style={{ display: "flex", alignItems: "center", gap: "6px", background: "rgba(255,255,255,0.1)", padding: "4px 8px", borderRadius: "6px", fontSize: "12px", border: "1px solid rgba(255,255,255,0.2)" }}>
+                   <FileText size={14} />
+                   <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: "150px" }}>{f.name}</span>
+                </div>
+              ))}
+            </div>
+          )}
+          {msg.content}
+        </div>
+      </div>,
+    );
+  }
 
-<button type="button" className="qa-msg-action" aria-label="复制原始内容" title="复制" onClick={() => onCopy(msg.content)}>
-
-
-<button type="button" className="qa-msg-action" aria-label="修改消息" title="修改" onClick={() => onEdit(msg)}>
-
-
-
-)}
-
-);
-
-const segmentBlocks = useMemo(() => {
-if (!msg.segments?.length) return null;
-const blocks: Array<{ kind: "text"; text: string } | { kind: "tools"; tools: QaToolStatus[] }> = [];
-for (const seg of msg.segments) {
-const last = blocks[blocks.length - 1];
-if (seg.kind === "tool") {
-if (last?.kind === "tools") last.tools.push(seg.tool);
-else blocks.push({ kind: "tools", tools: [seg.tool] });
-} else if (seg.text.trim()) {
-if (last?.kind === "text") last.text += seg.text;
-else blocks.push({ kind: "text", text: seg.text });
-}
-}
-return blocks.length ? blocks : null;
-}, [msg.segments]);
-
-if (msg.role === "user") {
-return msgWrap(
-
-
-{msg.images && msg.images.length > 0 && (
-
-{msg.images.map((url, i) => (
-<button key={i} type="button" className="qa-msg-image" onClick={() => onViewImage(url)} aria-label="查看图片">
-
-
-))}
-
-)}
-{msg.files && msg.files.length > 0 && (
-<div className="qa-msg-files" style={{ display: "flex", flexDirection: "column", gap: "4px", marginBottom: "8px" }}>
-{msg.files.map((f, i) => (
-<div key={i} style={{ display: "flex", alignItems: "center", gap: "6px", background: "rgba(255,255,255,0.1)", padding: "4px 8px", borderRadius: "12px", fontSize: "12px", border: "1px solid rgba(255,255,255,0.2)" }}>
-
-<span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: "150px" }}>{f.name}
-
-))}
-
-)}
-{msg.content}
-
-,
-);
-}
-
-return msgWrap(
-
-{segmentBlocks ? (
-segmentBlocks.map((block, i) =>
-block.kind === "tools" ? (
-
-{block.tools.map((tool, j) => (
-<QaToolRow key={${tool.name}-${j}} tool={tool} />
-))}
-
-) : isStreaming && i === segmentBlocks.length - 1 ? (
-
-
-
-) : (
-
-
-
-),
-)
-) : (
-<>
-{msg.tools && msg.tools.length > 0 && (
-
-{msg.tools.map((tool, i) => (
-<QaToolRow key={${tool.name}-${i}} tool={tool} />
-))}
-
-)}
-{thinkingOnly ? (
-{msg.toolDrafting ? "正在编写工具调用…" : msg.reasoning ? "正在思考…" : "正在生成…"}
-) : isStreaming ? (
-
-
-
-) : (
-
-
-
-)}
-</>
-)}
-{isStreaming && msg.toolDrafting && !thinkingOnly && (
-正在编写工具调用…
-)}
-{msg.streamNote && {msg.streamNote}}
-{msg.pendingCommit && }
-{msg.aborted && 已停止生成}
-{msg.error && (
-
-{msg.error}
-<button type="button" className="qa-retry-btn" onClick={() => onRetry(msg.id)}>
-重试
-
-
-)}
-,
-);
+  return msgWrap(
+    <div className="qa-msg-assistant">
+      {segmentBlocks ? (
+        segmentBlocks.map((block, i) =>
+          block.kind === "tools" ? (
+            <div className="qa-tools" key={i}>
+              {block.tools.map((tool, j) => (
+                <QaToolRow key={`${tool.name}-${j}`} tool={tool} />
+              ))}
+            </div>
+          ) : isStreaming && i === segmentBlocks.length - 1 ? (
+            <div className="qa-markdown" key={i}>
+              <QaStreamingText text={block.text} />
+            </div>
+          ) : (
+            <div className="qa-markdown" key={i}>
+              <QaMarkdownBlock text={block.text} />
+            </div>
+          ),
+        )
+      ) : (
+        <>
+          {msg.tools && msg.tools.length > 0 && (
+            <div className="qa-tools">
+              {msg.tools.map((tool, i) => (
+                <QaToolRow key={`${tool.name}-${i}`} tool={tool} />
+              ))}
+            </div>
+          )}
+          {thinkingOnly ? (
+            <div className="qa-thinking">{msg.toolDrafting ? "正在编写工具调用…" : msg.reasoning ? "正在思考…" : "正在生成…"}</div>
+          ) : isStreaming ? (
+            <div className="qa-markdown">
+              <QaStreamingText text={msg.content} />
+            </div>
+          ) : (
+            <div className="qa-markdown">
+              <QaMarkdownBlock text={msg.content} />
+            </div>
+          )}
+        </>
+      )}
+      {isStreaming && msg.toolDrafting && !thinkingOnly && (
+        <div className="qa-thinking qa-tool-drafting">正在编写工具调用…</div>
+      )}
+      {msg.streamNote && <div className="qa-msg-note">{msg.streamNote}</div>}
+      {msg.pendingCommit && <QaCommitCard msg={msg} />}
+      {msg.aborted && <div className="qa-msg-note">已停止生成</div>}
+      {msg.error && (
+        <div className="qa-msg-error">
+          <div className="qa-msg-error-text">{msg.error}</div>
+          <button type="button" className="qa-retry-btn" onClick={() => onRetry(msg.id)}>
+            重试
+          </button>
+        </div>
+      )}
+    </div>,
+  );
 });
 
 // ── 会话抽屉 ─────────────────────────────────────────
 
 function QaSessionDrawer({
-sessions,
-activeId,
-onSelect,
-onDelete,
-onCreate,
-onOpenSettings,
-onRenameRequest,
+  sessions,
+  activeId,
+  onSelect,
+  onDelete,
+  onCreate,
+  onOpenSettings,
+  onRenameRequest,
 }: {
-sessions: QaSession[];
-activeId: string | null;
-onSelect: (id: string) => void;
-onDelete: (id: string) => void;
-onCreate: () => void;
-onOpenSettings: () => void;
-onRenameRequest: (id: string, title: string) => void;
+  sessions: QaSession[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
+  onCreate: () => void;
+  onOpenSettings: () => void;
+  onRenameRequest: (id: string, title: string) => void;
 }) {
-const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 
-// 置顶的排最前，其余保持时间序。只在渲染层排，存储顺序不动
-const sortedSessions = useMemo(() => {
-return [...sessions].sort((a, b) => {
-if (Boolean(a.isPinned) !== Boolean(b.isPinned)) return a.isPinned ? -1 : 1;
-return b.updatedAt - a.updatedAt;
-});
-}, [sessions]);
+  // 置顶的排最前，其余保持时间序。只在渲染层排，存储顺序不动
+  const sortedSessions = useMemo(() => {
+    return [...sessions].sort((a, b) => {
+      if (Boolean(a.isPinned) !== Boolean(b.isPinned)) return a.isPinned ? -1 : 1;
+      return b.updatedAt - a.updatedAt;
+    });
+  }, [sessions]);
 
-return (
-
-
-对话记录
-
-<div
-className="qa-drawer-list hide-scrollbar"
-onClick={() => { if (menuOpenId) setMenuOpenId(null); }}
->
-{sortedSessions.length === 0 && 还没有对话}
-{sortedSessions.map((session) => (
-<div
-key={session.id}
-className={qa-drawer-item ${session.id === activeId ? "is-active" : ""}}
-onClick={() => onSelect(session.id)}
->
-
-
-{session.isPinned && }
-{session.title}
-
-{formatRelativeTime(session.updatedAt)}
-
-<button
-type="button"
-className="qa-icon-btn qa-drawer-item-more"
-aria-label="更多操作"
-aria-expanded={menuOpenId === session.id}
-onClick={(e) => {
-e.stopPropagation();
-setMenuOpenId(menuOpenId === session.id ? null : session.id);
-}}
->
-
-
-
-        {menuOpenId === session.id && (
-          <div className="qa-drawer-item-menu" role="menu">
-            <button
-              type="button"
-              role="menuitem"
-              className="qa-drawer-menu-btn"
-              onClick={(e) => {
-                e.stopPropagation();
-                toggleQaSessionPin(session.id);
-                setMenuOpenId(null);
-              }}
-            >
-              {session.isPinned ? <PinOff size={14} /> : <Pin size={14} />}
-              {session.isPinned ? "取消置顶" : "置顶"}
-            </button>
-            <button
-              type="button"
-              role="menuitem"
-              className="qa-drawer-menu-btn"
-              onClick={(e) => {
-                e.stopPropagation();
-                onRenameRequest(session.id, session.title);
-                setMenuOpenId(null);
-              }}
-            >
-              <Pencil size={14} /> 重命名
-            </button>
-            <button
-              type="button"
-              role="menuitem"
-              className="qa-drawer-menu-btn is-danger"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(session.id);
-                setMenuOpenId(null);
-              }}
-            >
-              <Trash2 size={14} /> 删除
-            </button>
-          </div>
-        )}
+  return (
+    <aside className="qa-drawer">
+      <div className="qa-drawer-head">
+        <span className="qa-drawer-title">对话记录</span>
       </div>
-    ))}
-  </div>
-  <div className="qa-drawer-foot">
-    <button type="button" className="qa-drawer-new qa-drawer-settings" onClick={onOpenSettings}>
-      <Wrench size={15} strokeWidth={2} />
-      <span>工坊配置</span>
-    </button>
-    <button type="button" className="qa-drawer-new" onClick={onCreate}>
-      <Plus size={16} strokeWidth={2} />
-      <span>新对话</span>
-    </button>
-  </div>
-</aside>
+      <div
+        className="qa-drawer-list hide-scrollbar"
+        onClick={() => { if (menuOpenId) setMenuOpenId(null); }}
+      >
+        {sortedSessions.length === 0 && <div className="qa-drawer-empty">还没有对话</div>}
+        {sortedSessions.map((session) => (
+          <div
+            key={session.id}
+            className={`qa-drawer-item ${session.id === activeId ? "is-active" : ""}`}
+            onClick={() => onSelect(session.id)}
+          >
+            <div className="qa-drawer-item-main">
+              <span className="qa-drawer-item-title">
+                {session.isPinned && <Pin size={12} className="qa-drawer-pin-mark" aria-label="已置顶" />}
+                {session.title}
+              </span>
+              <span className="qa-drawer-item-time">{formatRelativeTime(session.updatedAt)}</span>
+            </div>
+            <button
+              type="button"
+              className="qa-icon-btn qa-drawer-item-more"
+              aria-label="更多操作"
+              aria-expanded={menuOpenId === session.id}
+              onClick={(e) => {
+                e.stopPropagation();
+                setMenuOpenId(menuOpenId === session.id ? null : session.id);
+              }}
+            >
+              <MoreVertical size={14} />
+            </button>
 
-
-);
+            {menuOpenId === session.id && (
+              <div className="qa-drawer-item-menu" role="menu">
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="qa-drawer-menu-btn"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleQaSessionPin(session.id);
+                    setMenuOpenId(null);
+                  }}
+                >
+                  {session.isPinned ? <PinOff size={14} /> : <Pin size={14} />}
+                  {session.isPinned ? "取消置顶" : "置顶"}
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="qa-drawer-menu-btn"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRenameRequest(session.id, session.title);
+                    setMenuOpenId(null);
+                  }}
+                >
+                  <Pencil size={14} /> 重命名
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="qa-drawer-menu-btn is-danger"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete(session.id);
+                    setMenuOpenId(null);
+                  }}
+                >
+                  <Trash2 size={14} /> 删除
+                </button>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="qa-drawer-foot">
+        <button type="button" className="qa-drawer-new qa-drawer-settings" onClick={onOpenSettings}>
+          <Wrench size={15} strokeWidth={2} />
+          <span>工坊配置</span>
+        </button>
+        <button type="button" className="qa-drawer-new" onClick={onCreate}>
+          <Plus size={16} strokeWidth={2} />
+          <span>新对话</span>
+        </button>
+      </div>
+    </aside>
+  );
 }
 
 // ── 工坊配置面板 ─────────────────────────────────────
 
 function QaSettingsSheet({ onClose, onNotice }: { onClose: () => void; onNotice?: (msg: string) => void }) {
-const [budget, setBudget] = useState(() => String(getQaContextBudgetChars()));
-const [pageChars, setPageChars] = useState(() => String(getQaPageChars()));
-const [maxRounds, setMaxRounds] = useState(() => String(getQaMaxRounds()));
-const [maxOutTokens, setMaxOutTokens] = useState(() => {
-const v = getQaMaxOutputTokens();
-return v == null ? "" : String(v);
-});
-const usedChars = getQaActiveContextChars();
-const pct = Math.round((usedChars / getQaContextBudgetChars()) * 100);
+  const [budget, setBudget] = useState(() => String(getQaContextBudgetChars()));
+  const [pageChars, setPageChars] = useState(() => String(getQaPageChars()));
+  const [maxRounds, setMaxRounds] = useState(() => String(getQaMaxRounds()));
+  const [maxOutTokens, setMaxOutTokens] = useState(() => {
+    const v = getQaMaxOutputTokens();
+    return v == null ? "" : String(v);
+  });
+  const usedChars = getQaActiveContextChars();
+  const pct = Math.round((usedChars / getQaContextBudgetChars()) * 100);
 
-const save = () => {
-const parsed = Number(budget);
-if (!Number.isFinite(parsed) || parsed < QA_CONTEXT_BUDGET_MIN || parsed > QA_CONTEXT_BUDGET_MAX) {
-onNotice?.(预算需为 ${QA_CONTEXT_BUDGET_MIN.toLocaleString()} - ${QA_CONTEXT_BUDGET_MAX.toLocaleString()} 之间的数字。);
-return;
-}
-const parsedPage = Number(pageChars);
-if (!Number.isFinite(parsedPage) || parsedPage < QA_PAGE_CHARS_MIN || parsedPage > QA_PAGE_CHARS_MAX) {
-onNotice?.(单页字符数需为 ${QA_PAGE_CHARS_MIN.toLocaleString()} - ${QA_PAGE_CHARS_MAX.toLocaleString()} 之间的数字。);
-return;
-}
-const parsedRounds = Number(maxRounds);
-if (!Number.isFinite(parsedRounds) || parsedRounds < QA_MAX_ROUNDS_MIN || parsedRounds > QA_MAX_ROUNDS_MAX) {
-onNotice?.(工具调用上限需为 ${QA_MAX_ROUNDS_MIN} - ${QA_MAX_ROUNDS_MAX} 之间的数字。);
-return;
-}
-const trimmedTokens = maxOutTokens.trim();
-const parsedTokens = trimmedTokens ? Number(trimmedTokens) : null;
-if (parsedTokens != null && (!Number.isFinite(parsedTokens) || parsedTokens < QA_MAX_OUTPUT_TOKENS_MIN || parsedTokens > QA_MAX_OUTPUT_TOKENS_MAX)) {
-onNotice?.(单次最大输出 token 需留空或为 ${QA_MAX_OUTPUT_TOKENS_MIN.toLocaleString()} - ${QA_MAX_OUTPUT_TOKENS_MAX.toLocaleString()} 之间的数字。);
-return;
-}
-setQaContextBudgetChars(parsed);
-setQaPageChars(parsedPage);
-setQaMaxRounds(parsedRounds);
-setQaMaxOutputTokens(trimmedTokens ? parsedTokens : 0);
-onNotice?.("已保存工坊配置。");
-onClose();
-};
+  const save = () => {
+    const parsed = Number(budget);
+    if (!Number.isFinite(parsed) || parsed < QA_CONTEXT_BUDGET_MIN || parsed > QA_CONTEXT_BUDGET_MAX) {
+      onNotice?.(`预算需为 ${QA_CONTEXT_BUDGET_MIN.toLocaleString()} - ${QA_CONTEXT_BUDGET_MAX.toLocaleString()} 之间的数字。`);
+      return;
+    }
+    const parsedPage = Number(pageChars);
+    if (!Number.isFinite(parsedPage) || parsedPage < QA_PAGE_CHARS_MIN || parsedPage > QA_PAGE_CHARS_MAX) {
+      onNotice?.(`单页字符数需为 ${QA_PAGE_CHARS_MIN.toLocaleString()} - ${QA_PAGE_CHARS_MAX.toLocaleString()} 之间的数字。`);
+      return;
+    }
+    const parsedRounds = Number(maxRounds);
+    if (!Number.isFinite(parsedRounds) || parsedRounds < QA_MAX_ROUNDS_MIN || parsedRounds > QA_MAX_ROUNDS_MAX) {
+      onNotice?.(`工具调用上限需为 ${QA_MAX_ROUNDS_MIN} - ${QA_MAX_ROUNDS_MAX} 之间的数字。`);
+      return;
+    }
+    const trimmedTokens = maxOutTokens.trim();
+    const parsedTokens = trimmedTokens ? Number(trimmedTokens) : null;
+    if (parsedTokens != null && (!Number.isFinite(parsedTokens) || parsedTokens < QA_MAX_OUTPUT_TOKENS_MIN || parsedTokens > QA_MAX_OUTPUT_TOKENS_MAX)) {
+      onNotice?.(`单次最大输出 token 需留空或为 ${QA_MAX_OUTPUT_TOKENS_MIN.toLocaleString()} - ${QA_MAX_OUTPUT_TOKENS_MAX.toLocaleString()} 之间的数字。`);
+      return;
+    }
+    setQaContextBudgetChars(parsed);
+    setQaPageChars(parsedPage);
+    setQaMaxRounds(parsedRounds);
+    setQaMaxOutputTokens(trimmedTokens ? parsedTokens : 0);
+    onNotice?.("已保存工坊配置。");
+    onClose();
+  };
 
-const reset = () => {
-setQaContextBudgetChars(null);
-setQaPageChars(null);
-setQaMaxRounds(null);
-setQaMaxOutputTokens(null);
-setBudget(String(QA_DEFAULT_CONTEXT_BUDGET_CHARS));
-setPageChars(String(QA_DEFAULT_PAGE_CHARS));
-setMaxRounds(String(QA_DEFAULT_MAX_ROUNDS));
-setMaxOutTokens(String(QA_DEFAULT_MAX_OUTPUT_TOKENS));
-onNotice?.("已恢复默认配置。");
-};
+  const reset = () => {
+    setQaContextBudgetChars(null);
+    setQaPageChars(null);
+    setQaMaxRounds(null);
+    setQaMaxOutputTokens(null);
+    setBudget(String(QA_DEFAULT_CONTEXT_BUDGET_CHARS));
+    setPageChars(String(QA_DEFAULT_PAGE_CHARS));
+    setMaxRounds(String(QA_DEFAULT_MAX_ROUNDS));
+    setMaxOutTokens(String(QA_DEFAULT_MAX_OUTPUT_TOKENS));
+    onNotice?.("已恢复默认配置。");
+  };
 
-return (
-
-<div className="qa-devnotice" role="dialog" aria-label="工坊配置" onClick={(e) => e.stopPropagation()}>
-工坊配置
-
-上下文预算（字符）
-<input
-type="number"
-inputMode="numeric"
-min={QA_CONTEXT_BUDGET_MIN}
-max={QA_CONTEXT_BUDGET_MAX}
-step={1000}
-value={budget}
-onChange={(e) => setBudget(e.target.value)}
-/>
-
-
-上下文满 100% 时自动压缩成摘要并重新累计。中文约 1 字符 ≈ 1 token；默认 {QA_DEFAULT_CONTEXT_BUDGET_CHARS.toLocaleString()}，小上下文（32k）模型建议 30000–50000。
-
-当前会话已用 {usedChars.toLocaleString()} 字符（约 {pct}%）。
-
-单页读取字符数
-<input
-type="number"
-inputMode="numeric"
-min={QA_PAGE_CHARS_MIN}
-max={QA_PAGE_CHARS_MAX}
-step={1000}
-value={pageChars}
-onChange={(e) => setPageChars(e.target.value)}
-/>
-
-
-小坊翻页读答疑文档 / 本机内容 / 仓库源码时，每页返回的字符数。默认 {QA_DEFAULT_PAGE_CHARS.toLocaleString()}；调大读得快但更占上下文，小上下文模型建议调小。
-
-
-单轮工具调用上限（次）
-<input
-type="number"
-inputMode="numeric"
-min={QA_MAX_ROUNDS_MIN}
-max={QA_MAX_ROUNDS_MAX}
-step={1}
-value={maxRounds}
-onChange={(e) => setMaxRounds(e.target.value)}
-/>
-
-
-一次提问里小坊最多连续执行多少轮工具，用完会提示「回复继续」。默认 {QA_DEFAULT_MAX_ROUNDS}；复杂任务（写游戏、改代码）可调大，想控制 token 消耗可调小。
-
-
-单次最大输出 token
-<input
-type="number"
-inputMode="numeric"
-min={QA_MAX_OUTPUT_TOKENS_MIN}
-max={QA_MAX_OUTPUT_TOKENS_MAX}
-step={1000}
-placeholder="留空 = 不传"
-value={maxOutTokens}
-onChange={(e) => setMaxOutTokens(e.target.value)}
-/>
-
-
-输出长度护栏：每次请求带 max_tokens，小坊会按该预算分段写大文件，写超被安全截断后自动续接，不再整轮报废。默认 {QA_DEFAULT_MAX_OUTPUT_TOKENS.toLocaleString()}；留空 = 不传该参数（部分模型/中转不支持 max_tokens 时请留空）。
-
-
-恢复默认
-保存
-
-
-
-);
+  return (
+    <div className="qa-devnotice-backdrop" onClick={onClose}>
+      <div className="qa-devnotice" role="dialog" aria-label="工坊配置" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-devnotice-title">工坊配置</div>
+        <label className="qa-settings-field">
+          <span>上下文预算（字符）</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={QA_CONTEXT_BUDGET_MIN}
+            max={QA_CONTEXT_BUDGET_MAX}
+            step={1000}
+            value={budget}
+            onChange={(e) => setBudget(e.target.value)}
+          />
+        </label>
+        <div className="qa-settings-hint">
+          上下文满 100% 时自动压缩成摘要并重新累计。中文约 1 字符 ≈ 1 token；默认 {QA_DEFAULT_CONTEXT_BUDGET_CHARS.toLocaleString()}，小上下文（32k）模型建议 30000–50000。
+        </div>
+        <div className="qa-settings-hint">当前会话已用 {usedChars.toLocaleString()} 字符（约 {pct}%）。</div>
+        <label className="qa-settings-field">
+          <span>单页读取字符数</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={QA_PAGE_CHARS_MIN}
+            max={QA_PAGE_CHARS_MAX}
+            step={1000}
+            value={pageChars}
+            onChange={(e) => setPageChars(e.target.value)}
+          />
+        </label>
+        <div className="qa-settings-hint">
+          小坊翻页读答疑文档 / 本机内容 / 仓库源码时，每页返回的字符数。默认 {QA_DEFAULT_PAGE_CHARS.toLocaleString()}；调大读得快但更占上下文，小上下文模型建议调小。
+        </div>
+        <label className="qa-settings-field">
+          <span>单轮工具调用上限（次）</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={QA_MAX_ROUNDS_MIN}
+            max={QA_MAX_ROUNDS_MAX}
+            step={1}
+            value={maxRounds}
+            onChange={(e) => setMaxRounds(e.target.value)}
+          />
+        </label>
+        <div className="qa-settings-hint">
+          一次提问里小坊最多连续执行多少轮工具，用完会提示「回复继续」。默认 {QA_DEFAULT_MAX_ROUNDS}；复杂任务（写游戏、改代码）可调大，想控制 token 消耗可调小。
+        </div>
+        <label className="qa-settings-field">
+          <span>单次最大输出 token</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={QA_MAX_OUTPUT_TOKENS_MIN}
+            max={QA_MAX_OUTPUT_TOKENS_MAX}
+            step={1000}
+            placeholder="留空 = 不传"
+            value={maxOutTokens}
+            onChange={(e) => setMaxOutTokens(e.target.value)}
+          />
+        </label>
+        <div className="qa-settings-hint">
+          输出长度护栏：每次请求带 max_tokens，小坊会按该预算分段写大文件，写超被安全截断后自动续接，不再整轮报废。默认 {QA_DEFAULT_MAX_OUTPUT_TOKENS.toLocaleString()}；留空 = 不传该参数（部分模型/中转不支持 max_tokens 时请留空）。
+        </div>
+        <div className="qa-devnotice-actions is-row">
+          <button type="button" className="qa-devnotice-btn" onClick={reset}>恢复默认</button>
+          <button type="button" className="qa-devnotice-btn is-primary" onClick={save}>保存</button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 // ── GitHub 仓库配置面板 ──────────────────────────────
 
 function QaRepoSheet({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
-const existing = useMemo(() => loadQaGithubConfig(), []);
-const [owner, setOwner] = useState(existing?.owner ?? "");
-const [repo, setRepo] = useState(existing?.repo ?? "");
-const [branch, setBranch] = useState(existing?.branch ?? "");
-const [token, setToken] = useState(existing?.token ?? "");
-const [writeMode, setWriteMode] = useState<"confirm" | "auto">(existing?.writeMode ?? "confirm");
-const [checking, setChecking] = useState(false);
-const [result, setResult] = useState<QaGithubValidation | null>(null);
+  const existing = useMemo(() => loadQaGithubConfig(), []);
+  const [owner, setOwner] = useState(existing?.owner ?? "");
+  const [repo, setRepo] = useState(existing?.repo ?? "");
+  const [branch, setBranch] = useState(existing?.branch ?? "");
+  const [token, setToken] = useState(existing?.token ?? "");
+  const [writeMode, setWriteMode] = useState<"confirm" | "auto">(existing?.writeMode ?? "confirm");
+  const [checking, setChecking] = useState(false);
+  const [result, setResult] = useState<QaGithubValidation | null>(null);
 
-const buildConfig = useCallback((): QaGithubConfig => {
-const cfg: QaGithubConfig = { owner: owner.trim(), repo: repo.trim(), writeMode };
-if (branch.trim()) cfg.branch = branch.trim();
-if (token.trim()) cfg.token = token.trim();
-if (existing?.apiBase) cfg.apiBase = existing.apiBase;
-return cfg;
-}, [owner, repo, branch, token, writeMode, existing]);
+  const buildConfig = useCallback((): QaGithubConfig => {
+    const cfg: QaGithubConfig = { owner: owner.trim(), repo: repo.trim(), writeMode };
+    if (branch.trim()) cfg.branch = branch.trim();
+    if (token.trim()) cfg.token = token.trim();
+    if (existing?.apiBase) cfg.apiBase = existing.apiBase;
+    return cfg;
+  }, [owner, repo, branch, token, writeMode, existing]);
 
-const handleVerify = useCallback(async () => {
-if (!owner.trim() || !repo.trim()) {
-setResult({ ok: false, error: "请填写 owner 和 repo。" });
-return;
-}
-setChecking(true);
-setResult(null);
-const validation = await validateQaGithubConfig(buildConfig());
-setResult(validation);
-setChecking(false);
-}, [owner, repo, buildConfig]);
+  const handleVerify = useCallback(async () => {
+    if (!owner.trim() || !repo.trim()) {
+      setResult({ ok: false, error: "请填写 owner 和 repo。" });
+      return;
+    }
+    setChecking(true);
+    setResult(null);
+    const validation = await validateQaGithubConfig(buildConfig());
+    setResult(validation);
+    setChecking(false);
+  }, [owner, repo, buildConfig]);
 
-const handleSave = useCallback(() => {
-if (!owner.trim() || !repo.trim()) return;
-saveQaGithubConfig(buildConfig());
-onSaved();
-onClose();
-}, [owner, repo, buildConfig, onSaved, onClose]);
+  const handleSave = useCallback(() => {
+    if (!owner.trim() || !repo.trim()) return;
+    saveQaGithubConfig(buildConfig());
+    onSaved();
+    onClose();
+  }, [owner, repo, buildConfig, onSaved, onClose]);
 
-const handleDisconnect = useCallback(() => {
-clearQaGithubConfig();
-onSaved();
-onClose();
-}, [onSaved, onClose]);
+  const handleDisconnect = useCallback(() => {
+    clearQaGithubConfig();
+    onSaved();
+    onClose();
+  }, [onSaved, onClose]);
 
-return (
-
-<div className="qa-sheet" onClick={(e) => e.stopPropagation()}>
-
-
- 连接 GitHub 仓库
-
-
-
-
-
-
-
-连接后可以让工坊查阅这个仓库的代码来回答问题。配置只保存在你的浏览器本地，不会上传。公开仓库可不填 PAT。
-
-
-Owner（用户名 / 组织）
-<input className="qa-input" value={owner} onChange={(e) => setOwner(e.target.value)} placeholder="例：octocat" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-
-
-Repo（仓库名）
-<input className="qa-input" value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="例：hello-world" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-
-
-分支（可选，默认仓库默认分支）
-<input className="qa-input" value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="main" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-
-
-Fine-grained PAT（私有仓库或搜索代码需要）
-<input className="qa-input" type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="github_pat_…" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-
-GitHub → Settings → Menu 按钮 → Developer settings → Personal access tokens → Fine-grained tokens。创建时 Repository access 记得勾选目标仓库；Permissions 里：Contents——只查代码选 Read-only，要让工坊改代码选 Read and write；要用「创建PR」再加 Pull requests 的 Read and write（Metadata 会自动带上，其余权限都不用勾）。
-
-
-
-改代码时的模式
-
-<button type="button" className={qa-segment-btn ${writeMode === "confirm" ? "is-active" : ""}} onClick={() => setWriteMode("confirm")}>
-确认后提交
-
-<button type="button" className={qa-segment-btn ${writeMode === "auto" ? "is-active" : ""}} onClick={() => setWriteMode("auto")}>
-全自动
-
-
-
-{writeMode === "confirm"
-? "工坊改代码前会先展示改动，你点「应用」才真正提交。推荐。"
-: "工坊说完直接提交推送，不再逐次确认。仍可事后一键撤销。仅在信任后开启。"}
-
-
-{result && (
-<div className={qa-verify ${result.ok ? "is-ok" : "is-fail"}}>
-{result.ok
-? ✓ 已连接 ${result.fullName}（${result.private ? "私有" : "公开"}，默认分支 ${result.defaultBranch}）
-: ✗ ${result.error}}
-
-)}
-
-
-{existing && (
-
-断开
-
-)}
-
-{checking ?  : "验证"}
-
-<button type="button" className="qa-sheet-btn is-primary" onClick={handleSave} disabled={!owner.trim() || !repo.trim()}>
-保存
-
-
-
-
-);
+  return (
+    <div className="qa-sheet-backdrop" onClick={onClose}>
+      <div className="qa-sheet" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-sheet-head">
+          <span className="qa-sheet-title">
+            <Github size={16} /> 连接 GitHub 仓库
+          </span>
+          <button type="button" className="qa-icon-btn" onClick={onClose} aria-label="关闭">
+            <X size={16} />
+          </button>
+        </div>
+        <div className="qa-sheet-body hide-scrollbar">
+          <p className="qa-sheet-note">
+            连接后可以让工坊查阅这个仓库的代码来回答问题。配置只保存在你的浏览器本地，不会上传。公开仓库可不填 PAT。
+          </p>
+          <label className="qa-field">
+            <span className="qa-field-label">Owner（用户名 / 组织）</span>
+            <input className="qa-input" value={owner} onChange={(e) => setOwner(e.target.value)} placeholder="例：octocat" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+          </label>
+          <label className="qa-field">
+            <span className="qa-field-label">Repo（仓库名）</span>
+            <input className="qa-input" value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="例：hello-world" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+          </label>
+          <label className="qa-field">
+            <span className="qa-field-label">分支（可选，默认仓库默认分支）</span>
+            <input className="qa-input" value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="main" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+          </label>
+          <label className="qa-field">
+            <span className="qa-field-label">Fine-grained PAT（私有仓库或搜索代码需要）</span>
+            <input className="qa-input" type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="github_pat_…" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+            <span className="qa-field-hint">
+              GitHub → Settings → Menu 按钮 → Developer settings → Personal access tokens → Fine-grained tokens。创建时 Repository access 记得勾选目标仓库；Permissions 里：Contents——只查代码选 Read-only，要让工坊改代码选 Read and write；要用「创建PR」再加 Pull requests 的 Read and write（Metadata 会自动带上，其余权限都不用勾）。
+            </span>
+          </label>
+          <div className="qa-field">
+            <span className="qa-field-label">改代码时的模式</span>
+            <div className="qa-segment">
+              <button type="button" className={`qa-segment-btn ${writeMode === "confirm" ? "is-active" : ""}`} onClick={() => setWriteMode("confirm")}>
+                确认后提交
+              </button>
+              <button type="button" className={`qa-segment-btn ${writeMode === "auto" ? "is-active" : ""}`} onClick={() => setWriteMode("auto")}>
+                全自动
+              </button>
+            </div>
+            <span className="qa-field-hint">
+              {writeMode === "confirm"
+                ? "工坊改代码前会先展示改动，你点「应用」才真正提交。推荐。"
+                : "工坊说完直接提交推送，不再逐次确认。仍可事后一键撤销。仅在信任后开启。"}
+            </span>
+          </div>
+          {result && (
+            <div className={`qa-verify ${result.ok ? "is-ok" : "is-fail"}`}>
+              {result.ok
+                ? `✓ 已连接 ${result.fullName}（${result.private ? "私有" : "公开"}，默认分支 ${result.defaultBranch}）`
+                : `✗ ${result.error}`}
+            </div>
+          )}
+        </div>
+        <div className="qa-sheet-actions">
+          {existing && (
+            <button type="button" className="qa-sheet-btn is-danger" onClick={handleDisconnect}>
+              断开
+            </button>
+          )}
+          <button type="button" className="qa-sheet-btn" onClick={handleVerify} disabled={checking}>
+            {checking ? <Loader2 size={14} className="qa-spin" /> : "验证"}
+          </button>
+          <button type="button" className="qa-sheet-btn is-primary" onClick={handleSave} disabled={!owner.trim() || !repo.trim()}>
+            保存
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 // ── App 本体 ─────────────────────────────────────────
 
 export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
-const snapshot = useSyncExternalStore(subscribeQaChat, getQaChatSnapshot, getQaChatSnapshot);
-const [input, setInput] = useState("");
-const [drawerOpen, setDrawerOpen] = useState(false);
-const [repoSheetOpen, setRepoSheetOpen] = useState(false);
-const [repoConnected, setRepoConnected] = useState(false);
-const [clearToolsOpen, setClearToolsOpen] = useState(false);
-const [settingsOpen, setSettingsOpen] = useState(false);
-const [attachMenuOpen, setAttachMenuOpen] = useState(false); // 控制上方悬浮菜单状态
+  const snapshot = useSyncExternalStore(subscribeQaChat, getQaChatSnapshot, getQaChatSnapshot);
+  const [input, setInput] = useState("");
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [repoSheetOpen, setRepoSheetOpen] = useState(false);
+  const [repoConnected, setRepoConnected] = useState(false);
+  const [clearToolsOpen, setClearToolsOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [attachMenuOpen, setAttachMenuOpen] = useState(false); // 控制上方悬浮菜单状态
+  
+  /** 会话重命名弹窗：抽屉菜单里点「重命名」打开 */
+  const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
+  const [renameTitle, setRenameTitle] = useState("");
+  const [pendingImages, setPendingImages] = useState<string[]>([]);
+  const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
+  
+  const [viewerImage, setViewerImage] = useState<string | null>(null);
+  const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
+  const [editText, setEditText] = useState("");
+  const [editImages, setEditImages] = useState<string[]>([]);
+  const [editFiles, setEditFiles] = useState<{name: string, content: string}[]>([]);
+  
+  const [visionEnabled, setVisionEnabled] = useState(false);
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  
+  const [apiReady, setApiReady] = useState(true);
+  const [modelName, setModelName] = useState("");
+  const [repoWritable, setRepoWritable] = useState(false);
+  const [writeMode, setWriteMode] = useState<"confirm" | "auto">("confirm");
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const stickToBottomRef = useRef(true);
 
-/ 会话重命名弹窗：抽屉菜单里点「重命名」打开 */
-const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
-const [renameTitle, setRenameTitle] = useState("");
-const [pendingImages, setPendingImages] = useState<string[]>([]);
-const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
+  const refreshComposerMeta = useCallback(() => {
+    setApiReady(resolveQaApiConfig() != null);
+    setModelName(resolveQaApiConfig()?.defaultModel ?? "");
+    setVisionEnabled(resolveQaApiConfig()?.enableImageRecognition === true);
+    const gh = loadQaGithubConfig();
+    setRepoConnected(gh != null);
+    setRepoWritable(Boolean(gh?.token));
+    setWriteMode(gh?.writeMode ?? "confirm");
+  }, []);
 
-const [viewerImage, setViewerImage] = useState<string | null>(null);
-const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
-const [editText, setEditText] = useState("");
-const [editImages, setEditImages] = useState<string[]>([]);
-const [editFiles, setEditFiles] = useState<{name: string, content: string}[]>([]);
+  useEffect(() => {
+    void hydrateQaChat();
+    refreshComposerMeta();
+  }, [refreshComposerMeta]);
 
-const [visionEnabled, setVisionEnabled] = useState(false);
-const imageInputRef = useRef<HTMLInputElement | null>(null);
-const fileInputRef = useRef<HTMLInputElement | null>(null);
+  // 清理原生 tool 调用历史（防报错）：与小卷同款——移除上下文里的工具记录与原生元数据
+  const handleClearToolHistory = useCallback(() => {
+    if (snapshot.isGenerating) {
+      onNotice?.("小坊正在执行，完成后再清理。");
+      return;
+    }
+    if (!hasQaToolHistory()) {
+      onNotice?.("没有可清理的工具调用历史。");
+      return;
+    }
+    setClearToolsOpen(true);
+  }, [snapshot.isGenerating, onNotice]);
 
-const [apiReady, setApiReady] = useState(true);
-const [modelName, setModelName] = useState("");
-const [repoWritable, setRepoWritable] = useState(false);
-const [writeMode, setWriteMode] = useState<"confirm" | "auto">("confirm");
-const bodyRef = useRef<HTMLDivElement | null>(null);
-const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-const stickToBottomRef = useRef(true);
+  const confirmClearToolHistory = useCallback(() => {
+    setClearToolsOpen(false);
+    const result = clearQaToolHistory();
+    onNotice?.(result && result.removed + result.cleaned > 0
+      ? `已清理 ${result.removed} 条工具记录，整理 ${result.cleaned} 条消息。`
+      : "没有可清理的工具调用历史。");
+  }, [onNotice]);
 
-const refreshComposerMeta = useCallback(() => {
-setApiReady(resolveQaApiConfig() != null);
-setModelName(resolveQaApiConfig()?.defaultModel ?? "");
-setVisionEnabled(resolveQaApiConfig()?.enableImageRecognition === true);
-const gh = loadQaGithubConfig();
-setRepoConnected(gh != null);
-setRepoWritable(Boolean(gh?.token));
-setWriteMode(gh?.writeMode ?? "confirm");
-}, []);
+  const toggleWriteMode = useCallback(() => {
+    const gh = loadQaGithubConfig();
+    if (!gh) return;
+    const next = gh.writeMode === "auto" ? "confirm" : "auto";
+    saveQaGithubConfig({ ...gh, writeMode: next });
+    setWriteMode(next);
+  }, []);
 
-useEffect(() => {
-void hydrateQaChat();
-refreshComposerMeta();
-}, [refreshComposerMeta]);
+  const activeSession = useMemo(
+    () => snapshot.sessions.find((s) => s.id === snapshot.activeSessionId) ?? null,
+    [snapshot.sessions, snapshot.activeSessionId],
+  );
+  const messages = useMemo(() => activeSession?.messages ?? [], [activeSession]);
+  const createdContent = useMemo(() => activeSession?.createdContent ?? [], [activeSession]);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewItem, setPreviewItem] = useState<QaCreatedContent | null>(null);
+  const previewApp = useMemo(
+    () => (previewItem?.type === "app" ? getInstalledCustomApp(previewItem.refId) : null),
+    [previewItem],
+  );
 
-// 清理原生 tool 调用历史（防报错）：与小卷同款——移除上下文里的工具记录与原生元数据
-const handleClearToolHistory = useCallback(() => {
-if (snapshot.isGenerating) {
-onNotice?.("小坊正在执行，完成后再清理。");
-return;
-}
-if (!hasQaToolHistory()) {
-onNotice?.("没有可清理的工具调用历史。");
-return;
-}
-setClearToolsOpen(true);
-}, [snapshot.isGenerating, onNotice]);
+  // 自动滚动：用户上滚阅读时不拉回底部
+  const handleScroll = useCallback(() => {
+    const el = bodyRef.current;
+    if (!el) return;
+    stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  }, []);
 
-const confirmClearToolHistory = useCallback(() => {
-setClearToolsOpen(false);
-const result = clearQaToolHistory();
-onNotice?.(result && result.removed + result.cleaned > 0
-? 已清理 ${result.removed} 条工具记录，整理 ${result.cleaned} 条消息。
-: "没有可清理的工具调用历史。");
-}, [onNotice]);
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (el && stickToBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [messages]);
 
-const toggleWriteMode = useCallback(() => {
-const gh = loadQaGithubConfig();
-if (!gh) return;
-const next = gh.writeMode === "auto" ? "confirm" : "auto";
-saveQaGithubConfig({ ...gh, writeMode: next });
-setWriteMode(next);
-}, []);
+  const autoGrow = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+  }, []);
 
-const activeSession = useMemo(
-() => snapshot.sessions.find((s) => s.id === snapshot.activeSessionId) ?? null,
-[snapshot.sessions, snapshot.activeSessionId],
-);
-const messages = useMemo(() => activeSession?.messages ?? [], [activeSession]);
-const createdContent = useMemo(() => activeSession?.createdContent ?? [], [activeSession]);
-const [previewOpen, setPreviewOpen] = useState(false);
-const [previewItem, setPreviewItem] = useState<QaCreatedContent | null>(null);
-const previewApp = useMemo(
-() => (previewItem?.type === "app" ? getInstalledCustomApp(previewItem.refId) : null),
-[previewItem],
-);
+  const handleSend = useCallback(() => {
+    const text = input.trim();
+    if ((!text && pendingImages.length === 0 && pendingFiles.length === 0) || snapshot.isGenerating) return;
+    setInput("");
+    setAttachMenuOpen(false); // 发送时关闭菜单
+    const images = pendingImages;
+    const files = pendingFiles;
+    setPendingImages([]);
+    setPendingFiles([]);
+    stickToBottomRef.current = true;
+    requestAnimationFrame(autoGrow);
+    void sendQaMessage(text, images.length ? images : undefined, files.length ? files : undefined);
+  }, [input, pendingImages, pendingFiles, snapshot.isGenerating, autoGrow]);
 
-// 自动滚动：用户上滚阅读时不拉回底部
-const handleScroll = useCallback(() => {
-const el = bodyRef.current;
-if (!el) return;
-stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
-}, []);
+  // 附加图片：仅识图已开启的 API 显示入口；读为 dataURL，单张限 4MB
+  const handlePickImages = useCallback((files: FileList | null, isEditMode = false) => {
+    if (!files?.length) return;
+    const setter = isEditMode ? setEditImages : setPendingImages;
+    for (const file of Array.from(files).slice(0, 6)) {
+      if (file.size > 4 * 1024 * 1024) {
+        onNotice?.(`「${file.name}」超过 4MB，已跳过。`);
+        continue;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        const url = typeof reader.result === "string" ? reader.result : "";
+        if (url) setter((current) => (current.length >= 6 ? current : [...current, url]));
+      };
+      reader.readAsDataURL(file);
+    }
+    if (imageInputRef.current) imageInputRef.current.value = "";
+  }, [onNotice]);
 
-useEffect(() => {
-const el = bodyRef.current;
-if (el && stickToBottomRef.current) {
-el.scrollTop = el.scrollHeight;
-}
-}, [messages]);
+  // 附加文本文件
+  const handlePickFiles = useCallback((files: FileList | null, isEditMode = false) => {
+    if (!files?.length) return;
+    const setter = isEditMode ? setEditFiles : setPendingFiles;
+    for (const file of Array.from(files).slice(0, 6)) {
+      if (file.size > 1024 * 1024) { // 纯文本文件限 1MB
+        onNotice?.(`「${file.name}」太大（超过 1MB），请直接粘贴内容。`);
+        continue;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        const content = typeof reader.result === "string" ? reader.result : "";
+        if (content) setter((current) => {
+            if (current.length >= 6 || current.some(f => f.name === file.name)) return current;
+            return [...current, { name: file.name, content }];
+        });
+      };
+      reader.readAsText(file);
+    }
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }, [onNotice]);
 
-const autoGrow = useCallback(() => {
-const el = textareaRef.current;
-if (!el) return;
-el.style.height = "auto";
-el.style.height = ${Math.min(el.scrollHeight, 120)}px;
-}, []);
+  const handleRetry = useCallback((assistantMsgId: string) => {
+    stickToBottomRef.current = true;
+    void retryQaMessage(assistantMsgId);
+  }, []);
 
-const handleSend = useCallback(() => {
-const text = input.trim();
-if ((!text && pendingImages.length === 0 && pendingFiles.length === 0) || snapshot.isGenerating) return;
-setInput("");
-setAttachMenuOpen(false); // 发送时关闭菜单
-const images = pendingImages;
-const files = pendingFiles;
-setPendingImages([]);
-setPendingFiles([]);
-stickToBottomRef.current = true;
-requestAnimationFrame(autoGrow);
-void sendQaMessage(text, images.length ? images : undefined, files.length ? files : undefined);
-}, [input, pendingImages, pendingFiles, snapshot.isGenerating, autoGrow]);
+  const handleCopyMessage = useCallback((content: string) => {
+    void navigator.clipboard?.writeText(content).then(
+      () => onNotice?.("已复制原始内容"),
+      () => onNotice?.("复制失败"),
+    );
+  }, [onNotice]);
 
-// 附加图片：仅识图已开启的 API 显示入口；读为 dataURL，单张限 4MB
-const handlePickImages = useCallback((files: FileList | null, isEditMode = false) => {
-if (!files?.length) return;
-const setter = isEditMode ? setEditImages : setPendingImages;
-for (const file of Array.from(files).slice(0, 6)) {
-if (file.size > 4 * 1024 * 1024) {
-onNotice?.(「${file.name}」超过 4MB，已跳过。);
-continue;
-}
-const reader = new FileReader();
-reader.onload = () => {
-const url = typeof reader.result === "string" ? reader.result : "";
-if (url) setter((current) => (current.length >= 6 ? current : [...current, url]));
-};
-reader.readAsDataURL(file);
-}
-if (imageInputRef.current) imageInputRef.current.value = "";
-}, [onNotice]);
+  const handleEditMessage = useCallback((msg: QaMsg) => {
+    setEditingMsg(msg);
+    setEditText(msg.content);
+    setEditImages(msg.images || []);
+    setEditFiles(msg.files || []);
+  }, []);
 
-// 附加文本文件
-const handlePickFiles = useCallback((files: FileList | null, isEditMode = false) => {
-if (!files?.length) return;
-const setter = isEditMode ? setEditFiles : setPendingFiles;
-for (const file of Array.from(files).slice(0, 6)) {
-if (file.size > 1024 * 1024) { // 纯文本文件限 1MB
-onNotice?.(「${file.name}」太大（超过 1MB），请直接粘贴内容。);
-continue;
-}
-const reader = new FileReader();
-reader.onload = () => {
-const content = typeof reader.result === "string" ? reader.result : "";
-if (content) setter((current) => {
-if (current.length >= 6 || current.some(f => f.name === file.name)) return current;
-return [...current, { name: file.name, content }];
-});
-};
-reader.readAsText(file);
-}
-if (fileInputRef.current) fileInputRef.current.value = "";
-}, [onNotice]);
+  const handleSaveEdit = useCallback((andResend: boolean) => {
+    if (!editingMsg || !snapshot.activeSessionId) return;
+    if (andResend) {
+        editAndResendQaMessage(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
+    } else {
+        updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
+    }
+    setEditingMsg(null);
+    onNotice?.(andResend ? "已提交修改" : "已保存消息内容");
+  }, [editingMsg, editText, editImages, editFiles, snapshot.activeSessionId, onNotice]);
 
-const handleRetry = useCallback((assistantMsgId: string) => {
-stickToBottomRef.current = true;
-void retryQaMessage(assistantMsgId);
-}, []);
+  const streamingMsgId =
+    snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
+      ? messages[messages.length - 1].id
+      : null;
 
-const handleCopyMessage = useCallback((content: string) => {
-void navigator.clipboard?.writeText(content).then(
-() => onNotice?.("已复制原始内容"),
-() => onNotice?.("复制失败"),
-);
-}, [onNotice]);
-
-const handleEditMessage = useCallback((msg: QaMsg) => {
-setEditingMsg(msg);
-setEditText(msg.content);
-setEditImages(msg.images || []);
-setEditFiles(msg.files || []);
-}, []);
-
-const handleSaveEdit = useCallback((andResend: boolean) => {
-if (!editingMsg || !snapshot.activeSessionId) return;
-if (andResend) {
-editAndResendQaMessage(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
-} else {
-updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
-}
-setEditingMsg(null);
-onNotice?.(andResend ? "已提交修改" : "已保存消息内容");
-}, [editingMsg, editText, editImages, editFiles, snapshot.activeSessionId, onNotice]);
-
-const streamingMsgId =
-snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
-? messages[messages.length - 1].id
-: null;
-
-return (
-
-<QaSessionDrawer
-sessions={snapshot.sessions}
-activeId={snapshot.activeSessionId}
-onSelect={(id) => {
-switchQaSession(id);
-setDrawerOpen(false);
-}}
-onDelete={deleteQaSession}
-onCreate={() => {
-createQaSession();
-setDrawerOpen(false);
-}}
-onOpenSettings={() => {
-setSettingsOpen(true);
-setDrawerOpen(false);
-}}
-onRenameRequest={(id, title) => {
-setRenameTarget({ id, title });
-setRenameTitle(title);
-}}
-/>
-<div className={qa-stage ${drawerOpen ? "is-pushed" : ""}}>
-
-
-
-
-
-
-
-
-工坊
-{repoConnected && 已连接仓库}
-
-
-
-
-
-<button type="button" className="qa-icon-btn" onClick={() => setDrawerOpen((v) => !v)} aria-label="对话记录">
-
-
-
-
-
-  <div className="qa-body hide-scrollbar" ref={bodyRef} onScroll={handleScroll} onClick={() => { if (attachMenuOpen) setAttachMenuOpen(false); }}>
-    {messages.length === 0 ? (
-      <div className="qa-welcome">
-        <div className="qa-welcome-badge" aria-hidden>
-          <svg viewBox="0 0 24 24" width="26" height="26">
-            <path d={mdiHammerWrench} fill="currentColor" />
-          </svg>
+  return (
+    <div className="qa-app-shell">
+      <QaSessionDrawer
+        sessions={snapshot.sessions}
+        activeId={snapshot.activeSessionId}
+        onSelect={(id) => {
+          switchQaSession(id);
+          setDrawerOpen(false);
+        }}
+        onDelete={deleteQaSession}
+        onCreate={() => {
+          createQaSession();
+          setDrawerOpen(false);
+        }}
+        onOpenSettings={() => {
+          setSettingsOpen(true);
+          setDrawerOpen(false);
+        }}
+        onRenameRequest={(id, title) => {
+          setRenameTarget({ id, title });
+          setRenameTitle(title);
+        }}
+      />
+      <div className={`qa-stage ${drawerOpen ? "is-pushed" : ""}`}>
+      <div className="qa-ambient" aria-hidden />
+      <header className="qa-header">
+        <div className="qa-header-left">
+          <button type="button" className="qa-icon-btn" onClick={onClose} aria-label="返回">
+            <ChevronLeft size={22} strokeWidth={1.75} />
+          </button>
         </div>
-        <div className="qa-welcome-title">有什么问题？</div>
-        <div className="qa-welcome-sub">
-          我是小坊，工坊的驻场工程师。使用问题、报错排查、部署配置，都可以问我。
-          <br />
-          我还能动手：写小游戏 / APP / 剧场直接装进本机试玩；连接仓库后我会查源码答疑，填了有写权限的 PAT 还能帮你改代码。
-          <br />
-          想创作角色、世界书或美化桌面，找桌面上的小卷更合适。
+        <div className="qa-header-center">
+          <span className="qa-header-title">工坊</span>
+          {repoConnected && <span className="qa-header-sub">已连接仓库</span>}
         </div>
-        {!apiReady && (
-          <div className="qa-welcome-warn">还没有可用的 API：请先到「设置 → API 设置」添加 LLM API。</div>
-        )}
-        <div className="qa-suggestions">
-          {SUGGESTIONS.map((text) => (
-            <button
-              key={text}
-              type="button"
-              className="qa-suggestion"
-              onClick={() => {
-                stickToBottomRef.current = true;
-                void sendQaMessage(text);
-              }}
-            >
-              {text}
-            </button>
-          ))}
-        </div>
-      </div>
-    ) : (
-      <div className="qa-messages">
-        {messages.map((msg) => (
-          <QaMessageItem key={msg.id} msg={msg} isStreaming={msg.id === streamingMsgId} onRetry={handleRetry} onViewImage={setViewerImage} onCopy={handleCopyMessage} onEdit={handleEditMessage} />
-        ))}
-      </div>
-    )}
-  </div>
-
-  <footer className="qa-composer-wrap">
-    <div className={`qa-composer ${snapshot.isGenerating ? "is-generating" : ""}`}>
-      {(pendingImages.length > 0 || pendingFiles.length > 0) && (
-        <div className="qa-attach-strip">
-          {pendingImages.map((url, i) => (
-            <div key={`img-${i}`} className="qa-attach-thumb">
-              <button type="button" className="qa-attach-view" onClick={() => setViewerImage(url)} aria-label="查看图片">
-                <img src={url} alt="" />
-              </button>
-              <button
-                type="button"
-                className="qa-attach-remove"
-                onClick={() => setPendingImages((current) => current.filter((_, idx) => idx !== i))}
-                aria-label="移除图片"
-              >
-                <X size={11} strokeWidth={2.4} />
-              </button>
-            </div>
-          ))}
-          {pendingFiles.map((file, i) => (
-            <div key={`file-${i}`} className="qa-attach-thumb" style={{ background: "rgba(128,128,128,0.2)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px", borderRadius: "12px" }}>
-              <FileText size={16} style={{ minWidth: "16px", marginRight: "4px" }}/>
-              <span style={{ fontSize: "11px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{file.name}</span>
-              <button
-                type="button"
-                className="qa-attach-remove"
-                onClick={() => setPendingFiles((current) => current.filter((_, idx) => idx !== i))}
-                aria-label="移除附件"
-              >
-                <X size={11} strokeWidth={2.4} />
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
-      
-      {/* 在输入框上方的悬浮选择菜单 */}
-      {attachMenuOpen && (
-        <div className="qa-attach-menu" style={{ display: "flex", gap: "8px", padding: "8px 12px 4px 2px", animation: "fadeIn 0.2s" }}>
+        <div className="qa-header-right">
           <button
             type="button"
-            onClick={() => { fileInputRef.current?.click(); setAttachMenuOpen(false); }}
-            style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
+            className="qa-icon-btn"
+            onClick={handleClearToolHistory}
+            aria-label="清理原生tool调用历史（防报错）"
+            title="清理原生tool调用历史——防报错"
           >
-            <Paperclip size={15} strokeWidth={2} /> 上传附件
+            <BrushCleaning size={17} strokeWidth={1.75} />
           </button>
-          {visionEnabled && (
+          <button type="button" className="qa-icon-btn" onClick={() => setDrawerOpen((v) => !v)} aria-label="对话记录">
+            <Menu size={18} strokeWidth={1.75} />
+          </button>
+        </div>
+      </header>
+
+      <div className="qa-body hide-scrollbar" ref={bodyRef} onScroll={handleScroll} onClick={() => { if (attachMenuOpen) setAttachMenuOpen(false); }}>
+        {messages.length === 0 ? (
+          <div className="qa-welcome">
+            <div className="qa-welcome-badge" aria-hidden>
+              <svg viewBox="0 0 24 24" width="26" height="26">
+                <path d={mdiHammerWrench} fill="currentColor" />
+              </svg>
+            </div>
+            <div className="qa-welcome-title">有什么问题？</div>
+            <div className="qa-welcome-sub">
+              我是小坊，工坊的驻场工程师。使用问题、报错排查、部署配置，都可以问我。
+              <br />
+              我还能动手：写小游戏 / APP / 剧场直接装进本机试玩；连接仓库后我会查源码答疑，填了有写权限的 PAT 还能帮你改代码。
+              <br />
+              想创作角色、世界书或美化桌面，找桌面上的小卷更合适。
+            </div>
+            {!apiReady && (
+              <div className="qa-welcome-warn">还没有可用的 API：请先到「设置 → API 设置」添加 LLM API。</div>
+            )}
+            <div className="qa-suggestions">
+              {SUGGESTIONS.map((text) => (
+                <button
+                  key={text}
+                  type="button"
+                  className="qa-suggestion"
+                  onClick={() => {
+                    stickToBottomRef.current = true;
+                    void sendQaMessage(text);
+                  }}
+                >
+                  {text}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="qa-messages">
+            {messages.map((msg) => (
+              <QaMessageItem key={msg.id} msg={msg} isStreaming={msg.id === streamingMsgId} onRetry={handleRetry} onViewImage={setViewerImage} onCopy={handleCopyMessage} onEdit={handleEditMessage} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <footer className="qa-composer-wrap">
+        <div className={`qa-composer ${snapshot.isGenerating ? "is-generating" : ""}`}>
+          {(pendingImages.length > 0 || pendingFiles.length > 0) && (
+            <div className="qa-attach-strip">
+              {pendingImages.map((url, i) => (
+                <div key={`img-${i}`} className="qa-attach-thumb">
+                  <button type="button" className="qa-attach-view" onClick={() => setViewerImage(url)} aria-label="查看图片">
+                    <img src={url} alt="" />
+                  </button>
+                  <button
+                    type="button"
+                    className="qa-attach-remove"
+                    onClick={() => setPendingImages((current) => current.filter((_, idx) => idx !== i))}
+                    aria-label="移除图片"
+                  >
+                    <X size={11} strokeWidth={2.4} />
+                  </button>
+                </div>
+              ))}
+              {pendingFiles.map((file, i) => (
+                <div key={`file-${i}`} className="qa-attach-thumb" style={{ background: "rgba(128,128,128,0.2)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px", borderRadius: "12px" }}>
+                  <FileText size={16} style={{ minWidth: "16px", marginRight: "4px" }}/>
+                  <span style={{ fontSize: "11px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{file.name}</span>
+                  <button
+                    type="button"
+                    className="qa-attach-remove"
+                    onClick={() => setPendingFiles((current) => current.filter((_, idx) => idx !== i))}
+                    aria-label="移除附件"
+                  >
+                    <X size={11} strokeWidth={2.4} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+          
+          {/* 在输入框上方的悬浮选择菜单 */}
+          {attachMenuOpen && (
+            <div className="qa-attach-menu" style={{ display: "flex", gap: "8px", padding: "8px 12px 4px 2px", animation: "fadeIn 0.2s" }}>
+              <button
+                type="button"
+                onClick={() => { fileInputRef.current?.click(); setAttachMenuOpen(false); }}
+                style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
+              >
+                <Paperclip size={15} strokeWidth={2} /> 上传附件
+              </button>
+              {visionEnabled && (
+                <button
+                  type="button"
+                  onClick={() => { imageInputRef.current?.click(); setAttachMenuOpen(false); }}
+                  style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
+                >
+                  <Image size={15} strokeWidth={2} /> 添加图片
+                </button>
+              )}
+            </div>
+          )}
+
+          <textarea
+            ref={textareaRef}
+            className="qa-composer-input hide-scrollbar"
+            placeholder="输入你的问题…"
+            rows={1}
+            value={input}
+            onChange={(e) => {
+              setInput(e.target.value);
+              if (attachMenuOpen) setAttachMenuOpen(false);
+              autoGrow();
+            }}
+            onClick={() => {
+              if (attachMenuOpen) setAttachMenuOpen(false);
+            }}
+          />
+          <div className="qa-composer-toolbar">
+            <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
+                style={{ display: "none" }}
+                onChange={(e) => handlePickFiles(e.target.files)}
+            />
+            {visionEnabled && (
+                <input
+                  ref={imageInputRef}
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  style={{ display: "none" }}
+                  onChange={(e) => handlePickImages(e.target.files)}
+                />
+            )}
+            
+            {/* 统一的附件加号菜单按钮 */}
+            <button
+                type="button"
+                className={`qa-circle-btn qa-attach-btn ${attachMenuOpen ? 'is-active' : ''}`}
+                onClick={() => setAttachMenuOpen((prev) => !prev)}
+                aria-label="添加附件或图片"
+            >
+                <Plus size={17} strokeWidth={2.2} style={{ transform: attachMenuOpen ? 'rotate(45deg)' : 'none', transition: 'transform 0.2s ease-in-out' }} />
+            </button>
+
+            {modelName && <span className="qa-model-pill">{modelName}</span>}
+
+            {repoWritable && (
+              <button type="button" className="qa-mode-pill" onClick={toggleWriteMode}>
+                {writeMode === "auto" ? "全自动" : "确认后提交"}
+              </button>
+            )}
+
+            <div className="qa-composer-spacer" />
+
+            {createdContent.length > 0 && (
+              <button
+                type="button"
+                className="qa-circle-btn qa-preview-btn"
+                onClick={() => setPreviewOpen(true)}
+                aria-label="预览本轮创建的内容"
+              >
+                <Play size={16} />
+              </button>
+            )}
+
             <button
               type="button"
-              onClick={() => { imageInputRef.current?.click(); setAttachMenuOpen(false); }}
-              style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
+              className={`qa-circle-btn qa-github-btn ${repoConnected ? "is-active" : ""}`}
+              onClick={() => setRepoSheetOpen(true)}
+              aria-label="连接仓库"
             >
-              <Image size={15} strokeWidth={2} /> 添加图片
+              <Github size={16} strokeWidth={1.75} />
             </button>
+
+            {snapshot.isGenerating ? (
+              <button type="button" className="qa-circle-btn qa-send-btn is-stop" onClick={stopQaGeneration} aria-label="停止生成">
+                <Square size={14} fill="currentColor" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="qa-circle-btn qa-send-btn"
+                onClick={handleSend}
+                disabled={!input.trim() && pendingImages.length === 0 && pendingFiles.length === 0}
+                aria-label="发送"
+              >
+                <ArrowUp size={20} strokeWidth={2.4} />
+              </button>
+            )}
+          </div>
+          <div
+            className={`qa-context-meter ${snapshot.isCompacting ? "is-compacting" : ""}`}
+            title="上下文用量：满 100% 时自动压缩成摘要并从头累计"
+          >
+            <div className="qa-context-meter-track" aria-hidden>
+              <i style={{ width: `${Math.min(100, Math.round(snapshot.contextUsage * 100))}%` }} />
+            </div>
+            <span className="qa-context-meter-label">
+              {snapshot.isCompacting ? "压缩中" : `${Math.min(999, Math.round(snapshot.contextUsage * 100))}%`}
+            </span>
+          </div>
+        </div>
+      </footer>
+
+      {drawerOpen && (
+        <button
+          type="button"
+          className="qa-stage-scrim"
+          aria-label="关闭对话列表"
+          onClick={() => setDrawerOpen(false)}
+        />
+      )}
+      </div>
+
+      {renameTarget && (
+        <div className="qa-rename-backdrop" role="presentation" onClick={() => setRenameTarget(null)}>
+          <form
+            className="qa-rename-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="qa-rename-dialog-title"
+            onClick={(e) => e.stopPropagation()}
+            onSubmit={(e) => {
+              e.preventDefault();
+              const title = renameTitle.trim();
+              if (!title) return;
+              renameQaSession(renameTarget.id, title);
+              setRenameTarget(null);
+            }}
+          >
+            <div id="qa-rename-dialog-title" className="qa-rename-title">重命名对话</div>
+            <input
+              className="qa-rename-input"
+              autoFocus
+              value={renameTitle}
+              maxLength={80}
+              aria-label="新对话名称"
+              onChange={(e) => setRenameTitle(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Escape") setRenameTarget(null); }}
+            />
+            <div className="qa-rename-actions">
+              <button type="button" className="qa-rename-cancel" onClick={() => setRenameTarget(null)}>取消</button>
+              <button type="submit" className="qa-drawer-new qa-rename-confirm" disabled={!renameTitle.trim()}>确认</button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {clearToolsOpen && (
+        <div className="qa-devnotice-backdrop" onClick={() => setClearToolsOpen(false)}>
+          <div className="qa-devnotice" role="alertdialog" aria-label="清理工具历史确认" onClick={(e) => e.stopPropagation()}>
+            <div className="qa-devnotice-title">清理工具调用历史？</div>
+            <div className="qa-devnotice-text">
+              将移除本会话上下文中的工具调用与工具结果记录，用于修复原生工具协议的报错。普通对话内容不会删除，之前的工具结论仍保留在小坊的回复文字里。
+            </div>
+            <div className="qa-devnotice-actions is-row">
+              <button type="button" className="qa-devnotice-btn" onClick={() => setClearToolsOpen(false)}>
+                取消
+              </button>
+              <button type="button" className="qa-devnotice-btn is-primary" onClick={confirmClearToolHistory}>
+                清理
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {viewerImage && (
+        <div className="qa-image-viewer" role="presentation" onClick={() => setViewerImage(null)}>
+          <img src={viewerImage} alt="" />
+          <button type="button" className="qa-image-viewer-close" aria-label="关闭" onClick={() => setViewerImage(null)}>
+            <X size={20} />
+          </button>
+        </div>
+      )}
+
+      {editingMsg && (
+        <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
+          <div className="qa-edit-dialog" role="dialog" aria-label="修改消息" onClick={(e) => e.stopPropagation()}>
+            <div className="qa-edit-head">
+              <span className="qa-edit-title">修改消息</span>
+              <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
+                <X size={16} />
+              </button>
+            </div>
+            
+            <div style={{ padding: "0 16px 8px 16px" }}>
+                <textarea
+                  className="qa-edit-textarea"
+                  value={editText}
+                  onChange={(e) => setEditText(e.target.value)}
+                  spellCheck={false}
+                  autoFocus
+                  style={{ minHeight: "120px", marginBottom: "8px" }}
+                />
+                
+                <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "8px" }}>
+                    {editImages.map((url, i) => (
+                        <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "4px", overflow: "hidden", border: "1px solid rgba(255,255,255,0.1)" }}>
+                            <img src={url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+                            <button
+                                type="button"
+                                style={{ position: "absolute", top: 0, right: 0, background: "rgba(0,0,0,0.5)", color: "white", border: "none", borderRadius: "0 0 0 4px", cursor: "pointer", padding: "2px" }}
+                                onClick={() => setEditImages(current => current.filter((_, idx) => idx !== i))}
+                            >
+                                <X size={10} />
+                            </button>
+                        </div>
+                    ))}
+                    {editFiles.map((f, i) => (
+                         <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "rgba(255,255,255,0.1)", padding: "4px 20px 4px 8px", borderRadius: "12px", fontSize: "11px", border: "1px solid rgba(255,255,255,0.2)" }}>
+                            <FileText size={12} style={{ marginRight: "4px" }} />
+                            <span style={{ maxWidth: "80px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
+                            <button
+                                type="button"
+                                style={{ position: "absolute", right: "2px", background: "transparent", color: "inherit", border: "none", cursor: "pointer", display: "flex", alignItems: "center" }}
+                                onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}
+                            >
+                                <X size={12} />
+                            </button>
+                        </div>
+                    ))}
+                </div>
+
+                <div style={{ display: "flex", gap: "8px" }}>
+                    <button type="button" className="qa-devnotice-btn" onClick={() => fileInputRef.current?.click()} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
+                        <Paperclip size={12} /> 添加附件
+                    </button>
+                    <button type="button" className="qa-devnotice-btn" onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); }} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
+                        <Plus size={12} /> 添加图片
+                    </button>
+                     <input
+                        ref={imageInputRef}
+                        type="file"
+                        accept="image/*"
+                        multiple
+                        style={{ display: "none" }}
+                        onChange={(e) => {
+                            const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
+                            handlePickImages(e.target.files, isEditMode);
+                            e.target.removeAttribute('data-edit-mode');
+                        }}
+                    />
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
+                        style={{ display: "none" }}
+                        onChange={(e) => handlePickFiles(e.target.files, true)}
+                    />
+                </div>
+            </div>
+            
+            <div className="qa-edit-actions">
+              <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
+                取消
+              </button>
+              <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
+                仅保存
+              </button>
+              <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
+                保存并发送
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {settingsOpen && (
+        <QaSettingsSheet onClose={() => setSettingsOpen(false)} onNotice={onNotice} />
+      )}
+
+      {repoSheetOpen && (
+        <QaRepoSheet onClose={() => setRepoSheetOpen(false)} onSaved={refreshComposerMeta} />
+      )}
+
+      {previewOpen && !previewItem && (
+        <div className="qa-sheet-backdrop" onClick={() => setPreviewOpen(false)}>
+          <div className="qa-sheet qa-preview-sheet" onClick={(e) => e.stopPropagation()}>
+            <div className="qa-sheet-head">
+              <span className="qa-sheet-title">
+                <Play size={16} /> 预览本轮创建
+              </span>
+              <button type="button" className="qa-icon-btn" onClick={() => setPreviewOpen(false)} aria-label="关闭">
+                <X size={16} />
+              </button>
+            </div>
+            <div className="qa-sheet-body">
+              <p className="qa-sheet-note">本次对话里创建/更新的内容，点开直接测试，返回后回到聊天。</p>
+              {createdContent.map((item) => (
+                <button
+                  key={`${item.type}-${item.refId}`}
+                  type="button"
+                  className="qa-preview-item"
+                  onClick={() => setPreviewItem(item)}
+                >
+                  {item.type === "app" ? <AppWindow size={17} /> : item.type === "game" ? <Gamepad2 size={17} /> : <Drama size={17} />}
+                  <span className="qa-preview-item-title">{item.title}</span>
+                  <span className="qa-preview-item-type">
+                    {item.type === "app" ? "应用" : item.type === "game" ? "游戏" : "剧场"}
+                  </span>
+                  <ChevronRight size={15} />
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {previewItem && (
+        <div className="qa-preview-runtime">
+          {previewItem.type === "app" ? (
+            previewApp ? (
+              <CustomAppForegroundBoundary
+                key={previewApp.id}
+                appName={previewApp.name}
+                appId={previewApp.id}
+                appVersion={previewApp.version}
+                manifestId={previewApp.manifest?.id}
+                closeLabel="返回"
+                onClose={() => setPreviewItem(null)}
+              >
+                <CustomAppRunner app={previewApp} onClose={() => setPreviewItem(null)} />
+              </CustomAppForegroundBoundary>
+            ) : (
+              <div className="qa-preview-missing">
+                <p>这个应用已被卸载或找不到了。</p>
+                <button type="button" className="qa-sheet-btn is-primary" onClick={() => setPreviewItem(null)}>
+                  返回
+                </button>
+              </div>
+            )
+          ) : previewItem.type === "game" ? (
+            <GameHubApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
+          ) : (
+            <BlackMarketApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
           )}
         </div>
       )}
-
-      <textarea
-        ref={textareaRef}
-        className="qa-composer-input hide-scrollbar"
-        placeholder="输入你的问题…"
-        rows={1}
-        value={input}
-        onChange={(e) => {
-          setInput(e.target.value);
-          if (attachMenuOpen) setAttachMenuOpen(false);
-          autoGrow();
-        }}
-        onClick={() => {
-          if (attachMenuOpen) setAttachMenuOpen(false);
-        }}
-      />
-      <div className="qa-composer-toolbar">
-        <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
-            style={{ display: "none" }}
-            onChange={(e) => handlePickFiles(e.target.files)}
-        />
-        {visionEnabled && (
-            <input
-              ref={imageInputRef}
-              type="file"
-              accept="image/*"
-              multiple
-              style={{ display: "none" }}
-              onChange={(e) => handlePickImages(e.target.files)}
-            />
-        )}
-        
-        {/* 统一的附件加号菜单按钮 */}
-        <button
-            type="button"
-            className={`qa-circle-btn qa-attach-btn ${attachMenuOpen ? 'is-active' : ''}`}
-            onClick={() => setAttachMenuOpen((prev) => !prev)}
-            aria-label="添加附件或图片"
-        >
-            <Plus size={17} strokeWidth={2.2} style={{ transform: attachMenuOpen ? 'rotate(45deg)' : 'none', transition: 'transform 0.2s ease-in-out' }} />
-        </button>
-
-        {modelName && <span className="qa-model-pill">{modelName}</span>}
-
-        {repoWritable && (
-          <button type="button" className="qa-mode-pill" onClick={toggleWriteMode}>
-            {writeMode === "auto" ? "全自动" : "确认后提交"}
-          </button>
-        )}
-
-        <div className="qa-composer-spacer" />
-
-        {createdContent.length > 0 && (
-          <button
-            type="button"
-            className="qa-circle-btn qa-preview-btn"
-            onClick={() => setPreviewOpen(true)}
-            aria-label="预览本轮创建的内容"
-          >
-            <Play size={16} />
-          </button>
-        )}
-
-        <button
-          type="button"
-          className={`qa-circle-btn qa-github-btn ${repoConnected ? "is-active" : ""}`}
-          onClick={() => setRepoSheetOpen(true)}
-          aria-label="连接仓库"
-        >
-          <Github size={16} strokeWidth={1.75} />
-        </button>
-
-        {snapshot.isGenerating ? (
-          <button type="button" className="qa-circle-btn qa-send-btn is-stop" onClick={stopQaGeneration} aria-label="停止生成">
-            <Square size={14} fill="currentColor" />
-          </button>
-        ) : (
-          <button
-            type="button"
-            className="qa-circle-btn qa-send-btn"
-            onClick={handleSend}
-            disabled={!input.trim() && pendingImages.length === 0 && pendingFiles.length === 0}
-            aria-label="发送"
-          >
-            <ArrowUp size={20} strokeWidth={2.4} />
-          </button>
-        )}
-      </div>
-      <div
-        className={`qa-context-meter ${snapshot.isCompacting ? "is-compacting" : ""}`}
-        title="上下文用量：满 100% 时自动压缩成摘要并从头累计"
-      >
-        <div className="qa-context-meter-track" aria-hidden>
-          <i style={{ width: `${Math.min(100, Math.round(snapshot.contextUsage * 100))}%` }} />
-        </div>
-        <span className="qa-context-meter-label">
-          {snapshot.isCompacting ? "压缩中" : `${Math.min(999, Math.round(snapshot.contextUsage * 100))}%`}
-        </span>
-      </div>
     </div>
-  </footer>
-
-  {drawerOpen && (
-    <button
-      type="button"
-      className="qa-stage-scrim"
-      aria-label="关闭对话列表"
-      onClick={() => setDrawerOpen(false)}
-    />
-  )}
-  </div>
-
-  {renameTarget && (
-    <div className="qa-rename-backdrop" role="presentation" onClick={() => setRenameTarget(null)}>
-      <form
-        className="qa-rename-dialog"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="qa-rename-dialog-title"
-        onClick={(e) => e.stopPropagation()}
-        onSubmit={(e) => {
-          e.preventDefault();
-          const title = renameTitle.trim();
-          if (!title) return;
-          renameQaSession(renameTarget.id, title);
-          setRenameTarget(null);
-        }}
-      >
-        <div id="qa-rename-dialog-title" className="qa-rename-title">重命名对话</div>
-        <input
-          className="qa-rename-input"
-          autoFocus
-          value={renameTitle}
-          maxLength={80}
-          aria-label="新对话名称"
-          onChange={(e) => setRenameTitle(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Escape") setRenameTarget(null); }}
-        />
-        <div className="qa-rename-actions">
-          <button type="button" className="qa-rename-cancel" onClick={() => setRenameTarget(null)}>取消</button>
-          <button type="submit" className="qa-drawer-new qa-rename-confirm" disabled={!renameTitle.trim()}>确认</button>
-        </div>
-      </form>
-    </div>
-  )}
-
-  {clearToolsOpen && (
-    <div className="qa-devnotice-backdrop" onClick={() => setClearToolsOpen(false)}>
-      <div className="qa-devnotice" role="alertdialog" aria-label="清理工具历史确认" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-devnotice-title">清理工具调用历史？</div>
-        <div className="qa-devnotice-text">
-          将移除本会话上下文中的工具调用与工具结果记录，用于修复原生工具协议的报错。普通对话内容不会删除，之前的工具结论仍保留在小坊的回复文字里。
-        </div>
-        <div className="qa-devnotice-actions is-row">
-          <button type="button" className="qa-devnotice-btn" onClick={() => setClearToolsOpen(false)}>
-            取消
-          </button>
-          <button type="button" className="qa-devnotice-btn is-primary" onClick={confirmClearToolHistory}>
-            清理
-          </button>
-        </div>
-      </div>
-    </div>
-  )}
-
-  {viewerImage && (
-    <div className="qa-image-viewer" role="presentation" onClick={() => setViewerImage(null)}>
-      <img src={viewerImage} alt="" />
-      <button type="button" className="qa-image-viewer-close" aria-label="关闭" onClick={() => setViewerImage(null)}>
-        <X size={20} />
-      </button>
-    </div>
-  )}
-
-  {editingMsg && (
-    <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
-      <div className="qa-edit-dialog" role="dialog" aria-label="修改消息" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-edit-head">
-          <span className="qa-edit-title">修改消息</span>
-          <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
-            <X size={16} />
-          </button>
-        </div>
-        
-        <div style={{ padding: "0 16px 8px 16px" }}>
-            <textarea
-              className="qa-edit-textarea"
-              value={editText}
-              onChange={(e) => setEditText(e.target.value)}
-              spellCheck={false}
-              autoFocus
-              style={{ minHeight: "120px", marginBottom: "8px" }}
-            />
-            
-            <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "8px" }}>
-                {editImages.map((url, i) => (
-                    <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "4px", overflow: "hidden", border: "1px solid rgba(255,255,255,0.1)" }}>
-                        <img src={url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
-                        <button
-                            type="button"
-                            style={{ position: "absolute", top: 0, right: 0, background: "rgba(0,0,0,0.5)", color: "white", border: "none", borderRadius: "0 0 0 4px", cursor: "pointer", padding: "2px" }}
-                            onClick={() => setEditImages(current => current.filter((_, idx) => idx !== i))}
-                        >
-                            <X size={10} />
-                        </button>
-                    </div>
-                ))}
-                {editFiles.map((f, i) => (
-                     <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "rgba(255,255,255,0.1)", padding: "4px 20px 4px 8px", borderRadius: "12px", fontSize: "11px", border: "1px solid rgba(255,255,255,0.2)" }}>
-                        <FileText size={12} style={{ marginRight: "4px" }} />
-                        <span style={{ maxWidth: "80px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
-                        <button
-                            type="button"
-                            style={{ position: "absolute", right: "2px", background: "transparent", color: "inherit", border: "none", cursor: "pointer", display: "flex", alignItems: "center" }}
-                            onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}
-                        >
-                            <X size={12} />
-                        </button>
-                    </div>
-                ))}
-            </div>
-
-            <div style={{ display: "flex", gap: "8px" }}>
-                <button type="button" className="qa-devnotice-btn" onClick={() => fileInputRef.current?.click()} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
-                    <Paperclip size={12} /> 添加附件
-                </button>
-                <button type="button" className="qa-devnotice-btn" onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); }} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
-                    <Plus size={12} /> 添加图片
-                </button>
-                 <input
-                    ref={imageInputRef}
-                    type="file"
-                    accept="image/*"
-                    multiple
-                    style={{ display: "none" }}
-                    onChange={(e) => {
-                        const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
-                        handlePickImages(e.target.files, isEditMode);
-                        e.target.removeAttribute('data-edit-mode');
-                    }}
-                />
-                <input
-                    ref={fileInputRef}
-                    type="file"
-                    multiple
-                    accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
-                    style={{ display: "none" }}
-                    onChange={(e) => handlePickFiles(e.target.files, true)}
-                />
-            </div>
-        </div>
-        
-        <div className="qa-edit-actions">
-          <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
-            取消
-          </button>
-          <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
-            仅保存
-          </button>
-          <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
-            保存并发送
-          </button>
-        </div>
-      </div>
-    </div>
-  )}
-
-  {settingsOpen && (
-    <QaSettingsSheet onClose={() => setSettingsOpen(false)} onNotice={onNotice} />
-  )}
-
-  {repoSheetOpen && (
-    <QaRepoSheet onClose={() => setRepoSheetOpen(false)} onSaved={refreshComposerMeta} />
-  )}
-
-  {previewOpen && !previewItem && (
-    <div className="qa-sheet-backdrop" onClick={() => setPreviewOpen(false)}>
-      <div className="qa-sheet qa-preview-sheet" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-sheet-head">
-          <span className="qa-sheet-title">
-            <Play size={16} /> 预览本轮创建
-          </span>
-          <button type="button" className="qa-icon-btn" onClick={() => setPreviewOpen(false)} aria-label="关闭">
-            <X size={16} />
-          </button>
-        </div>
-        <div className="qa-sheet-body">
-          <p className="qa-sheet-note">本次对话里创建/更新的内容，点开直接测试，返回后回到聊天。</p>
-          {createdContent.map((item) => (
-            <button
-              key={`${item.type}-${item.refId}`}
-              type="button"
-              className="qa-preview-item"
-              onClick={() => setPreviewItem(item)}
-            >
-              {item.type === "app" ? <AppWindow size={17} /> : item.type === "game" ? <Gamepad2 size={17} /> : <Drama size={17} />}
-              <span className="qa-preview-item-title">{item.title}</span>
-              <span className="qa-preview-item-type">
-                {item.type === "app" ? "应用" : item.type === "game" ? "游戏" : "剧场"}
-              </span>
-              <ChevronRight size={15} />
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
-  )}
-
-  {previewItem && (
-    <div className="qa-preview-runtime">
-      {previewItem.type === "app" ? (
-        previewApp ? (
-          <CustomAppForegroundBoundary
-            key={previewApp.id}
-            appName={previewApp.name}
-            appId={previewApp.id}
-            appVersion={previewApp.version}
-            manifestId={previewApp.manifest?.id}
-            closeLabel="返回"
-            onClose={() => setPreviewItem(null)}
-          >
-            <CustomAppRunner app={previewApp} onClose={() => setPreviewItem(null)} />
-          </CustomAppForegroundBoundary>
-        ) : (
-          <div className="qa-preview-missing">
-            <p>这个应用已被卸载或找不到了。</p>
-            <button type="button" className="qa-sheet-btn is-primary" onClick={() => setPreviewItem(null)}>
-              返回
-            </button>
-          </div>
-        )
-      ) : previewItem.type === "game" ? (
-        <GameHubApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
-      ) : (
-        <BlackMarketApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
-      )}
-    </div>
-  )}
-</div>
-
-
-);
+  );
 }

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -1396,30 +1396,32 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                         onChange={(e) => handlePickFiles(e.target.files, true)}
                     />
                 </div>
+                
+                {/* 菜单移到这里，取消绝对定位，融入正常排版，自动撑开高度并完美左对齐 */}
+                {editAttachMenuOpen && (
+                    <div style={{ display: "flex", gap: "8px", marginBottom: "8px", animation: "fadeIn 0.2s", whiteSpace: "nowrap" }}>
+                        <button
+                            type="button"
+                            onClick={() => { fileInputRef.current?.click(); setEditAttachMenuOpen(false); }}
+                            style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
+                        >
+                            <Paperclip size={15} strokeWidth={2} /> 上传附件
+                        </button>
+                        {visionEnabled && (
+                            <button
+                                type="button"
+                                onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); setEditAttachMenuOpen(false); }}
+                                style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
+                            >
+                                <Image size={15} strokeWidth={2} /> 添加图片
+                            </button>
+                        )}
+                    </div>
+                )}
             </div>
             
             <div className="qa-edit-actions" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', marginTop: '8px' }}>
                 <div style={{ position: 'relative' }}>
-                    {editAttachMenuOpen && (
-                        <div style={{ position: "absolute", bottom: "100%", left: "0", marginBottom: "4px", display: "flex", gap: "8px", padding: "8px", animation: "fadeIn 0.2s", whiteSpace: "nowrap" }}>
-                            <button
-                                type="button"
-                                onClick={() => { fileInputRef.current?.click(); setEditAttachMenuOpen(false); }}
-                                style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
-                            >
-                                <Paperclip size={15} strokeWidth={2} /> 上传附件
-                            </button>
-                            {visionEnabled && (
-                                <button
-                                    type="button"
-                                    onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); setEditAttachMenuOpen(false); }}
-                                    style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
-                                >
-                                    <Image size={15} strokeWidth={2} /> 添加图片
-                                </button>
-                            )}
-                        </div>
-                    )}
                     <button
                         type="button"
                         onClick={() => setEditAttachMenuOpen(prev => !prev)}
@@ -1447,7 +1449,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                         type="button" 
                         className="qa-devnotice-btn" 
                         onClick={() => handleSaveEdit(false)}
-                        style={{ whiteSpace: 'nowrap', padding: '0 16px' }}
+                        style={{ whiteSpace: 'nowrap', padding: '0 24px', borderRadius: '8px' }}
                     >
                         保存
                     </button>
@@ -1455,7 +1457,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                         type="button" 
                         className="qa-devnotice-btn is-primary" 
                         onClick={() => handleSaveEdit(true)}
-                        style={{ whiteSpace: 'nowrap', padding: '0 16px' }}
+                        style={{ whiteSpace: 'nowrap', padding: '0 24px', borderRadius: '8px' }}
                     >
                         保存并发送
                     </button>

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -259,7 +259,7 @@ function QaToolRow({ tool }: { tool: QaToolStatus }) {
 // 低端机 WebView OOM 崩溃的主因（几万字 × 每秒多次解析）。文本不变就不重渲。
 const QaMarkdownBlock = memo(function QaMarkdownBlock({ text }: { text: string }) {
   return (
-    <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={QA_MARKDOWN_COMPONENTS}>
+    <ReactMarkdown components={QA_MARKDOWN_COMPONENTS}>
       {text}
     </ReactMarkdown>
   );
@@ -274,15 +274,6 @@ function QaStreamingText({ text }: { text: string }) {
     </>
   );
 }
-
-const QaMarkdownBlock = memo(function QaMarkdownBlock({ text }: { text: string }) {
-  return (
-    <ReactMarkdown components={QA_MARKDOWN_COMPONENTS}>
-      {text}
-    </ReactMarkdown>
-  );
-});
-
 
 const QaMessageItem = memo(function QaMessageItem({
   msg,

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -1469,4 +1469,3 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
     </div>
   );
 }
-```eof

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -1,1426 +1,1428 @@
 "use client";
 
-import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, FileText, Gamepad2, Github, Loader2, Menu, MoreVertical, Pencil, Pin, PinOff, Play, Plus, Square, Trash2, Wrench, X } from "lucide-react";
-
-// mock missing components and libs
-const QaFileCard = ({ file }: any) => <div className="qa-file-card">{file.name}</div>;
-const parseQaFileMarker = (text: string) => ({ text, file: null });
-const mdiHammerWrench = "M13.78 15.3L19.78 21.3L21.89 19.14L15.89 13.14L13.78 15.3M17.5 10.1C17.11 10.1 16.73 10.15 16.38 10.27L14.7 8.59L15.27 7.5L12 4.25L10.33 6H7.95L5.78 3.83L4.2 5.41L6.37 7.58V10.13L4.54 11.5L5.61 12.07L7.3 13.75C7.18 14.1 7.12 14.47 7.12 14.86C7.12 17.73 9.46 20.07 12.33 20.07C13.2 20.07 14.03 19.85 14.73 19.46L16.42 21.15L18.58 18.97L16.9 17.29C17.29 16.59 17.5 15.76 17.5 14.86C17.5 14.54 17.47 14.23 17.41 13.93L19.64 11.7L18.55 10.63L17.18 12.44C16.89 12.22 16.58 12.04 16.24 11.91L17.33 10.82C17.38 10.58 17.5 10.35 17.5 10.1Z";
-const CustomAppRunner = () => <div>App Runner</div>;
-const CustomAppForegroundBoundary = ({ children }: any) => <>{children}</>;
-const GameHubApp = () => <div>Game Hub</div>;
-const BlackMarketApp = () => <div>Black Market</div>;
-const getInstalledCustomApp = (id: string) => null;
-// mock chat store
-const applyQaCommit = async () => {};
-const cancelQaCommit = () => {};
-const clearQaToolHistory = () => ({ removed: 0, cleaned: 0 });
-const createQaSession = () => "session-1";
-const deleteQaSession = () => {};
-const getQaActiveContextChars = () => 0;
-const getQaChatSnapshot = () => ({ sessions: [], activeSessionId: null, hydrated: true, isGenerating: false, contextUsage: 0, isCompacting: false });
-const getQaContextBudgetChars = () => 100000;
-const hasQaToolHistory = () => false;
-const hydrateQaChat = async () => {};
-const QA_CONTEXT_BUDGET_MAX = 2000000;
-const QA_CONTEXT_BUDGET_MIN = 2000;
-const QA_DEFAULT_CONTEXT_BUDGET_CHARS = 1000000;
-const setQaContextBudgetChars = () => {};
-const retryQaMessage = async () => {};
-const renameQaSession = () => {};
-const revertQaAppliedCommit = async () => {};
-const sendQaMessage = async () => {};
-const stopQaGeneration = () => {};
-const subscribeQaChat = () => () => {};
-const switchQaSession = () => {};
-const toggleQaSessionPin = () => {};
-const updateQaMessageContent = () => {};
-const editAndResendQaMessage = async () => {};
-type QaMsg = any;
-type QaSession = any;
-type QaToolStatus = any;
-type QaCreatedContent = any;
-// mock prefs
-const getQaPageChars = () => 4000;
-const setQaPageChars = () => {};
-const QA_DEFAULT_PAGE_CHARS = 4000;
-const QA_PAGE_CHARS_MIN = 1000;
-const QA_PAGE_CHARS_MAX = 30000;
-const getQaMaxRounds = () => 5;
-const setQaMaxRounds = () => {};
-const QA_DEFAULT_MAX_ROUNDS = 5;
-const QA_MAX_ROUNDS_MIN = 1;
-const QA_MAX_ROUNDS_MAX = 30;
-const getQaMaxOutputTokens = () => 4000;
-const setQaMaxOutputTokens = () => {};
-const QA_DEFAULT_MAX_OUTPUT_TOKENS = 4000;
-const QA_MAX_OUTPUT_TOKENS_MIN = 500;
-const QA_MAX_OUTPUT_TOKENS_MAX = 100000;
-// mock agent engine
-const resolveQaApiConfig = () => ({ defaultModel: "mock-model", enableImageRecognition: true });
-// mock github
-const loadQaGithubConfig = () => null;
-const saveQaGithubConfig = () => {};
-const clearQaGithubConfig = () => {};
-const validateQaGithubConfig = async () => ({ ok: true });
-type QaGithubConfig = any;
-type QaGithubValidation = any;
+import { QaFileCard } from "@/components/qa-file-card";
+import { parseQaFileMarker } from "@/lib/qa-computer-tools";
+import { mdiHammerWrench } from "@mdi/js";
+import { CustomAppRunner } from "@/components/app-market/custom-app-runner";
+import { CustomAppForegroundBoundary } from "@/components/app-market/custom-app-failure";
+import { GameHubApp } from "@/components/game/game-hub-app";
+import { BlackMarketApp } from "@/components/shopping/black-market-app";
+import { getInstalledCustomApp } from "@/lib/custom-app-storage";
+import type { QaCreatedContent } from "@/lib/qa-agent-tools";
+import {
+applyQaCommit,
+cancelQaCommit,
+clearQaToolHistory,
+createQaSession,
+deleteQaSession,
+getQaActiveContextChars,
+getQaChatSnapshot,
+getQaContextBudgetChars,
+hasQaToolHistory,
+hydrateQaChat,
+QA_CONTEXT_BUDGET_MAX,
+QA_CONTEXT_BUDGET_MIN,
+QA_DEFAULT_CONTEXT_BUDGET_CHARS,
+setQaContextBudgetChars,
+retryQaMessage,
+renameQaSession,
+revertQaAppliedCommit,
+sendQaMessage,
+stopQaGeneration,
+subscribeQaChat,
+switchQaSession,
+toggleQaSessionPin,
+updateQaMessageContent,
+editAndResendQaMessage,
+type QaMsg,
+type QaSession,
+type QaToolStatus,
+} from "@/lib/qa-chat-store";
+import {
+getQaPageChars,
+setQaPageChars,
+QA_DEFAULT_PAGE_CHARS,
+QA_PAGE_CHARS_MIN,
+QA_PAGE_CHARS_MAX,
+getQaMaxRounds,
+setQaMaxRounds,
+QA_DEFAULT_MAX_ROUNDS,
+QA_MAX_ROUNDS_MIN,
+QA_MAX_ROUNDS_MAX,
+getQaMaxOutputTokens,
+setQaMaxOutputTokens,
+QA_DEFAULT_MAX_OUTPUT_TOKENS,
+QA_MAX_OUTPUT_TOKENS_MIN,
+QA_MAX_OUTPUT_TOKENS_MAX,
+} from "@/lib/qa-prefs";
+import { resolveQaApiConfig } from "@/lib/qa-agent-engine";
+import {
+loadQaGithubConfig,
+saveQaGithubConfig,
+clearQaGithubConfig,
+validateQaGithubConfig,
+type QaGithubConfig,
+type QaGithubValidation,
+} from "@/lib/qa-github";
+import "@/lib/qa-error-log";
 
 type PhoneQaAppProps = {
-  onClose: () => void;
-  onNotice?: (msg: string) => void;
+onClose: () => void;
+onNotice?: (msg: string) => void;
 };
 
 const SUGGESTIONS = [
-  "怎么添加我的 API？",
-  "聊天没有回复怎么排查？",
-  "怎么部署到 Netlify / Vercel？",
-  "数据存在哪里，怎么备份？",
-  "帮我写个小游戏装到本机",
+"怎么添加我的 API？",
+"聊天没有回复怎么排查？",
+"怎么部署到 Netlify / Vercel？",
+"数据存在哪里，怎么备份？",
+"帮我写个小游戏装到本机",
 ];
 
 function formatRelativeTime(ts: number): string {
-  const diff = Date.now() - ts;
-  if (diff < 60_000) return "刚刚";
-  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟前`;
-  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前`;
-  return `${Math.floor(diff / 86_400_000)} 天前`;
+const diff = Date.now() - ts;
+if (diff < 60_000) return "刚刚";
+if (diff < 3_600_000) return ${Math.floor(diff / 60_000)} 分钟前;
+if (diff < 86_400_000) return ${Math.floor(diff / 3_600_000)} 小时前;
+return ${Math.floor(diff / 86_400_000)} 天前;
 }
 
 // ── 代码块（语言标签 + 一键复制）─────────────────────
 
 function QaCodeBlock({ className, children }: { className?: string; children?: React.ReactNode }) {
-  const [copied, setCopied] = useState(false);
-  const language = /language-(\w+)/.exec(className || "")?.[1] ?? "";
-  const code = String(children ?? "").replace(/\n$/, "");
+const [copied, setCopied] = useState(false);
+const language = /language-(\w+)/.exec(className || "")?.[1] ?? "";
+const code = String(children ?? "").replace(/\n$/, "");
 
-  const handleCopy = useCallback(() => {
-    navigator.clipboard
-      ?.writeText(code)
-      .then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      })
-      .catch(() => {});
-  }, [code]);
+const handleCopy = useCallback(() => {
+navigator.clipboard
+?.writeText(code)
+.then(() => {
+setCopied(true);
+setTimeout(() => setCopied(false), 1500);
+})
+.catch(() => {});
+}, [code]);
 
-  return (
-    <div className="qa-codeblock">
-      <div className="qa-codeblock-head">
-        <span className="qa-codeblock-lang">{language || "code"}</span>
-        <button type="button" className="qa-codeblock-copy" onClick={handleCopy} aria-label="复制代码">
-          {copied ? <Check size={13} /> : <Copy size={13} />}
-        </button>
-      </div>
-      <pre>
-        <code>{code}</code>
-      </pre>
-    </div>
-  );
+return (
+
+
+{language || "code"}
+
+{copied ?  : }
+
+
+
+{code}
+
+
+);
 }
 
 const QA_MARKDOWN_COMPONENTS = {
-  pre({ children }: { children?: React.ReactNode }) {
-    return <>{children}</>;
-  },
-  code(props: { className?: string; children?: React.ReactNode }) {
-    const { className, children } = props;
-    const isBlock = /language-/.test(className || "") || String(children ?? "").includes("\n");
-    if (isBlock) return <QaCodeBlock className={className}>{children}</QaCodeBlock>;
-    return <code className="qa-inline-code">{children}</code>;
-  },
-  a({ href, children }: { href?: string; children?: React.ReactNode }) {
-    return (
-      <a href={href} target="_blank" rel="noreferrer noopener">
-        {children}
-      </a>
-    );
-  },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+pre({ children }: { children?: React.ReactNode }) {
+return <>{children}</>;
+},
+code(props: { className?: string; children?: React.ReactNode }) {
+const { className, children } = props;
+const isBlock = /language-/.test(className || "") || String(children ?? "").includes("\n");
+if (isBlock) return {children};
+return {children};
+},
+a({ href, children }: { href?: string; children?: React.ReactNode }) {
+return (
+
+{children}
+
+);
+},
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any;
 
 // ── 提交提案卡片 ─────────────────────────────────────
 
 function QaCommitCard({ msg }: { msg: QaMsg }) {
-  const pending = msg.pendingCommit;
-  const [busy, setBusy] = useState(false);
-  if (!pending) return null;
-  const { proposal, status, result, error } = pending;
-  const files = proposal.files;
+const pending = msg.pendingCommit;
+const [busy, setBusy] = useState(false);
+if (!pending) return null;
+const { proposal, status, result, error } = pending;
+const files = proposal.files;
 
-  const apply = async () => {
-    setBusy(true);
-    await applyQaCommit(msg.id);
-    setBusy(false);
-  };
-  const revert = async () => {
-    setBusy(true);
-    await revertQaAppliedCommit(msg.id);
-    setBusy(false);
-  };
+const apply = async () => {
+setBusy(true);
+await applyQaCommit(msg.id);
+setBusy(false);
+};
+const revert = async () => {
+setBusy(true);
+await revertQaAppliedCommit(msg.id);
+setBusy(false);
+};
 
-  return (
-    <div className={`qa-commit-card status-${status}`}>
-      <div className="qa-commit-head">
-        <span className="qa-commit-title">
-          {status === "applied" ? "已提交" : status === "reverted" ? "已撤销" : status === "canceled" ? "已取消" : "修改提案"}
-        </span>
-        <span className="qa-commit-branch">{proposal.branch || "默认分支"} · {files.length + (proposal.deletes?.length ?? 0)} 个文件</span>
-      </div>
-      <div className="qa-commit-msg">{proposal.message}</div>
-      <ul className="qa-commit-files">
-        {files.map((f) => (
-          <li key={f.path}>{f.path}</li>
-        ))}
-        {(proposal.deletes ?? []).map((path) => (
-          <li key={`del-${path}`} className="qa-commit-file-delete">− {path}（删除）</li>
-        ))}
-      </ul>
-      {error && <div className="qa-commit-error">{error}</div>}
-      {status === "pending" && (
-        <div className="qa-commit-actions">
-          <button type="button" className="qa-commit-btn is-primary" onClick={apply} disabled={busy}>
-            {busy ? <Loader2 size={13} className="qa-spin" /> : "应用"}
-          </button>
-          <button type="button" className="qa-commit-btn" onClick={() => cancelQaCommit(msg.id)} disabled={busy}>
-            取消
-          </button>
-        </div>
-      )}
-      {(status === "applying" || status === "reverting") && (
-        <div className="qa-commit-actions">
-          <span className="qa-commit-progress">
-            <Loader2 size={13} className="qa-spin" /> {status === "applying" ? "提交中…" : "撤销中…"}
-          </span>
-        </div>
-      )}
-      {status === "applied" && result && (
-        <div className="qa-commit-actions">
-          <a className="qa-commit-link" href={result.htmlUrl} target="_blank" rel="noreferrer noopener">
-            查看 commit {result.sha.slice(0, 7)}
-          </a>
-          <button type="button" className="qa-commit-btn is-danger" onClick={revert} disabled={busy}>
-            撤销
-          </button>
-        </div>
-      )}
-    </div>
-  );
+return (
+<div className={qa-commit-card status-${status}}>
+
+
+{status === "applied" ? "已提交" : status === "reverted" ? "已撤销" : status === "canceled" ? "已取消" : "修改提案"}
+
+{proposal.branch || "默认分支"} · {files.length + (proposal.deletes?.length ?? 0)} 个文件
+
+{proposal.message}
+
+{files.map((f) => (
+{f.path}
+))}
+{(proposal.deletes ?? []).map((path) => (
+<li key={del-${path}} className="qa-commit-file-delete">− {path}（删除）
+))}
+
+{error && {error}}
+{status === "pending" && (
+
+
+{busy ?  : "应用"}
+
+<button type="button" className="qa-commit-btn" onClick={() => cancelQaCommit(msg.id)} disabled={busy}>
+取消
+
+
+)}
+{(status === "applying" || status === "reverting") && (
+
+
+ {status === "applying" ? "提交中…" : "撤销中…"}
+
+
+)}
+{status === "applied" && result && (
+
+
+查看 commit {result.sha.slice(0, 7)}
+
+
+撤销
+
+
+)}
+
+);
 }
 
 // ── 消息渲染 ─────────────────────────────────────────
 
-// 工具调用行：折叠的单行摘要，点开展开参数与结果（Claude Code 风格）
+// 工具调用行：折叠的单行摘要，点开展开参数与结果
 function QaToolRow({ tool }: { tool: QaToolStatus }) {
-  const [open, setOpen] = useState(false);
-  // 「电脑文件 op=send」的结果里带文件卡标记：卡片常显，标记从结果文本中剥离
-  const { text: resultText, file } = parseQaFileMarker(tool.result || "");
-  const hasDetail = Boolean(tool.detail || resultText);
-  const summary = tool.running ? `正在${tool.name}…` : tool.success === false ? `${tool.name}失败` : tool.name;
-  return (
-    <div className={`qa-tool-row ${tool.running ? "is-running" : tool.success === false ? "is-fail" : "is-done"}`}>
-      <button
-        type="button"
-        className="qa-tool-row-head"
-        onClick={() => hasDetail && setOpen((v) => !v)}
-        disabled={!hasDetail}
-      >
-        {tool.running ? <Loader2 size={13} className="qa-spin" /> : <Wrench size={13} />}
-        <span className="qa-tool-row-summary">
-          {summary}
-          {tool.subtitle && <span className="qa-tool-row-sub">{tool.subtitle}</span>}
-        </span>
-        {hasDetail && <ChevronRight size={14} className={`qa-tool-row-chevron ${open ? "is-open" : ""}`} />}
-      </button>
-      {open && hasDetail && (
-        <div className="qa-tool-row-body">
-          {tool.detail && (
-            <>
-              <div className="qa-tool-row-label">参数</div>
-              <pre className="qa-tool-row-pre">{tool.detail}</pre>
-            </>
-          )}
-          {resultText && (
-            <>
-              <div className="qa-tool-row-label">结果</div>
-              <pre className="qa-tool-row-pre">{resultText}</pre>
-            </>
-          )}
-        </div>
-      )}
-      {file && <QaFileCard file={file} />}
-    </div>
-  );
+const [open, setOpen] = useState(false);
+const { text: resultText, file } = parseQaFileMarker(tool.result || "");
+const hasDetail = Boolean(tool.detail || resultText);
+const summary = tool.running ? 正在${tool.name}… : tool.success === false ? ${tool.name}失败 : tool.name;
+return (
+<div className={qa-tool-row ${tool.running ? "is-running" : tool.success === false ? "is-fail" : "is-done"}}>
+<button
+type="button"
+className="qa-tool-row-head"
+onClick={() => hasDetail && setOpen((v) => !v)}
+disabled={!hasDetail}
+>
+{tool.running ?  : }
+
+{summary}
+{tool.subtitle && {tool.subtitle}}
+
+{hasDetail && <ChevronRight size={14} className={qa-tool-row-chevron ${open ? "is-open" : ""}} />}
+
+{open && hasDetail && (
+
+{tool.detail && (
+<>
+参数
+{tool.detail}
+</>
+)}
+{resultText && (
+<>
+结果
+{resultText}
+</>
+)}
+
+)}
+{file && }
+
+);
 }
 
-// 已完成文本的 Markdown 渲染：memo 缓存——流式期间每次增量都全文重排 remark 是
-// 低端机 WebView OOM 崩溃的主因（几万字 × 每秒多次解析）。文本不变就不重渲。
+// 已完成文本的 Markdown 渲染：memo 缓存，流式期间不再重复渲染全文以避免 OOM
 const QaMarkdownBlock = memo(function QaMarkdownBlock({ text }: { text: string }) {
-  return (
-    <ReactMarkdown components={QA_MARKDOWN_COMPONENTS}>
-      {text}
-    </ReactMarkdown>
-  );
+return (
+
+{text}
+
+);
 });
 
 // 正在生长的活跃段：纯文本渲染（零解析成本），生成结束后换回完整 Markdown
 function QaStreamingText({ text }: { text: string }) {
-  return (
-    <>
-      <div className="qa-stream-text">{text}</div>
-      <span className="qa-cursor" />
-    </>
-  );
+return (
+<>
+{text}
+
+</>
+);
 }
 
 const QaMessageItem = memo(function QaMessageItem({
-  msg,
-  isStreaming,
-  onRetry,
-  onViewImage,
-  onCopy,
-  onEdit,
+msg,
+isStreaming,
+onRetry,
+onViewImage,
+onCopy,
+onEdit,
 }: {
-  msg: QaMsg;
-  isStreaming: boolean;
-  onRetry: (id: string) => void;
-  onViewImage: (url: string) => void;
-  onCopy: (content: string) => void;
-  onEdit: (msg: QaMsg) => void;
+msg: QaMsg;
+isStreaming: boolean;
+onRetry: (id: string) => void;
+onViewImage: (url: string) => void;
+onCopy: (content: string) => void;
+onEdit: (msg: QaMsg) => void;
 }) {
-  const thinkingOnly = isStreaming && !msg.content && (!msg.tools || msg.tools.length === 0);
-  const showActions = !isStreaming && !thinkingOnly;
-  const msgWrap = (node: ReactNode) => (
-    <div className="qa-msg-wrap">
-      {node}
-      {showActions && (
-        <div className="qa-msg-actions" data-role={msg.role}>
-          <button type="button" className="qa-msg-action" aria-label="复制原始内容" title="复制" onClick={() => onCopy(msg.content)}>
-            <Copy size={14} strokeWidth={2} />
-          </button>
-          <button type="button" className="qa-msg-action" aria-label="编辑原始内容" title="编辑" onClick={() => onEdit(msg)}>
-            <Pencil size={14} strokeWidth={2} />
-          </button>
-        </div>
-      )}
-    </div>
-  );
+const thinkingOnly = isStreaming && !msg.content && (!msg.tools || msg.tools.length === 0);
+const showActions = !isStreaming && !thinkingOnly;
+const msgWrap = (node: ReactNode) => (
 
-  const segmentBlocks = useMemo(() => {
-    if (!msg.segments?.length) return null;
-    const blocks: Array<{ kind: "text"; text: string } | { kind: "tools"; tools: QaToolStatus[] }> = [];
-    for (const seg of msg.segments) {
-      const last = blocks[blocks.length - 1];
-      if (seg.kind === "tool") {
-        if (last?.kind === "tools") last.tools.push(seg.tool);
-        else blocks.push({ kind: "tools", tools: [seg.tool] });
-      } else if (seg.text.trim()) {
-        if (last?.kind === "text") last.text += seg.text;
-        else blocks.push({ kind: "text", text: seg.text });
-      }
-    }
-    return blocks.length ? blocks : null;
-  }, [msg.segments]);
+{node}
+{showActions && (
 
-  if (msg.role === "user") {
-    return msgWrap(
-      <div className="qa-msg-user-row">
-        <div className="qa-msg-user">
-          {msg.images && msg.images.length > 0 && (
-            <div className="qa-msg-images">
-              {msg.images.map((url, i) => (
-                <button key={i} type="button" className="qa-msg-image" onClick={() => onViewImage(url)} aria-label="查看图片">
-                  <img src={url} alt="" />
-                </button>
-              ))}
-            </div>
-          )}
-          {msg.files && msg.files.length > 0 && (
-            <div className="qa-msg-files" style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '8px' }}>
-              {msg.files.map((file, i) => (
-                <div key={i} className="qa-msg-file" style={{ display: 'flex', alignItems: 'center', gap: '6px', background: 'rgba(255,255,255,0.15)', padding: '6px 10px', borderRadius: '6px', fontSize: '13px', border: '1px solid rgba(255,255,255,0.1)' }}>
-                  <FileText size={15} style={{ opacity: 0.8 }} />
-                  <span style={{ maxWidth: '160px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{file.name}</span>
-                </div>
-              ))}
-            </div>
-          )}
-          {msg.content}
-        </div>
-      </div>,
-    );
-  }
+<button type="button" className="qa-msg-action" aria-label="复制原始内容" title="复制" onClick={() => onCopy(msg.content)}>
 
-  return msgWrap(
-    <div className="qa-msg-assistant">
-      {segmentBlocks ? (
-        segmentBlocks.map((block, i) =>
-          block.kind === "tools" ? (
-            <div className="qa-tools" key={i}>
-              {block.tools.map((tool, j) => (
-                <QaToolRow key={`${tool.name}-${j}`} tool={tool} />
-              ))}
-            </div>
-          ) : isStreaming && i === segmentBlocks.length - 1 ? (
-            <div className="qa-markdown" key={i}>
-              <QaStreamingText text={block.text} />
-            </div>
-          ) : (
-            <div className="qa-markdown" key={i}>
-              <QaMarkdownBlock text={block.text} />
-            </div>
-          ),
-        )
-      ) : (
-        <>
-          {msg.tools && msg.tools.length > 0 && (
-            <div className="qa-tools">
-              {msg.tools.map((tool, i) => (
-                <QaToolRow key={`${tool.name}-${i}`} tool={tool} />
-              ))}
-            </div>
-          )}
-          {thinkingOnly ? (
-            <div className="qa-thinking">{msg.toolDrafting ? "正在编写工具调用…" : msg.reasoning ? "正在思考…" : "正在生成…"}</div>
-          ) : isStreaming ? (
-            <div className="qa-markdown">
-              <QaStreamingText text={msg.content} />
-            </div>
-          ) : (
-            <div className="qa-markdown">
-              <QaMarkdownBlock text={msg.content} />
-            </div>
-          )}
-        </>
-      )}
-      {isStreaming && msg.toolDrafting && !thinkingOnly && (
-        <div className="qa-thinking qa-tool-drafting">正在编写工具调用…</div>
-      )}
-      {msg.streamNote && <div className="qa-msg-note">{msg.streamNote}</div>}
-      {msg.pendingCommit && <QaCommitCard msg={msg} />}
-      {msg.aborted && <div className="qa-msg-note">已停止生成</div>}
-      {msg.error && (
-        <div className="qa-msg-error">
-          <div className="qa-msg-error-text">{msg.error}</div>
-          <button type="button" className="qa-retry-btn" onClick={() => onRetry(msg.id)}>
-            重试
-          </button>
-        </div>
-      )}
-    </div>,
-  );
+
+<button type="button" className="qa-msg-action" aria-label="编辑原始内容" title="编辑" onClick={() => onEdit(msg)}>
+
+
+
+)}
+
+);
+
+const segmentBlocks = useMemo(() => {
+if (!msg.segments?.length) return null;
+const blocks: Array<{ kind: "text"; text: string } | { kind: "tools"; tools: QaToolStatus[] }> = [];
+for (const seg of msg.segments) {
+const last = blocks[blocks.length - 1];
+if (seg.kind === "tool") {
+if (last?.kind === "tools") last.tools.push(seg.tool);
+else blocks.push({ kind: "tools", tools: [seg.tool] });
+} else if (seg.text.trim()) {
+if (last?.kind === "text") last.text += seg.text;
+else blocks.push({ kind: "text", text: seg.text });
+}
+}
+return blocks.length ? blocks : null;
+}, [msg.segments]);
+
+if (msg.role === "user") {
+return msgWrap(
+
+
+{msg.images && msg.images.length > 0 && (
+
+{msg.images.map((url, i) => (
+<button key={i} type="button" className="qa-msg-image" onClick={() => onViewImage(url)} aria-label="查看图片">
+
+
+))}
+
+)}
+{msg.files && msg.files.length > 0 && (
+<div className="qa-msg-files" style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '8px' }}>
+{msg.files.map((file, i) => (
+<div key={i} className="qa-msg-file" style={{ display: 'flex', alignItems: 'center', gap: '6px', background: 'rgba(255,255,255,0.15)', padding: '6px 10px', borderRadius: '6px', fontSize: '13px', border: '1px solid rgba(255,255,255,0.1)' }}>
+<FileText size={15} style={{ opacity: 0.8 }} />
+<span style={{ maxWidth: '160px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{file.name}
+
+))}
+
+)}
+{msg.content}
+
+,
+);
+}
+
+return msgWrap(
+
+{segmentBlocks ? (
+segmentBlocks.map((block, i) =>
+block.kind === "tools" ? (
+
+{block.tools.map((tool, j) => (
+<QaToolRow key={${tool.name}-${j}} tool={tool} />
+))}
+
+) : isStreaming && i === segmentBlocks.length - 1 ? (
+
+
+
+) : (
+
+
+
+),
+)
+) : (
+<>
+{msg.tools && msg.tools.length > 0 && (
+
+{msg.tools.map((tool, i) => (
+<QaToolRow key={${tool.name}-${i}} tool={tool} />
+))}
+
+)}
+{thinkingOnly ? (
+{msg.toolDrafting ? "正在编写工具调用…" : msg.reasoning ? "正在思考…" : "正在生成…"}
+) : isStreaming ? (
+
+
+
+) : (
+
+
+
+)}
+</>
+)}
+{isStreaming && msg.toolDrafting && !thinkingOnly && (
+正在编写工具调用…
+)}
+{msg.streamNote && {msg.streamNote}}
+{msg.pendingCommit && }
+{msg.aborted && 已停止生成}
+{msg.error && (
+
+{msg.error}
+<button type="button" className="qa-retry-btn" onClick={() => onRetry(msg.id)}>
+重试
+
+
+)}
+,
+);
 });
 
 // ── 会话抽屉 ─────────────────────────────────────────
 
 function QaSessionDrawer({
-  sessions,
-  activeId,
-  onSelect,
-  onDelete,
-  onCreate,
-  onOpenSettings,
-  onRenameRequest,
+sessions,
+activeId,
+onSelect,
+onDelete,
+onCreate,
+onOpenSettings,
+onRenameRequest,
 }: {
-  sessions: QaSession[];
-  activeId: string | null;
-  onSelect: (id: string) => void;
-  onDelete: (id: string) => void;
-  onCreate: () => void;
-  onOpenSettings: () => void;
-  onRenameRequest: (id: string, title: string) => void;
+sessions: QaSession[];
+activeId: string | null;
+onSelect: (id: string) => void;
+onDelete: (id: string) => void;
+onCreate: () => void;
+onOpenSettings: () => void;
+onRenameRequest: (id: string, title: string) => void;
 }) {
-  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 
-  const sortedSessions = useMemo(() => {
-    return [...sessions].sort((a, b) => {
-      if (Boolean(a.isPinned) !== Boolean(b.isPinned)) return a.isPinned ? -1 : 1;
-      return b.updatedAt - a.updatedAt;
-    });
-  }, [sessions]);
+const sortedSessions = useMemo(() => {
+return [...sessions].sort((a, b) => {
+if (Boolean(a.isPinned) !== Boolean(b.isPinned)) return a.isPinned ? -1 : 1;
+return b.updatedAt - a.updatedAt;
+});
+}, [sessions]);
 
-  return (
-    <aside className="qa-drawer">
-      <div className="qa-drawer-head">
-        <span className="qa-drawer-title">对话记录</span>
-      </div>
-      <div
-        className="qa-drawer-list hide-scrollbar"
-        onClick={() => { if (menuOpenId) setMenuOpenId(null); }}
-      >
-        {sortedSessions.length === 0 && <div className="qa-drawer-empty">还没有对话</div>}
-        {sortedSessions.map((session) => (
-          <div
-            key={session.id}
-            className={`qa-drawer-item ${session.id === activeId ? "is-active" : ""}`}
-            onClick={() => onSelect(session.id)}
-          >
-            <div className="qa-drawer-item-main">
-              <span className="qa-drawer-item-title">
-                {session.isPinned && <Pin size={12} className="qa-drawer-pin-mark" aria-label="已置顶" />}
-                {session.title}
-              </span>
-              <span className="qa-drawer-item-time">{formatRelativeTime(session.updatedAt)}</span>
-            </div>
+return (
+
+
+对话记录
+
+<div
+className="qa-drawer-list hide-scrollbar"
+onClick={() => { if (menuOpenId) setMenuOpenId(null); }}
+>
+{sortedSessions.length === 0 && 还没有对话}
+{sortedSessions.map((session) => (
+<div
+key={session.id}
+className={qa-drawer-item ${session.id === activeId ? "is-active" : ""}}
+onClick={() => onSelect(session.id)}
+>
+
+
+{session.isPinned && }
+{session.title}
+
+{formatRelativeTime(session.updatedAt)}
+
+<button
+type="button"
+className="qa-icon-btn qa-drawer-item-more"
+aria-label="更多操作"
+aria-expanded={menuOpenId === session.id}
+onClick={(e) => {
+e.stopPropagation();
+setMenuOpenId(menuOpenId === session.id ? null : session.id);
+}}
+>
+
+
+
+        {menuOpenId === session.id && (
+          <div className="qa-drawer-item-menu" role="menu">
             <button
               type="button"
-              className="qa-icon-btn qa-drawer-item-more"
-              aria-label="更多操作"
-              aria-expanded={menuOpenId === session.id}
+              role="menuitem"
+              className="qa-drawer-menu-btn"
               onClick={(e) => {
                 e.stopPropagation();
-                setMenuOpenId(menuOpenId === session.id ? null : session.id);
+                toggleQaSessionPin(session.id);
+                setMenuOpenId(null);
               }}
             >
-              <MoreVertical size={14} />
+              {session.isPinned ? <PinOff size={14} /> : <Pin size={14} />}
+              {session.isPinned ? "取消置顶" : "置顶"}
             </button>
-
-            {menuOpenId === session.id && (
-              <div className="qa-drawer-item-menu" role="menu">
-                <button
-                  type="button"
-                  role="menuitem"
-                  className="qa-drawer-menu-btn"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    toggleQaSessionPin(session.id);
-                    setMenuOpenId(null);
-                  }}
-                >
-                  {session.isPinned ? <PinOff size={14} /> : <Pin size={14} />}
-                  {session.isPinned ? "取消置顶" : "置顶"}
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className="qa-drawer-menu-btn"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onRenameRequest(session.id, session.title);
-                    setMenuOpenId(null);
-                  }}
-                >
-                  <Pencil size={14} /> 重命名
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className="qa-drawer-menu-btn is-danger"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDelete(session.id);
-                    setMenuOpenId(null);
-                  }}
-                >
-                  <Trash2 size={14} /> 删除
-                </button>
-              </div>
-            )}
+            <button
+              type="button"
+              role="menuitem"
+              className="qa-drawer-menu-btn"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRenameRequest(session.id, session.title);
+                setMenuOpenId(null);
+              }}
+            >
+              <Pencil size={14} /> 重命名
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className="qa-drawer-menu-btn is-danger"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(session.id);
+                setMenuOpenId(null);
+              }}
+            >
+              <Trash2 size={14} /> 删除
+            </button>
           </div>
-        ))}
+        )}
       </div>
-      <div className="qa-drawer-foot">
-        <button type="button" className="qa-drawer-new qa-drawer-settings" onClick={onOpenSettings}>
-          <Wrench size={15} strokeWidth={2} />
-          <span>工坊配置</span>
-        </button>
-        <button type="button" className="qa-drawer-new" onClick={onCreate}>
-          <Plus size={16} strokeWidth={2} />
-          <span>新对话</span>
-        </button>
-      </div>
-    </aside>
-  );
+    ))}
+  </div>
+  <div className="qa-drawer-foot">
+    <button type="button" className="qa-drawer-new qa-drawer-settings" onClick={onOpenSettings}>
+      <Wrench size={15} strokeWidth={2} />
+      <span>工坊配置</span>
+    </button>
+    <button type="button" className="qa-drawer-new" onClick={onCreate}>
+      <Plus size={16} strokeWidth={2} />
+      <span>新对话</span>
+    </button>
+  </div>
+</aside>
+
+
+);
 }
 
 // ── 工坊配置面板 ─────────────────────────────────────
 
 function QaSettingsSheet({ onClose, onNotice }: { onClose: () => void; onNotice?: (msg: string) => void }) {
-  const [budget, setBudget] = useState(() => String(getQaContextBudgetChars()));
-  const [pageChars, setPageChars] = useState(() => String(getQaPageChars()));
-  const [maxRounds, setMaxRounds] = useState(() => String(getQaMaxRounds()));
-  const [maxOutTokens, setMaxOutTokens] = useState(() => {
-    const v = getQaMaxOutputTokens();
-    return v == null ? "" : String(v);
-  });
-  const usedChars = getQaActiveContextChars();
-  const pct = Math.round((usedChars / getQaContextBudgetChars()) * 100);
+const [budget, setBudget] = useState(() => String(getQaContextBudgetChars()));
+const [pageChars, setPageChars] = useState(() => String(getQaPageChars()));
+const [maxRounds, setMaxRounds] = useState(() => String(getQaMaxRounds()));
+const [maxOutTokens, setMaxOutTokens] = useState(() => {
+const v = getQaMaxOutputTokens();
+return v == null ? "" : String(v);
+});
+const usedChars = getQaActiveContextChars();
+const pct = Math.round((usedChars / getQaContextBudgetChars()) * 100);
 
-  const save = () => {
-    const parsed = Number(budget);
-    if (!Number.isFinite(parsed) || parsed < QA_CONTEXT_BUDGET_MIN || parsed > QA_CONTEXT_BUDGET_MAX) {
-      onNotice?.(`预算需为 ${QA_CONTEXT_BUDGET_MIN.toLocaleString()} - ${QA_CONTEXT_BUDGET_MAX.toLocaleString()} 之间的数字。`);
-      return;
-    }
-    const parsedPage = Number(pageChars);
-    if (!Number.isFinite(parsedPage) || parsedPage < QA_PAGE_CHARS_MIN || parsedPage > QA_PAGE_CHARS_MAX) {
-      onNotice?.(`单页字符数需为 ${QA_PAGE_CHARS_MIN.toLocaleString()} - ${QA_PAGE_CHARS_MAX.toLocaleString()} 之间的数字。`);
-      return;
-    }
-    const parsedRounds = Number(maxRounds);
-    if (!Number.isFinite(parsedRounds) || parsedRounds < QA_MAX_ROUNDS_MIN || parsedRounds > QA_MAX_ROUNDS_MAX) {
-      onNotice?.(`工具调用上限需为 ${QA_MAX_ROUNDS_MIN} - ${QA_MAX_ROUNDS_MAX} 之间的数字。`);
-      return;
-    }
-    const trimmedTokens = maxOutTokens.trim();
-    const parsedTokens = trimmedTokens ? Number(trimmedTokens) : null;
-    if (parsedTokens != null && (!Number.isFinite(parsedTokens) || parsedTokens < QA_MAX_OUTPUT_TOKENS_MIN || parsedTokens > QA_MAX_OUTPUT_TOKENS_MAX)) {
-      onNotice?.(`单次最大输出 token 需留空或为 ${QA_MAX_OUTPUT_TOKENS_MIN.toLocaleString()} - ${QA_MAX_OUTPUT_TOKENS_MAX.toLocaleString()} 之间的数字。`);
-      return;
-    }
-    setQaContextBudgetChars(parsed);
-    setQaPageChars(parsedPage);
-    setQaMaxRounds(parsedRounds);
-    setQaMaxOutputTokens(trimmedTokens ? parsedTokens : 0);
-    onNotice?.("已保存工坊配置。");
-    onClose();
-  };
+const save = () => {
+const parsed = Number(budget);
+if (!Number.isFinite(parsed) || parsed < QA_CONTEXT_BUDGET_MIN || parsed > QA_CONTEXT_BUDGET_MAX) {
+onNotice?.(预算需为 ${QA_CONTEXT_BUDGET_MIN.toLocaleString()} - ${QA_CONTEXT_BUDGET_MAX.toLocaleString()} 之间的数字。);
+return;
+}
+const parsedPage = Number(pageChars);
+if (!Number.isFinite(parsedPage) || parsedPage < QA_PAGE_CHARS_MIN || parsedPage > QA_PAGE_CHARS_MAX) {
+onNotice?.(单页字符数需为 ${QA_PAGE_CHARS_MIN.toLocaleString()} - ${QA_PAGE_CHARS_MAX.toLocaleString()} 之间的数字。);
+return;
+}
+const parsedRounds = Number(maxRounds);
+if (!Number.isFinite(parsedRounds) || parsedRounds < QA_MAX_ROUNDS_MIN || parsedRounds > QA_MAX_ROUNDS_MAX) {
+onNotice?.(工具调用上限需为 ${QA_MAX_ROUNDS_MIN} - ${QA_MAX_ROUNDS_MAX} 之间的数字。);
+return;
+}
+const trimmedTokens = maxOutTokens.trim();
+const parsedTokens = trimmedTokens ? Number(trimmedTokens) : null;
+if (parsedTokens != null && (!Number.isFinite(parsedTokens) || parsedTokens < QA_MAX_OUTPUT_TOKENS_MIN || parsedTokens > QA_MAX_OUTPUT_TOKENS_MAX)) {
+onNotice?.(单次最大输出 token 需留空或为 ${QA_MAX_OUTPUT_TOKENS_MIN.toLocaleString()} - ${QA_MAX_OUTPUT_TOKENS_MAX.toLocaleString()} 之间的数字。);
+return;
+}
+setQaContextBudgetChars(parsed);
+setQaPageChars(parsedPage);
+setQaMaxRounds(parsedRounds);
+setQaMaxOutputTokens(trimmedTokens ? parsedTokens : 0);
+onNotice?.("已保存工坊配置。");
+onClose();
+};
 
-  const reset = () => {
-    setQaContextBudgetChars(null);
-    setQaPageChars(null);
-    setQaMaxRounds(null);
-    setQaMaxOutputTokens(null);
-    setBudget(String(QA_DEFAULT_CONTEXT_BUDGET_CHARS));
-    setPageChars(String(QA_DEFAULT_PAGE_CHARS));
-    setMaxRounds(String(QA_DEFAULT_MAX_ROUNDS));
-    setMaxOutTokens(String(QA_DEFAULT_MAX_OUTPUT_TOKENS));
-    onNotice?.("已恢复默认配置。");
-  };
+const reset = () => {
+setQaContextBudgetChars(null);
+setQaPageChars(null);
+setQaMaxRounds(null);
+setQaMaxOutputTokens(null);
+setBudget(String(QA_DEFAULT_CONTEXT_BUDGET_CHARS));
+setPageChars(String(QA_DEFAULT_PAGE_CHARS));
+setMaxRounds(String(QA_DEFAULT_MAX_ROUNDS));
+setMaxOutTokens(String(QA_DEFAULT_MAX_OUTPUT_TOKENS));
+onNotice?.("已恢复默认配置。");
+};
 
-  return (
-    <div className="qa-devnotice-backdrop" onClick={onClose}>
-      <div className="qa-devnotice" role="dialog" aria-label="工坊配置" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-devnotice-title">工坊配置</div>
-        <label className="qa-settings-field">
-          <span>上下文预算（字符）</span>
-          <input
-            type="number"
-            inputMode="numeric"
-            min={QA_CONTEXT_BUDGET_MIN}
-            max={QA_CONTEXT_BUDGET_MAX}
-            step={1000}
-            value={budget}
-            onChange={(e) => setBudget(e.target.value)}
-          />
-        </label>
-        <div className="qa-settings-hint">
-          上下文满 100% 时自动压缩成摘要并重新累计。中文约 1 字符 ≈ 1 token；默认 {QA_DEFAULT_CONTEXT_BUDGET_CHARS.toLocaleString()}，小上下文（32k）模型建议 30000–50000。
-        </div>
-        <div className="qa-settings-hint">当前会话已用 {usedChars.toLocaleString()} 字符（约 {pct}%）。</div>
-        <label className="qa-settings-field">
-          <span>单页读取字符数</span>
-          <input
-            type="number"
-            inputMode="numeric"
-            min={QA_PAGE_CHARS_MIN}
-            max={QA_PAGE_CHARS_MAX}
-            step={1000}
-            value={pageChars}
-            onChange={(e) => setPageChars(e.target.value)}
-          />
-        </label>
-        <div className="qa-settings-hint">
-          小坊翻页读答疑文档 / 本机内容 / 仓库源码时，每页返回的字符数。默认 {QA_DEFAULT_PAGE_CHARS.toLocaleString()}；调大读得快但更占上下文，小上下文模型建议调小。
-        </div>
-        <label className="qa-settings-field">
-          <span>单轮工具调用上限（次）</span>
-          <input
-            type="number"
-            inputMode="numeric"
-            min={QA_MAX_ROUNDS_MIN}
-            max={QA_MAX_ROUNDS_MAX}
-            step={1}
-            value={maxRounds}
-            onChange={(e) => setMaxRounds(e.target.value)}
-          />
-        </label>
-        <div className="qa-settings-hint">
-          一次提问里小坊最多连续执行多少轮工具，用完会提示「回复继续」。默认 {QA_DEFAULT_MAX_ROUNDS}；复杂任务（写游戏、改代码）可调大，想控制 token 消耗可调小。
-        </div>
-        <label className="qa-settings-field">
-          <span>单次最大输出 token</span>
-          <input
-            type="number"
-            inputMode="numeric"
-            min={QA_MAX_OUTPUT_TOKENS_MIN}
-            max={QA_MAX_OUTPUT_TOKENS_MAX}
-            step={1000}
-            placeholder="留空 = 不传"
-            value={maxOutTokens}
-            onChange={(e) => setMaxOutTokens(e.target.value)}
-          />
-        </label>
-        <div className="qa-settings-hint">
-          输出长度护栏：每次请求带 max_tokens，小坊会按该预算分段写大文件，写超被安全截断后自动续接，不再整轮报废。默认 {QA_DEFAULT_MAX_OUTPUT_TOKENS.toLocaleString()}；留空 = 不传该参数（部分模型/中转不支持 max_tokens 时请留空）。
-        </div>
-        <div className="qa-devnotice-actions is-row">
-          <button type="button" className="qa-devnotice-btn" onClick={reset}>恢复默认</button>
-          <button type="button" className="qa-devnotice-btn is-primary" onClick={save}>保存</button>
-        </div>
-      </div>
-    </div>
-  );
+return (
+
+<div className="qa-devnotice" role="dialog" aria-label="工坊配置" onClick={(e) => e.stopPropagation()}>
+工坊配置
+
+上下文预算（字符）
+<input
+type="number"
+inputMode="numeric"
+min={QA_CONTEXT_BUDGET_MIN}
+max={QA_CONTEXT_BUDGET_MAX}
+step={1000}
+value={budget}
+onChange={(e) => setBudget(e.target.value)}
+/>
+
+
+上下文满 100% 时自动压缩成摘要并重新累计。中文约 1 字符 ≈ 1 token；默认 {QA_DEFAULT_CONTEXT_BUDGET_CHARS.toLocaleString()}，小上下文（32k）模型建议 30000–50000。
+
+当前会话已用 {usedChars.toLocaleString()} 字符（约 {pct}%）。
+
+单页读取字符数
+<input
+type="number"
+inputMode="numeric"
+min={QA_PAGE_CHARS_MIN}
+max={QA_PAGE_CHARS_MAX}
+step={1000}
+value={pageChars}
+onChange={(e) => setPageChars(e.target.value)}
+/>
+
+
+小坊翻页读答疑文档 / 本机内容 / 仓库源码时，每页返回的字符数。默认 {QA_DEFAULT_PAGE_CHARS.toLocaleString()}；调大读得快但更占上下文，小上下文模型建议调小。
+
+
+单轮工具调用上限（次）
+<input
+type="number"
+inputMode="numeric"
+min={QA_MAX_ROUNDS_MIN}
+max={QA_MAX_ROUNDS_MAX}
+step={1}
+value={maxRounds}
+onChange={(e) => setMaxRounds(e.target.value)}
+/>
+
+
+一次提问里小坊最多连续执行多少轮工具，用完会提示「回复继续」。默认 {QA_DEFAULT_MAX_ROUNDS}；复杂任务（写游戏、改代码）可调大，想控制 token 消耗可调小。
+
+
+单次最大输出 token
+<input
+type="number"
+inputMode="numeric"
+min={QA_MAX_OUTPUT_TOKENS_MIN}
+max={QA_MAX_OUTPUT_TOKENS_MAX}
+step={1000}
+placeholder="留空 = 不传"
+value={maxOutTokens}
+onChange={(e) => setMaxOutTokens(e.target.value)}
+/>
+
+
+输出长度护栏：每次请求带 max_tokens，小坊会按该预算分段写大文件，写超被安全截断后自动续接，不再整轮报废。默认 {QA_DEFAULT_MAX_OUTPUT_TOKENS.toLocaleString()}；留空 = 不传该参数（部分模型/中转不支持 max_tokens 时请留空）。
+
+
+恢复默认
+保存
+
+
+
+);
 }
 
 // ── GitHub 仓库配置面板 ──────────────────────────────
 
 function QaRepoSheet({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
-  const existing = useMemo(() => loadQaGithubConfig(), []);
-  const [owner, setOwner] = useState(existing?.owner ?? "");
-  const [repo, setRepo] = useState(existing?.repo ?? "");
-  const [branch, setBranch] = useState(existing?.branch ?? "");
-  const [token, setToken] = useState(existing?.token ?? "");
-  const [writeMode, setWriteMode] = useState<"confirm" | "auto">(existing?.writeMode ?? "confirm");
-  const [checking, setChecking] = useState(false);
-  const [result, setResult] = useState<QaGithubValidation | null>(null);
+const existing = useMemo(() => loadQaGithubConfig(), []);
+const [owner, setOwner] = useState(existing?.owner ?? "");
+const [repo, setRepo] = useState(existing?.repo ?? "");
+const [branch, setBranch] = useState(existing?.branch ?? "");
+const [token, setToken] = useState(existing?.token ?? "");
+const [writeMode, setWriteMode] = useState<"confirm" | "auto">(existing?.writeMode ?? "confirm");
+const [checking, setChecking] = useState(false);
+const [result, setResult] = useState<QaGithubValidation | null>(null);
 
-  const buildConfig = useCallback((): QaGithubConfig => {
-    const cfg: QaGithubConfig = { owner: owner.trim(), repo: repo.trim(), writeMode };
-    if (branch.trim()) cfg.branch = branch.trim();
-    if (token.trim()) cfg.token = token.trim();
-    if (existing?.apiBase) cfg.apiBase = existing.apiBase;
-    return cfg;
-  }, [owner, repo, branch, token, writeMode, existing]);
+const buildConfig = useCallback((): QaGithubConfig => {
+const cfg: QaGithubConfig = { owner: owner.trim(), repo: repo.trim(), writeMode };
+if (branch.trim()) cfg.branch = branch.trim();
+if (token.trim()) cfg.token = token.trim();
+if (existing?.apiBase) cfg.apiBase = existing.apiBase;
+return cfg;
+}, [owner, repo, branch, token, writeMode, existing]);
 
-  const handleVerify = useCallback(async () => {
-    if (!owner.trim() || !repo.trim()) {
-      setResult({ ok: false, error: "请填写 owner 和 repo。" });
-      return;
-    }
-    setChecking(true);
-    setResult(null);
-    const validation = await validateQaGithubConfig(buildConfig());
-    setResult(validation);
-    setChecking(false);
-  }, [owner, repo, buildConfig]);
+const handleVerify = useCallback(async () => {
+if (!owner.trim() || !repo.trim()) {
+setResult({ ok: false, error: "请填写 owner 和 repo。" });
+return;
+}
+setChecking(true);
+setResult(null);
+const validation = await validateQaGithubConfig(buildConfig());
+setResult(validation);
+setChecking(false);
+}, [owner, repo, buildConfig]);
 
-  const handleSave = useCallback(() => {
-    if (!owner.trim() || !repo.trim()) return;
-    saveQaGithubConfig(buildConfig());
-    onSaved();
-    onClose();
-  }, [owner, repo, buildConfig, onSaved, onClose]);
+const handleSave = useCallback(() => {
+if (!owner.trim() || !repo.trim()) return;
+saveQaGithubConfig(buildConfig());
+onSaved();
+onClose();
+}, [owner, repo, buildConfig, onSaved, onClose]);
 
-  const handleDisconnect = useCallback(() => {
-    clearQaGithubConfig();
-    onSaved();
-    onClose();
-  }, [onSaved, onClose]);
+const handleDisconnect = useCallback(() => {
+clearQaGithubConfig();
+onSaved();
+onClose();
+}, [onSaved, onClose]);
 
-  return (
-    <div className="qa-sheet-backdrop" onClick={onClose}>
-      <div className="qa-sheet" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-sheet-head">
-          <span className="qa-sheet-title">
-            <Github size={16} /> 连接 GitHub 仓库
-          </span>
-          <button type="button" className="qa-icon-btn" onClick={onClose} aria-label="关闭">
-            <X size={16} />
-          </button>
-        </div>
-        <div className="qa-sheet-body hide-scrollbar">
-          <p className="qa-sheet-note">
-            连接后可以让工坊查阅这个仓库的代码来回答问题。配置只保存在你的浏览器本地，不会上传。公开仓库可不填 PAT。
-          </p>
-          <label className="qa-field">
-            <span className="qa-field-label">Owner（用户名 / 组织）</span>
-            <input className="qa-input" value={owner} onChange={(e) => setOwner(e.target.value)} placeholder="例：octocat" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-          </label>
-          <label className="qa-field">
-            <span className="qa-field-label">Repo（仓库名）</span>
-            <input className="qa-input" value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="例：hello-world" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-          </label>
-          <label className="qa-field">
-            <span className="qa-field-label">分支（可选，默认仓库默认分支）</span>
-            <input className="qa-input" value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="main" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-          </label>
-          <label className="qa-field">
-            <span className="qa-field-label">Fine-grained PAT（私有仓库或搜索代码需要）</span>
-            <input className="qa-input" type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="github_pat_…" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-            <span className="qa-field-hint">
-              GitHub → Settings → Menu 按钮 → Developer settings → Personal access tokens → Fine-grained tokens。创建时 Repository access 记得勾选目标仓库；Permissions 里：Contents——只查代码选 Read-only，要让工坊改代码选 Read and write；要用「创建PR」再加 Pull requests 的 Read and write（Metadata 会自动带上，其余权限都不用勾）。
-            </span>
-          </label>
-          <div className="qa-field">
-            <span className="qa-field-label">改代码时的模式</span>
-            <div className="qa-segment">
-              <button type="button" className={`qa-segment-btn ${writeMode === "confirm" ? "is-active" : ""}`} onClick={() => setWriteMode("confirm")}>
-                确认后提交
-              </button>
-              <button type="button" className={`qa-segment-btn ${writeMode === "auto" ? "is-active" : ""}`} onClick={() => setWriteMode("auto")}>
-                全自动
-              </button>
-            </div>
-            <span className="qa-field-hint">
-              {writeMode === "confirm"
-                ? "工坊改代码前会先展示改动，你点「应用」才真正提交。推荐。"
-                : "工坊说完直接提交推送，不再逐次确认。仍可事后一键撤销。仅在信任后开启。"}
-            </span>
-          </div>
-          {result && (
-            <div className={`qa-verify ${result.ok ? "is-ok" : "is-fail"}`}>
-              {result.ok
-                ? `✓ 已连接 ${result.fullName}（${result.private ? "私有" : "公开"}，默认分支 ${result.defaultBranch}）`
-                : `✗ ${result.error}`}
-            </div>
-          )}
-        </div>
-        <div className="qa-sheet-actions">
-          {existing && (
-            <button type="button" className="qa-sheet-btn is-danger" onClick={handleDisconnect}>
-              断开
-            </button>
-          )}
-          <button type="button" className="qa-sheet-btn" onClick={handleVerify} disabled={checking}>
-            {checking ? <Loader2 size={14} className="qa-spin" /> : "验证"}
-          </button>
-          <button type="button" className="qa-sheet-btn is-primary" onClick={handleSave} disabled={!owner.trim() || !repo.trim()}>
-            保存
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+return (
+
+<div className="qa-sheet" onClick={(e) => e.stopPropagation()}>
+
+
+ 连接 GitHub 仓库
+
+
+
+
+
+
+
+连接后可以让工坊查阅这个仓库的代码来回答问题。配置只保存在你的浏览器本地，不会上传。公开仓库可不填 PAT。
+
+
+Owner（用户名 / 组织）
+<input className="qa-input" value={owner} onChange={(e) => setOwner(e.target.value)} placeholder="例：octocat" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+
+
+Repo（仓库名）
+<input className="qa-input" value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="例：hello-world" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+
+
+分支（可选，默认仓库默认分支）
+<input className="qa-input" value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="main" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+
+
+Fine-grained PAT（私有仓库或搜索代码需要）
+<input className="qa-input" type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="github_pat_…" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+
+GitHub → Settings → Menu 按钮 → Developer settings → Personal access tokens → Fine-grained tokens。创建时 Repository access 记得勾选目标仓库；Permissions 里：Contents——只查代码选 Read-only，要让工坊改代码选 Read and write；要用「创建PR」再加 Pull requests 的 Read and write（Metadata 会自动带上，其余权限都不用勾）。
+
+
+
+改代码时的模式
+
+<button type="button" className={qa-segment-btn ${writeMode === "confirm" ? "is-active" : ""}} onClick={() => setWriteMode("confirm")}>
+确认后提交
+
+<button type="button" className={qa-segment-btn ${writeMode === "auto" ? "is-active" : ""}} onClick={() => setWriteMode("auto")}>
+全自动
+
+
+
+{writeMode === "confirm"
+? "工坊改代码前会先展示改动，你点「应用」才真正提交。推荐。"
+: "工坊说完直接提交推送，不再逐次确认。仍可事后一键撤销。仅在信任后开启。"}
+
+
+{result && (
+<div className={qa-verify ${result.ok ? "is-ok" : "is-fail"}}>
+{result.ok
+? ✓ 已连接 ${result.fullName}（${result.private ? "私有" : "公开"}，默认分支 ${result.defaultBranch}）
+: ✗ ${result.error}}
+
+)}
+
+
+{existing && (
+
+断开
+
+)}
+
+{checking ?  : "验证"}
+
+<button type="button" className="qa-sheet-btn is-primary" onClick={handleSave} disabled={!owner.trim() || !repo.trim()}>
+保存
+
+
+
+
+);
 }
 
 // ── App 本体 ─────────────────────────────────────────
 
 export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
-  const snapshot = useSyncExternalStore(subscribeQaChat, getQaChatSnapshot, getQaChatSnapshot);
-  const [input, setInput] = useState("");
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const [repoSheetOpen, setRepoSheetOpen] = useState(false);
-  const [repoConnected, setRepoConnected] = useState(false);
-  const [clearToolsOpen, setClearToolsOpen] = useState(false);
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
-  const [renameTitle, setRenameTitle] = useState("");
-  
-  const [pendingImages, setPendingImages] = useState<string[]>([]);
-  // 新增：文本附件的状态记录
-  const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
-  const [viewerImage, setViewerImage] = useState<string | null>(null);
-  const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
-  const [editText, setEditText] = useState("");
-  const [visionEnabled, setVisionEnabled] = useState(false);
-  
-  const imageInputRef = useRef<HTMLInputElement | null>(null);
-  // 新增：文本文件的 input ref
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const [apiReady, setApiReady] = useState(true);
-  const [modelName, setModelName] = useState("");
-  const [repoWritable, setRepoWritable] = useState(false);
-  const [writeMode, setWriteMode] = useState<"confirm" | "auto">("confirm");
-  const bodyRef = useRef<HTMLDivElement | null>(null);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const stickToBottomRef = useRef(true);
+// 弃用 useSyncExternalStore，改回经典的 useEffect + useState 模式。
+// LLM 流式输出的频率极高（可能几毫秒就 emit 一次），会导致 useSyncExternalStore
+// 触发 React 18 的 Concurrent Mode 防撕裂（Tearing）保护机制，抛出
+// "The result of getSnapshot should be cached to avoid an infinite loop" 的崩溃。
+// 改回传统的订阅方式能优雅地解决这个问题。
+const [snapshot, setSnapshot] = useState(getQaChatSnapshot);
+useEffect(() => {
+return subscribeQaChat(() => {
+setSnapshot(getQaChatSnapshot());
+});
+}, []);
 
-  const refreshComposerMeta = useCallback(() => {
-    setApiReady(resolveQaApiConfig() != null);
-    setModelName(resolveQaApiConfig()?.defaultModel ?? "");
-    setVisionEnabled(resolveQaApiConfig()?.enableImageRecognition === true);
-    const gh = loadQaGithubConfig();
-    setRepoConnected(gh != null);
-    setRepoWritable(Boolean(gh?.token));
-    setWriteMode(gh?.writeMode ?? "confirm");
-  }, []);
+const [input, setInput] = useState("");
+const [drawerOpen, setDrawerOpen] = useState(false);
+const [repoSheetOpen, setRepoSheetOpen] = useState(false);
+const [repoConnected, setRepoConnected] = useState(false);
+const [clearToolsOpen, setClearToolsOpen] = useState(false);
+const [settingsOpen, setSettingsOpen] = useState(false);
+const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
+const [renameTitle, setRenameTitle] = useState("");
 
-  useEffect(() => {
-    void hydrateQaChat();
-    refreshComposerMeta();
-  }, [refreshComposerMeta]);
+const [pendingImages, setPendingImages] = useState<string[]>([]);
+// 新增：文本附件的状态记录
+const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
+const [viewerImage, setViewerImage] = useState<string | null>(null);
+const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
+const [editText, setEditText] = useState("");
+const [visionEnabled, setVisionEnabled] = useState(false);
 
-  const handleClearToolHistory = useCallback(() => {
-    if (snapshot.isGenerating) {
-      onNotice?.("小坊正在执行，完成后再清理。");
-      return;
-    }
-    if (!hasQaToolHistory()) {
-      onNotice?.("没有可清理的工具调用历史。");
-      return;
-    }
-    setClearToolsOpen(true);
-  }, [snapshot.isGenerating, onNotice]);
+const imageInputRef = useRef<HTMLInputElement | null>(null);
+const fileInputRef = useRef<HTMLInputElement | null>(null);
+const [apiReady, setApiReady] = useState(true);
+const [modelName, setModelName] = useState("");
+const [repoWritable, setRepoWritable] = useState(false);
+const [writeMode, setWriteMode] = useState<"confirm" | "auto">("confirm");
+const bodyRef = useRef<HTMLDivElement | null>(null);
+const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+const stickToBottomRef = useRef(true);
 
-  const confirmClearToolHistory = useCallback(() => {
-    setClearToolsOpen(false);
-    const result = clearQaToolHistory();
-    onNotice?.(result && result.removed + result.cleaned > 0
-      ? `已清理 ${result.removed} 条工具记录，整理 ${result.cleaned} 条消息。`
-      : "没有可清理的工具调用历史。");
-  }, [onNotice]);
+const refreshComposerMeta = useCallback(() => {
+setApiReady(resolveQaApiConfig() != null);
+setModelName(resolveQaApiConfig()?.defaultModel ?? "");
+setVisionEnabled(resolveQaApiConfig()?.enableImageRecognition === true);
+const gh = loadQaGithubConfig();
+setRepoConnected(gh != null);
+setRepoWritable(Boolean(gh?.token));
+setWriteMode(gh?.writeMode ?? "confirm");
+}, []);
 
-  const toggleWriteMode = useCallback(() => {
-    const gh = loadQaGithubConfig();
-    if (!gh) return;
-    const next = gh.writeMode === "auto" ? "confirm" : "auto";
-    saveQaGithubConfig({ ...gh, writeMode: next });
-    setWriteMode(next);
-  }, []);
+useEffect(() => {
+void hydrateQaChat();
+refreshComposerMeta();
+}, [refreshComposerMeta]);
 
-  const activeSession = useMemo(
-    () => snapshot.sessions.find((s) => s.id === snapshot.activeSessionId) ?? null,
-    [snapshot.sessions, snapshot.activeSessionId],
-  );
-  const messages = useMemo(() => activeSession?.messages ?? [], [activeSession]);
-  const createdContent = useMemo(() => activeSession?.createdContent ?? [], [activeSession]);
-  const [previewOpen, setPreviewOpen] = useState(false);
-  const [previewItem, setPreviewItem] = useState<QaCreatedContent | null>(null);
-  const previewApp = useMemo(
-    () => (previewItem?.type === "app" ? getInstalledCustomApp(previewItem.refId) : null),
-    [previewItem],
-  );
+const handleClearToolHistory = useCallback(() => {
+if (snapshot.isGenerating) {
+onNotice?.("小坊正在执行，完成后再清理。");
+return;
+}
+if (!hasQaToolHistory()) {
+onNotice?.("没有可清理的工具调用历史。");
+return;
+}
+setClearToolsOpen(true);
+}, [snapshot.isGenerating, onNotice]);
 
-  const handleScroll = useCallback(() => {
-    const el = bodyRef.current;
-    if (!el) return;
-    stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
-  }, []);
+const confirmClearToolHistory = useCallback(() => {
+setClearToolsOpen(false);
+const result = clearQaToolHistory();
+onNotice?.(result && result.removed + result.cleaned > 0
+? 已清理 ${result.removed} 条工具记录，整理 ${result.cleaned} 条消息。
+: "没有可清理的工具调用历史。");
+}, [onNotice]);
 
-  useEffect(() => {
-    const el = bodyRef.current;
-    if (el && stickToBottomRef.current) {
-      el.scrollTop = el.scrollHeight;
-    }
-  }, [messages]);
+const toggleWriteMode = useCallback(() => {
+const gh = loadQaGithubConfig();
+if (!gh) return;
+const next = gh.writeMode === "auto" ? "confirm" : "auto";
+saveQaGithubConfig({ ...gh, writeMode: next });
+setWriteMode(next);
+}, []);
 
-  const autoGrow = useCallback(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
-  }, []);
+const activeSession = useMemo(
+() => snapshot.sessions.find((s) => s.id === snapshot.activeSessionId) ?? null,
+[snapshot.sessions, snapshot.activeSessionId],
+);
+const messages = useMemo(() => activeSession?.messages ?? [], [activeSession]);
+const createdContent = useMemo(() => activeSession?.createdContent ?? [], [activeSession]);
+const [previewOpen, setPreviewOpen] = useState(false);
+const [previewItem, setPreviewItem] = useState<QaCreatedContent | null>(null);
+const previewApp = useMemo(
+() => (previewItem?.type === "app" ? getInstalledCustomApp(previewItem.refId) : null),
+[previewItem],
+);
 
-  const handleSend = useCallback(() => {
-    const text = input.trim();
-    if ((!text && pendingImages.length === 0 && pendingFiles.length === 0) || snapshot.isGenerating) return;
-    setInput("");
-    const images = pendingImages;
-    const files = pendingFiles; // 新增传递文本附件
-    setPendingImages([]);
-    setPendingFiles([]);
-    stickToBottomRef.current = true;
-    requestAnimationFrame(autoGrow);
-    void sendQaMessage(text, images.length ? images : undefined, files.length ? files : undefined);
-  }, [input, pendingImages, pendingFiles, snapshot.isGenerating, autoGrow]);
+const handleScroll = useCallback(() => {
+const el = bodyRef.current;
+if (!el) return;
+stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+}, []);
 
-  const handlePickImages = useCallback((files: FileList | null) => {
-    if (!files?.length) return;
-    for (const file of Array.from(files).slice(0, 6)) {
-      if (file.size > 4 * 1024 * 1024) {
-        onNotice?.(`「${file.name}」超过 4MB，已跳过。`);
-        continue;
-      }
-      const reader = new FileReader();
-      reader.onload = () => {
-        const url = typeof reader.result === "string" ? reader.result : "";
-        if (url) setPendingImages((current) => (current.length >= 6 ? current : [...current, url]));
-      };
-      reader.readAsDataURL(file);
-    }
-    if (imageInputRef.current) imageInputRef.current.value = "";
-  }, [onNotice]);
+useEffect(() => {
+const el = bodyRef.current;
+if (el && stickToBottomRef.current) {
+el.scrollTop = el.scrollHeight;
+}
+}, [messages]);
 
-  // 新增：提取并读取纯文本附件
-  const handlePickFiles = useCallback((files: FileList | null) => {
-    if (!files?.length) return;
-    for (const file of Array.from(files).slice(0, 5)) {
-      if (file.size > 1024 * 1024) {
-        onNotice?.(`「${file.name}」超过 1MB，为避免超量占用，已跳过。`);
-        continue;
-      }
-      const reader = new FileReader();
-      reader.onload = () => {
-        const content = reader.result;
-        if (typeof content === "string") {
-          setPendingFiles((current) => {
-            if (current.length >= 5) return current;
-            return [...current, { name: file.name, content }];
-          });
-        }
-      };
-      reader.readAsText(file);
-    }
-    if (fileInputRef.current) fileInputRef.current.value = "";
-  }, [onNotice]);
+const autoGrow = useCallback(() => {
+const el = textareaRef.current;
+if (!el) return;
+el.style.height = "auto";
+el.style.height = ${Math.min(el.scrollHeight, 120)}px;
+}, []);
 
-  const handleRetry = useCallback((assistantMsgId: string) => {
-    stickToBottomRef.current = true;
-    void retryQaMessage(assistantMsgId);
-  }, []);
+const handleSend = useCallback(() => {
+const text = input.trim();
+if ((!text && pendingImages.length === 0 && pendingFiles.length === 0) || snapshot.isGenerating) return;
+setInput("");
+const images = pendingImages;
+const files = pendingFiles;
+setPendingImages([]);
+setPendingFiles([]);
+stickToBottomRef.current = true;
+requestAnimationFrame(autoGrow);
+void sendQaMessage(text, images.length ? images : undefined, files.length ? files : undefined);
+}, [input, pendingImages, pendingFiles, snapshot.isGenerating, autoGrow]);
 
-  const handleCopyMessage = useCallback((content: string) => {
-    void navigator.clipboard?.writeText(content).then(
-      () => onNotice?.("已复制原始内容"),
-      () => onNotice?.("复制失败"),
-    );
-  }, [onNotice]);
+const handlePickImages = useCallback((files: FileList | null) => {
+if (!files?.length) return;
+for (const file of Array.from(files).slice(0, 6)) {
+if (file.size > 4 * 1024 * 1024) {
+onNotice?.(「${file.name}」超过 4MB，已跳过。);
+continue;
+}
+const reader = new FileReader();
+reader.onload = () => {
+const url = typeof reader.result === "string" ? reader.result : "";
+if (url) setPendingImages((current) => (current.length >= 6 ? current : [...current, url]));
+};
+reader.readAsDataURL(file);
+}
+if (imageInputRef.current) imageInputRef.current.value = "";
+}, [onNotice]);
 
-  const handleEditMessage = useCallback((msg: QaMsg) => {
-    setEditingMsg(msg);
-    setEditText(msg.content);
-  }, []);
+const handlePickFiles = useCallback((files: FileList | null) => {
+if (!files?.length) return;
+for (const file of Array.from(files).slice(0, 5)) {
+if (file.size > 1024 * 1024) {
+onNotice?.(「${file.name}」超过 1MB，为避免超量占用，已跳过。);
+continue;
+}
+const reader = new FileReader();
+reader.onload = () => {
+const content = reader.result;
+if (typeof content === "string") {
+setPendingFiles((current) => {
+if (current.length >= 5) return current;
+return [...current, { name: file.name, content }];
+});
+}
+};
+reader.readAsText(file);
+}
+if (fileInputRef.current) fileInputRef.current.value = "";
+}, [onNotice]);
 
-  const handleSaveEdit = useCallback(() => {
-    if (!editingMsg || !snapshot.activeSessionId) return;
-    updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editingMsg.images, editingMsg.files);
-    setEditingMsg(null);
-    onNotice?.("已保存消息内容");
-  }, [editingMsg, editText, snapshot.activeSessionId, onNotice]);
+const handleRetry = useCallback((assistantMsgId: string) => {
+stickToBottomRef.current = true;
+void retryQaMessage(assistantMsgId);
+}, []);
 
-  // 新增：保存并重新发送
-  const handleEditAndResend = useCallback(() => {
-    if (!editingMsg || !snapshot.activeSessionId) return;
-    void editAndResendQaMessage(
-      snapshot.activeSessionId, 
-      editingMsg.id, 
-      editText, 
-      editingMsg.images, 
-      editingMsg.files
-    );
-    setEditingMsg(null);
-    onNotice?.("已保存并重新发送，中断后续对话");
-  }, [editingMsg, editText, snapshot.activeSessionId, onNotice]);
+const handleCopyMessage = useCallback((content: string) => {
+void navigator.clipboard?.writeText(content).then(
+() => onNotice?.("已复制原始内容"),
+() => onNotice?.("复制失败"),
+);
+}, [onNotice]);
 
-  const streamingMsgId =
-    snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
-      ? messages[messages.length - 1].id
-      : null;
+const handleEditMessage = useCallback((msg: QaMsg) => {
+setEditingMsg(msg);
+setEditText(msg.content);
+}, []);
 
-  return (
-    <div className="qa-app-shell">
-      <QaSessionDrawer
-        sessions={snapshot.sessions}
-        activeId={snapshot.activeSessionId}
-        onSelect={(id) => {
-          switchQaSession(id);
-          setDrawerOpen(false);
-        }}
-        onDelete={deleteQaSession}
-        onCreate={() => {
-          createQaSession();
-          setDrawerOpen(false);
-        }}
-        onOpenSettings={() => {
-          setSettingsOpen(true);
-          setDrawerOpen(false);
-        }}
-        onRenameRequest={(id, title) => {
-          setRenameTarget({ id, title });
-          setRenameTitle(title);
+const handleSaveEdit = useCallback(() => {
+if (!editingMsg || !snapshot.activeSessionId) return;
+updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editingMsg.images, editingMsg.files);
+setEditingMsg(null);
+onNotice?.("已保存消息内容");
+}, [editingMsg, editText, snapshot.activeSessionId, onNotice]);
+
+const handleEditAndResend = useCallback(() => {
+if (!editingMsg || !snapshot.activeSessionId) return;
+void editAndResendQaMessage(
+snapshot.activeSessionId,
+editingMsg.id,
+editText,
+editingMsg.images,
+editingMsg.files
+);
+setEditingMsg(null);
+onNotice?.("已保存并重新发送，中断后续对话");
+}, [editingMsg, editText, snapshot.activeSessionId, onNotice]);
+
+const streamingMsgId =
+snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
+? messages[messages.length - 1].id
+: null;
+
+return (
+
+<QaSessionDrawer
+sessions={snapshot.sessions}
+activeId={snapshot.activeSessionId}
+onSelect={(id) => {
+switchQaSession(id);
+setDrawerOpen(false);
+}}
+onDelete={deleteQaSession}
+onCreate={() => {
+createQaSession();
+setDrawerOpen(false);
+}}
+onOpenSettings={() => {
+setSettingsOpen(true);
+setDrawerOpen(false);
+}}
+onRenameRequest={(id, title) => {
+setRenameTarget({ id, title });
+setRenameTitle(title);
+}}
+/>
+<div className={qa-stage ${drawerOpen ? "is-pushed" : ""}}>
+
+
+
+
+
+
+
+
+工坊
+{repoConnected && 已连接仓库}
+
+
+
+
+
+<button type="button" className="qa-icon-btn" onClick={() => setDrawerOpen((v) => !v)} aria-label="对话记录">
+
+
+
+
+
+  <div className="qa-body hide-scrollbar" ref={bodyRef} onScroll={handleScroll}>
+    {messages.length === 0 ? (
+      <div className="qa-welcome">
+        <div className="qa-welcome-badge" aria-hidden>
+          <svg viewBox="0 0 24 24" width="26" height="26">
+            <path d={mdiHammerWrench} fill="currentColor" />
+          </svg>
+        </div>
+        <div className="qa-welcome-title">有什么问题？</div>
+        <div className="qa-welcome-sub">
+          我是小坊，工坊的驻场工程师。使用问题、报错排查、部署配置，都可以问我。
+          <br />
+          我还能动手：写小游戏 / APP / 剧场直接装进本机试玩；连接仓库后我会查源码答疑，填了有写权限的 PAT 还能帮你改代码。
+          <br />
+          想创作角色、世界书或美化桌面，找桌面上的小卷更合适。
+        </div>
+        {!apiReady && (
+          <div className="qa-welcome-warn">还没有可用的 API：请先到「设置 → API 设置」添加 LLM API。</div>
+        )}
+        <div className="qa-suggestions">
+          {SUGGESTIONS.map((text) => (
+            <button
+              key={text}
+              type="button"
+              className="qa-suggestion"
+              onClick={() => {
+                stickToBottomRef.current = true;
+                void sendQaMessage(text);
+              }}
+            >
+              {text}
+            </button>
+          ))}
+        </div>
+      </div>
+    ) : (
+      <div className="qa-messages">
+        {messages.map((msg) => (
+          <QaMessageItem key={msg.id} msg={msg} isStreaming={msg.id === streamingMsgId} onRetry={handleRetry} onViewImage={setViewerImage} onCopy={handleCopyMessage} onEdit={handleEditMessage} />
+        ))}
+      </div>
+    )}
+  </div>
+
+  <footer className="qa-composer-wrap">
+    <div className={`qa-composer ${snapshot.isGenerating ? "is-generating" : ""}`}>
+      {(pendingImages.length > 0 || pendingFiles.length > 0) && (
+        <div className="qa-attach-strip">
+          {pendingImages.map((url, i) => (
+            <div key={`img-${i}`} className="qa-attach-thumb">
+              <button type="button" className="qa-attach-view" onClick={() => setViewerImage(url)} aria-label="查看图片">
+                <img src={url} alt="" />
+              </button>
+              <button
+                type="button"
+                className="qa-attach-remove"
+                onClick={() => setPendingImages((current) => current.filter((_, idx) => idx !== i))}
+                aria-label="移除图片"
+              >
+                <X size={11} strokeWidth={2.4} />
+              </button>
+            </div>
+          ))}
+          {pendingFiles.map((file, i) => (
+            <div key={`file-${i}`} className="qa-attach-thumb is-file" style={{ display: 'flex', alignItems: 'center', gap: '4px', padding: '0 8px', background: 'var(--surface-3)', borderRadius: '6px', minWidth: 0, height: '48px', flexShrink: 0 }}>
+              <FileText size={15} style={{ flexShrink: 0, opacity: 0.8 }} />
+              <span style={{ fontSize: '12px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '80px' }}>{file.name}</span>
+              <button
+                type="button"
+                className="qa-attach-remove"
+                style={{ position: 'static', transform: 'none', marginLeft: '2px', background: 'rgba(0,0,0,0.1)' }}
+                onClick={() => setPendingFiles((current) => current.filter((_, idx) => idx !== i))}
+                aria-label="移除文件"
+              >
+                <X size={11} strokeWidth={2.4} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      
+      <textarea
+        ref={textareaRef}
+        className="qa-composer-input hide-scrollbar"
+        placeholder="输入你的问题…"
+        rows={1}
+        value={input}
+        onChange={(e) => {
+          setInput(e.target.value);
+          autoGrow();
         }}
       />
-      <div className={`qa-stage ${drawerOpen ? "is-pushed" : ""}`}>
-      <div className="qa-ambient" aria-hidden />
-      <header className="qa-header">
-        <div className="qa-header-left">
-          <button type="button" className="qa-icon-btn" onClick={onClose} aria-label="返回">
-            <ChevronLeft size={22} strokeWidth={1.75} />
-          </button>
-        </div>
-        <div className="qa-header-center">
-          <span className="qa-header-title">工坊</span>
-          {repoConnected && <span className="qa-header-sub">已连接仓库</span>}
-        </div>
-        <div className="qa-header-right">
+      <div className="qa-composer-toolbar">
+        {visionEnabled && (
+          <>
+            <input
+              ref={imageInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              style={{ display: "none" }}
+              onChange={(e) => handlePickImages(e.target.files)}
+            />
+            <button
+              type="button"
+              className="qa-circle-btn qa-attach-btn"
+              onClick={() => imageInputRef.current?.click()}
+              aria-label="发送图片"
+              title="添加图片"
+            >
+              <Plus size={17} strokeWidth={2.2} />
+            </button>
+          </>
+        )}
+        
+        <>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".txt,.md,.json,.js,.ts,.jsx,.tsx,.csv,.py,.html,.css"
+            multiple
+            style={{ display: "none" }}
+            onChange={(e) => handlePickFiles(e.target.files)}
+          />
           <button
             type="button"
-            className="qa-icon-btn"
-            onClick={handleClearToolHistory}
-            aria-label="清理原生tool调用历史（防报错）"
-            title="清理原生tool调用历史——防报错"
+            className="qa-circle-btn qa-attach-btn"
+            onClick={() => fileInputRef.current?.click()}
+            aria-label="发送文本文件"
+            title="添加文本文件"
           >
-            <BrushCleaning size={17} strokeWidth={1.75} />
+            <FileText size={16} strokeWidth={2} />
           </button>
-          <button type="button" className="qa-icon-btn" onClick={() => setDrawerOpen((v) => !v)} aria-label="对话记录">
-            <Menu size={18} strokeWidth={1.75} />
+        </>
+        
+        {modelName && <span className="qa-model-pill">{modelName}</span>}
+
+        {repoWritable && (
+          <button type="button" className="qa-mode-pill" onClick={toggleWriteMode}>
+            {writeMode === "auto" ? "全自动" : "确认后提交"}
+          </button>
+        )}
+
+        <div className="qa-composer-spacer" />
+
+        {createdContent.length > 0 && (
+          <button
+            type="button"
+            className="qa-circle-btn qa-preview-btn"
+            onClick={() => setPreviewOpen(true)}
+            aria-label="预览本轮创建的内容"
+          >
+            <Play size={16} />
+          </button>
+        )}
+
+        <button
+          type="button"
+          className={`qa-circle-btn qa-github-btn ${repoConnected ? "is-active" : ""}`}
+          onClick={() => setRepoSheetOpen(true)}
+          aria-label="连接仓库"
+        >
+          <Github size={16} strokeWidth={1.75} />
+        </button>
+
+        {snapshot.isGenerating ? (
+          <button type="button" className="qa-circle-btn qa-send-btn is-stop" onClick={stopQaGeneration} aria-label="停止生成">
+            <Square size={14} fill="currentColor" />
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="qa-circle-btn qa-send-btn"
+            onClick={handleSend}
+            disabled={!input.trim() && pendingImages.length === 0 && pendingFiles.length === 0}
+            aria-label="发送"
+          >
+            <ArrowUp size={20} strokeWidth={2.4} />
+          </button>
+        )}
+      </div>
+      <div
+        className={`qa-context-meter ${snapshot.isCompacting ? "is-compacting" : ""}`}
+        title="上下文用量：满 100% 时自动压缩成摘要并从头累计"
+      >
+        <div className="qa-context-meter-track" aria-hidden>
+          <i style={{ width: `${Math.min(100, Math.round(snapshot.contextUsage * 100))}%` }} />
+        </div>
+        <span className="qa-context-meter-label">
+          {snapshot.isCompacting ? "压缩中" : `${Math.min(999, Math.round(snapshot.contextUsage * 100))}%`}
+        </span>
+      </div>
+    </div>
+  </footer>
+
+  {drawerOpen && (
+    <button
+      type="button"
+      className="qa-stage-scrim"
+      aria-label="关闭对话列表"
+      onClick={() => setDrawerOpen(false)}
+    />
+  )}
+  </div>
+
+  {renameTarget && (
+    <div className="qa-rename-backdrop" role="presentation" onClick={() => setRenameTarget(null)}>
+      <form
+        className="qa-rename-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="qa-rename-dialog-title"
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={(e) => {
+          e.preventDefault();
+          const title = renameTitle.trim();
+          if (!title) return;
+          renameQaSession(renameTarget.id, title);
+          setRenameTarget(null);
+        }}
+      >
+        <div id="qa-rename-dialog-title" className="qa-rename-title">重命名对话</div>
+        <input
+          className="qa-rename-input"
+          autoFocus
+          value={renameTitle}
+          maxLength={80}
+          aria-label="新对话名称"
+          onChange={(e) => setRenameTitle(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Escape") setRenameTarget(null); }}
+        />
+        <div className="qa-rename-actions">
+          <button type="button" className="qa-rename-cancel" onClick={() => setRenameTarget(null)}>取消</button>
+          <button type="submit" className="qa-drawer-new qa-rename-confirm" disabled={!renameTitle.trim()}>确认</button>
+        </div>
+      </form>
+    </div>
+  )}
+
+  {clearToolsOpen && (
+    <div className="qa-devnotice-backdrop" onClick={() => setClearToolsOpen(false)}>
+      <div className="qa-devnotice" role="alertdialog" aria-label="清理工具历史确认" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-devnotice-title">清理工具调用历史？</div>
+        <div className="qa-devnotice-text">
+          将移除本会话上下文中的工具调用与工具结果记录，用于修复原生工具协议的报错。普通对话内容不会删除，之前的工具结论仍保留在小坊的回复文字里。
+        </div>
+        <div className="qa-devnotice-actions is-row">
+          <button type="button" className="qa-devnotice-btn" onClick={() => setClearToolsOpen(false)}>
+            取消
+          </button>
+          <button type="button" className="qa-devnotice-btn is-primary" onClick={confirmClearToolHistory}>
+            清理
           </button>
         </div>
-      </header>
+      </div>
+    </div>
+  )}
 
-      <div className="qa-body hide-scrollbar" ref={bodyRef} onScroll={handleScroll}>
-        {messages.length === 0 ? (
-          <div className="qa-welcome">
-            <div className="qa-welcome-badge" aria-hidden>
-              <svg viewBox="0 0 24 24" width="26" height="26">
-                <path d={mdiHammerWrench} fill="currentColor" />
-              </svg>
-            </div>
-            <div className="qa-welcome-title">有什么问题？</div>
-            <div className="qa-welcome-sub">
-              我是小坊，工坊的驻场工程师。使用问题、报错排查、部署配置，都可以问我。
-              <br />
-              我还能动手：写小游戏 / APP / 剧场直接装进本机试玩；连接仓库后我会查源码答疑，填了有写权限的 PAT 还能帮你改代码。
-              <br />
-              想创作角色、世界书或美化桌面，找桌面上的小卷更合适。
-            </div>
-            {!apiReady && (
-              <div className="qa-welcome-warn">还没有可用的 API：请先到「设置 → API 设置」添加 LLM API。</div>
-            )}
-            <div className="qa-suggestions">
-              {SUGGESTIONS.map((text) => (
-                <button
-                  key={text}
-                  type="button"
-                  className="qa-suggestion"
-                  onClick={() => {
-                    stickToBottomRef.current = true;
-                    void sendQaMessage(text);
-                  }}
-                >
-                  {text}
-                </button>
-              ))}
-            </div>
-          </div>
-        ) : (
-          <div className="qa-messages">
-            {messages.map((msg) => (
-              <QaMessageItem key={msg.id} msg={msg} isStreaming={msg.id === streamingMsgId} onRetry={handleRetry} onViewImage={setViewerImage} onCopy={handleCopyMessage} onEdit={handleEditMessage} />
-            ))}
+  {viewerImage && (
+    <div className="qa-image-viewer" role="presentation" onClick={() => setViewerImage(null)}>
+      <img src={viewerImage} alt="" />
+      <button type="button" className="qa-image-viewer-close" aria-label="关闭" onClick={() => setViewerImage(null)}>
+        <X size={20} />
+      </button>
+    </div>
+  )}
+
+  {editingMsg && (
+    <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
+      <div className="qa-edit-dialog" role="dialog" aria-label="编辑消息" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-edit-head">
+          <span className="qa-edit-title">编辑消息（未渲染原始内容）</span>
+          <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
+            <X size={16} />
+          </button>
+        </div>
+        <textarea
+          className="qa-edit-textarea"
+          value={editText}
+          onChange={(e) => setEditText(e.target.value)}
+          spellCheck={false}
+          autoFocus
+          placeholder="这里显示的是消息的原始内容，不会被前端渲染，可放心查看特殊标签。"
+        />
+        <div className="qa-edit-actions">
+          <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
+            取消
+          </button>
+          <button type="button" className="qa-devnotice-btn is-primary" onClick={handleSaveEdit}>
+            仅保存
+          </button>
+          {editingMsg.role === "user" && (
+            <button type="button" className="qa-devnotice-btn is-danger" onClick={handleEditAndResend}>
+              保存并重发
+            </button>
+          )}
+        </div>
+        {editingMsg.role === "user" && (
+          <div style={{ fontSize: '11px', color: 'var(--text-secondary)', textAlign: 'right', marginTop: '6px' }}>
+            * 重发会截断此消息之后的所有回复并重新触发 AI
           </div>
         )}
       </div>
+    </div>
+  )}
 
-      <footer className="qa-composer-wrap">
-        <div className={`qa-composer ${snapshot.isGenerating ? "is-generating" : ""}`}>
-          {(pendingImages.length > 0 || pendingFiles.length > 0) && (
-            <div className="qa-attach-strip">
-              {pendingImages.map((url, i) => (
-                <div key={`img-${i}`} className="qa-attach-thumb">
-                  <button type="button" className="qa-attach-view" onClick={() => setViewerImage(url)} aria-label="查看图片">
-                    <img src={url} alt="" />
-                  </button>
-                  <button
-                    type="button"
-                    className="qa-attach-remove"
-                    onClick={() => setPendingImages((current) => current.filter((_, idx) => idx !== i))}
-                    aria-label="移除图片"
-                  >
-                    <X size={11} strokeWidth={2.4} />
-                  </button>
-                </div>
-              ))}
-              {/* 新增：文本附件的缩略图展示 */}
-              {pendingFiles.map((file, i) => (
-                <div key={`file-${i}`} className="qa-attach-thumb is-file" style={{ display: 'flex', alignItems: 'center', gap: '4px', padding: '0 8px', background: 'var(--surface-3)', borderRadius: '6px', minWidth: 0, height: '48px', flexShrink: 0 }}>
-                  <FileText size={15} style={{ flexShrink: 0, opacity: 0.8 }} />
-                  <span style={{ fontSize: '12px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '80px' }}>{file.name}</span>
-                  <button
-                    type="button"
-                    className="qa-attach-remove"
-                    style={{ position: 'static', transform: 'none', marginLeft: '2px', background: 'rgba(0,0,0,0.1)' }}
-                    onClick={() => setPendingFiles((current) => current.filter((_, idx) => idx !== i))}
-                    aria-label="移除文件"
-                  >
-                    <X size={11} strokeWidth={2.4} />
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-          
-          <textarea
-            ref={textareaRef}
-            className="qa-composer-input hide-scrollbar"
-            placeholder="输入你的问题…"
-            rows={1}
-            value={input}
-            onChange={(e) => {
-              setInput(e.target.value);
-              autoGrow();
-            }}
-          />
-          <div className="qa-composer-toolbar">
-            {visionEnabled && (
-              <>
-                <input
-                  ref={imageInputRef}
-                  type="file"
-                  accept="image/*"
-                  multiple
-                  style={{ display: "none" }}
-                  onChange={(e) => handlePickImages(e.target.files)}
-                />
-                <button
-                  type="button"
-                  className="qa-circle-btn qa-attach-btn"
-                  onClick={() => imageInputRef.current?.click()}
-                  aria-label="发送图片"
-                  title="添加图片"
-                >
-                  <Plus size={17} strokeWidth={2.2} />
-                </button>
-              </>
-            )}
-            
-            {/* 新增：上传文本附件的按钮（只要环境准备好就能用） */}
-            <>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".txt,.md,.json,.js,.ts,.jsx,.tsx,.csv,.py,.html,.css"
-                multiple
-                style={{ display: "none" }}
-                onChange={(e) => handlePickFiles(e.target.files)}
-              />
-              <button
-                type="button"
-                className="qa-circle-btn qa-attach-btn"
-                onClick={() => fileInputRef.current?.click()}
-                aria-label="发送文本文件"
-                title="添加文本文件"
-              >
-                <FileText size={16} strokeWidth={2} />
-              </button>
-            </>
-            
-            {modelName && <span className="qa-model-pill">{modelName}</span>}
+  {settingsOpen && (
+    <QaSettingsSheet onClose={() => setSettingsOpen(false)} onNotice={onNotice} />
+  )}
 
-            {repoWritable && (
-              <button type="button" className="qa-mode-pill" onClick={toggleWriteMode}>
-                {writeMode === "auto" ? "全自动" : "确认后提交"}
-              </button>
-            )}
+  {repoSheetOpen && (
+    <QaRepoSheet onClose={() => setRepoSheetOpen(false)} onSaved={refreshComposerMeta} />
+  )}
 
-            <div className="qa-composer-spacer" />
-
-            {createdContent.length > 0 && (
-              <button
-                type="button"
-                className="qa-circle-btn qa-preview-btn"
-                onClick={() => setPreviewOpen(true)}
-                aria-label="预览本轮创建的内容"
-              >
-                <Play size={16} />
-              </button>
-            )}
-
-            <button
-              type="button"
-              className={`qa-circle-btn qa-github-btn ${repoConnected ? "is-active" : ""}`}
-              onClick={() => setRepoSheetOpen(true)}
-              aria-label="连接仓库"
-            >
-              <Github size={16} strokeWidth={1.75} />
-            </button>
-
-            {snapshot.isGenerating ? (
-              <button type="button" className="qa-circle-btn qa-send-btn is-stop" onClick={stopQaGeneration} aria-label="停止生成">
-                <Square size={14} fill="currentColor" />
-              </button>
-            ) : (
-              <button
-                type="button"
-                className="qa-circle-btn qa-send-btn"
-                onClick={handleSend}
-                disabled={!input.trim() && pendingImages.length === 0 && pendingFiles.length === 0}
-                aria-label="发送"
-              >
-                <ArrowUp size={20} strokeWidth={2.4} />
-              </button>
-            )}
-          </div>
-          <div
-            className={`qa-context-meter ${snapshot.isCompacting ? "is-compacting" : ""}`}
-            title="上下文用量：满 100% 时自动压缩成摘要并从头累计"
-          >
-            <div className="qa-context-meter-track" aria-hidden>
-              <i style={{ width: `${Math.min(100, Math.round(snapshot.contextUsage * 100))}%` }} />
-            </div>
-            <span className="qa-context-meter-label">
-              {snapshot.isCompacting ? "压缩中" : `${Math.min(999, Math.round(snapshot.contextUsage * 100))}%`}
-            </span>
-          </div>
-        </div>
-      </footer>
-
-      {drawerOpen && (
-        <button
-          type="button"
-          className="qa-stage-scrim"
-          aria-label="关闭对话列表"
-          onClick={() => setDrawerOpen(false)}
-        />
-      )}
-      </div>
-
-      {renameTarget && (
-        <div className="qa-rename-backdrop" role="presentation" onClick={() => setRenameTarget(null)}>
-          <form
-            className="qa-rename-dialog"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="qa-rename-dialog-title"
-            onClick={(e) => e.stopPropagation()}
-            onSubmit={(e) => {
-              e.preventDefault();
-              const title = renameTitle.trim();
-              if (!title) return;
-              renameQaSession(renameTarget.id, title);
-              setRenameTarget(null);
-            }}
-          >
-            <div id="qa-rename-dialog-title" className="qa-rename-title">重命名对话</div>
-            <input
-              className="qa-rename-input"
-              autoFocus
-              value={renameTitle}
-              maxLength={80}
-              aria-label="新对话名称"
-              onChange={(e) => setRenameTitle(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Escape") setRenameTarget(null); }}
-            />
-            <div className="qa-rename-actions">
-              <button type="button" className="qa-rename-cancel" onClick={() => setRenameTarget(null)}>取消</button>
-              <button type="submit" className="qa-drawer-new qa-rename-confirm" disabled={!renameTitle.trim()}>确认</button>
-            </div>
-          </form>
-        </div>
-      )}
-
-      {clearToolsOpen && (
-        <div className="qa-devnotice-backdrop" onClick={() => setClearToolsOpen(false)}>
-          <div className="qa-devnotice" role="alertdialog" aria-label="清理工具历史确认" onClick={(e) => e.stopPropagation()}>
-            <div className="qa-devnotice-title">清理工具调用历史？</div>
-            <div className="qa-devnotice-text">
-              将移除本会话上下文中的工具调用与工具结果记录，用于修复原生工具协议的报错。普通对话内容不会删除，之前的工具结论仍保留在小坊的回复文字里。
-            </div>
-            <div className="qa-devnotice-actions is-row">
-              <button type="button" className="qa-devnotice-btn" onClick={() => setClearToolsOpen(false)}>
-                取消
-              </button>
-              <button type="button" className="qa-devnotice-btn is-primary" onClick={confirmClearToolHistory}>
-                清理
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {viewerImage && (
-        <div className="qa-image-viewer" role="presentation" onClick={() => setViewerImage(null)}>
-          <img src={viewerImage} alt="" />
-          <button type="button" className="qa-image-viewer-close" aria-label="关闭" onClick={() => setViewerImage(null)}>
-            <X size={20} />
+  {previewOpen && !previewItem && (
+    <div className="qa-sheet-backdrop" onClick={() => setPreviewOpen(false)}>
+      <div className="qa-sheet qa-preview-sheet" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-sheet-head">
+          <span className="qa-sheet-title">
+            <Play size={16} /> 预览本轮创建
+          </span>
+          <button type="button" className="qa-icon-btn" onClick={() => setPreviewOpen(false)} aria-label="关闭">
+            <X size={16} />
           </button>
         </div>
-      )}
-
-      {editingMsg && (
-        <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
-          <div className="qa-edit-dialog" role="dialog" aria-label="编辑消息" onClick={(e) => e.stopPropagation()}>
-            <div className="qa-edit-head">
-              <span className="qa-edit-title">编辑消息（未渲染原始内容）</span>
-              <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
-                <X size={16} />
-              </button>
-            </div>
-            <textarea
-              className="qa-edit-textarea"
-              value={editText}
-              onChange={(e) => setEditText(e.target.value)}
-              spellCheck={false}
-              autoFocus
-              placeholder="这里显示的是消息的原始内容，不会被前端渲染，可放心查看特殊标签。"
-            />
-            <div className="qa-edit-actions">
-              <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
-                取消
-              </button>
-              <button type="button" className="qa-devnotice-btn is-primary" onClick={handleSaveEdit}>
-                仅保存
-              </button>
-              {/* 新增：如果消息是你自己发的，支持截断保存并重发 */}
-              {editingMsg.role === "user" && (
-                <button type="button" className="qa-devnotice-btn is-danger" onClick={handleEditAndResend}>
-                  保存并重发
-                </button>
-              )}
-            </div>
-            {editingMsg.role === "user" && (
-              <div style={{ fontSize: '11px', color: 'var(--text-secondary)', textAlign: 'right', marginTop: '6px' }}>
-                * 重发会截断此消息之后的所有回复并重新触发 AI
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-
-      {settingsOpen && (
-        <QaSettingsSheet onClose={() => setSettingsOpen(false)} onNotice={onNotice} />
-      )}
-
-      {repoSheetOpen && (
-        <QaRepoSheet onClose={() => setRepoSheetOpen(false)} onSaved={refreshComposerMeta} />
-      )}
-
-      {previewOpen && !previewItem && (
-        <div className="qa-sheet-backdrop" onClick={() => setPreviewOpen(false)}>
-          <div className="qa-sheet qa-preview-sheet" onClick={(e) => e.stopPropagation()}>
-            <div className="qa-sheet-head">
-              <span className="qa-sheet-title">
-                <Play size={16} /> 预览本轮创建
+        <div className="qa-sheet-body">
+          <p className="qa-sheet-note">本次对话里创建/更新的内容，点开直接测试，返回后回到聊天。</p>
+          {createdContent.map((item) => (
+            <button
+              key={`${item.type}-${item.refId}`}
+              type="button"
+              className="qa-preview-item"
+              onClick={() => setPreviewItem(item)}
+            >
+              {item.type === "app" ? <AppWindow size={17} /> : item.type === "game" ? <Gamepad2 size={17} /> : <Drama size={17} />}
+              <span className="qa-preview-item-title">{item.title}</span>
+              <span className="qa-preview-item-type">
+                {item.type === "app" ? "应用" : item.type === "game" ? "游戏" : "剧场"}
               </span>
-              <button type="button" className="qa-icon-btn" onClick={() => setPreviewOpen(false)} aria-label="关闭">
-                <X size={16} />
-              </button>
-            </div>
-            <div className="qa-sheet-body">
-              <p className="qa-sheet-note">本次对话里创建/更新的内容，点开直接测试，返回后回到聊天。</p>
-              {createdContent.map((item) => (
-                <button
-                  key={`${item.type}-${item.refId}`}
-                  type="button"
-                  className="qa-preview-item"
-                  onClick={() => setPreviewItem(item)}
-                >
-                  {item.type === "app" ? <AppWindow size={17} /> : item.type === "game" ? <Gamepad2 size={17} /> : <Drama size={17} />}
-                  <span className="qa-preview-item-title">{item.title}</span>
-                  <span className="qa-preview-item-type">
-                    {item.type === "app" ? "应用" : item.type === "game" ? "游戏" : "剧场"}
-                  </span>
-                  <ChevronRight size={15} />
-                </button>
-              ))}
-            </div>
-          </div>
+              <ChevronRight size={15} />
+            </button>
+          ))}
         </div>
-      )}
+      </div>
+    </div>
+  )}
 
-      {previewItem && (
-        <div className="qa-preview-runtime">
-          {previewItem.type === "app" ? (
-            previewApp ? (
-              <CustomAppForegroundBoundary
-                key={previewApp.id}
-                appName={previewApp.name}
-                appId={previewApp.id}
-                appVersion={previewApp.version}
-                manifestId={previewApp.manifest?.id}
-                closeLabel="返回"
-                onClose={() => setPreviewItem(null)}
-              >
-                <CustomAppRunner app={previewApp} onClose={() => setPreviewItem(null)} />
-              </CustomAppForegroundBoundary>
-            ) : (
-              <div className="qa-preview-missing">
-                <p>这个应用已被卸载或找不到了。</p>
-                <button type="button" className="qa-sheet-btn is-primary" onClick={() => setPreviewItem(null)}>
-                  返回
-                </button>
-              </div>
-            )
-          ) : previewItem.type === "game" ? (
-            <GameHubApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
-          ) : (
-            <BlackMarketApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
-          )}
-        </div>
+  {previewItem && (
+    <div className="qa-preview-runtime">
+      {previewItem.type === "app" ? (
+        previewApp ? (
+          <CustomAppForegroundBoundary
+            key={previewApp.id}
+            appName={previewApp.name}
+            appId={previewApp.id}
+            appVersion={previewApp.version}
+            manifestId={previewApp.manifest?.id}
+            closeLabel="返回"
+            onClose={() => setPreviewItem(null)}
+          >
+            <CustomAppRunner app={previewApp} onClose={() => setPreviewItem(null)} />
+          </CustomAppForegroundBoundary>
+        ) : (
+          <div className="qa-preview-missing">
+            <p>这个应用已被卸载或找不到了。</p>
+            <button type="button" className="qa-sheet-btn is-primary" onClick={() => setPreviewItem(null)}>
+              返回
+            </button>
+          </div>
+        )
+      ) : previewItem.type === "game" ? (
+        <GameHubApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
+      ) : (
+        <BlackMarketApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
       )}
     </div>
-  );
+  )}
+</div>
+
+
+);
 }

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
-import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, FileText, Gamepad2, Github, Loader2, Menu, MoreVertical, Pencil, Pin, PinOff, Play, Plus, Square, Trash2, Wrench, X } from "lucide-react";
-
+import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
+import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, MoreVertical, Pencil, Pin, PinOff, Play, Plus, Square, Trash2, Wrench, X, Paperclip, FileText, Image as ImageIcon } from "lucide-react";
 import { QaFileCard } from "@/components/qa-file-card";
 import { parseQaFileMarker } from "@/lib/qa-computer-tools";
 import { mdiHammerWrench } from "@mdi/js";
@@ -13,7 +14,6 @@ import { GameHubApp } from "@/components/game/game-hub-app";
 import { BlackMarketApp } from "@/components/shopping/black-market-app";
 import { getInstalledCustomApp } from "@/lib/custom-app-storage";
 import type { QaCreatedContent } from "@/lib/qa-agent-tools";
-
 import {
 applyQaCommit,
 cancelQaCommit,
@@ -92,6 +92,7 @@ if (diff < 86_400_000) return ${Math.floor(diff / 3_600_000)} 小时前;
 return ${Math.floor(diff / 86_400_000)} 天前;
 }
 
+/* STREAMING_CHUNK:Defining UI Helper Components... */
 // ── 代码块（语言标签 + 一键复制）─────────────────────
 
 function QaCodeBlock({ className, children }: { className?: string; children?: React.ReactNode }) {
@@ -213,12 +214,12 @@ return (
 );
 }
 
+/* STREAMING_CHUNK:Rendering Chat Messages... */
 // ── 消息渲染 ─────────────────────────────────────────
 
-// 工具调用行：折叠的单行摘要，点开展开参数与结果（Claude Code 风格）
+// 工具调用行：折叠的单行摘要，点开展开参数与结果
 function QaToolRow({ tool }: { tool: QaToolStatus }) {
 const [open, setOpen] = useState(false);
-// 「电脑文件 op=send」的结果里带文件卡标记：卡片常显，标记从结果文本中剥离
 const { text: resultText, file } = parseQaFileMarker(tool.result || "");
 const hasDetail = Boolean(tool.detail || resultText);
 const summary = tool.running ? 正在${tool.name}… : tool.success === false ? ${tool.name}失败 : tool.name;
@@ -258,16 +259,14 @@ disabled={!hasDetail}
 );
 }
 
-// 已完成文本的 Markdown 渲染：memo 缓存
 const QaMarkdownBlock = memo(function QaMarkdownBlock({ text }: { text: string }) {
 return (
-
+<ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={QA_MARKDOWN_COMPONENTS}>
 {text}
 
 );
 });
 
-// 正在生长的活跃段：纯文本渲染（零解析成本），生成结束后换回完整 Markdown
 function QaStreamingText({ text }: { text: string }) {
 return (
 <>
@@ -302,7 +301,7 @@ const msgWrap = (node: ReactNode) => (
 <button type="button" className="qa-msg-action" aria-label="复制原始内容" title="复制" onClick={() => onCopy(msg.content)}>
 
 
-<button type="button" className="qa-msg-action" aria-label="编辑原始内容" title="编辑" onClick={() => onEdit(msg)}>
+<button type="button" className="qa-msg-action" aria-label="修改消息" title="修改" onClick={() => onEdit(msg)}>
 
 
 
@@ -340,11 +339,11 @@ return msgWrap(
 
 )}
 {msg.files && msg.files.length > 0 && (
-<div className="qa-msg-files" style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '8px' }}>
-{msg.files.map((file, i) => (
-<div key={i} className="qa-msg-file" style={{ display: 'flex', alignItems: 'center', gap: '6px', background: 'rgba(255,255,255,0.15)', padding: '6px 10px', borderRadius: '6px', fontSize: '13px', border: '1px solid rgba(255,255,255,0.1)' }}>
-<FileText size={15} style={{ opacity: 0.8 }} />
-<span style={{ maxWidth: '160px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{file.name}
+<div className="qa-msg-files" style={{ display: "flex", flexDirection: "column", gap: "4px", marginBottom: "8px" }}>
+{msg.files.map((f, i) => (
+<div key={i} style={{ display: "flex", alignItems: "center", gap: "6px", background: "rgba(255,255,255,0.1)", padding: "4px 8px", borderRadius: "6px", fontSize: "12px", border: "1px solid rgba(255,255,255,0.2)" }}>
+
+<span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: "150px" }}>{f.name}
 
 ))}
 
@@ -415,6 +414,7 @@ block.kind === "tools" ? (
 );
 });
 
+/* STREAMING_CHUNK:Session Drawers and Settings Panels... */
 // ── 会话抽屉 ─────────────────────────────────────────
 
 function QaSessionDrawer({
@@ -767,7 +767,7 @@ GitHub → Settings → Menu 按钮 → Developer settings → Personal access t
 {result && (
 <div className={qa-verify ${result.ok ? "is-ok" : "is-fail"}}>
 {result.ok
-? ✓ 已连接 ${result.fullName}（${result.private ? "私有" : "公开"}，默认分支 ${result.defaultBranch}）
+? ✓ 已连接 ${result.fullName}（${result.private ? "私有" : "默认分支 ${result.defaultBranch}"}）
 : ✗ ${result.error}}
 
 )}
@@ -790,35 +790,39 @@ GitHub → Settings → Menu 按钮 → Developer settings → Personal access t
 );
 }
 
+/* STREAMING_CHUNK:Main App Component Initialization... */
 // ── App 本体 ─────────────────────────────────────────
 
 export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
-// 使用 useState + useEffect 替换 useSyncExternalStore，完美解决 tearing 引起的无线重渲问题
-const [snapshot, setSnapshot] = useState(getQaChatSnapshot);
-useEffect(() => {
-return subscribeQaChat(() => {
-setSnapshot(getQaChatSnapshot());
-});
-}, []);
-
+const snapshot = useSyncExternalStore(subscribeQaChat, getQaChatSnapshot, getQaChatSnapshot);
 const [input, setInput] = useState("");
 const [drawerOpen, setDrawerOpen] = useState(false);
 const [repoSheetOpen, setRepoSheetOpen] = useState(false);
 const [repoConnected, setRepoConnected] = useState(false);
 const [clearToolsOpen, setClearToolsOpen] = useState(false);
 const [settingsOpen, setSettingsOpen] = useState(false);
+/ 会话重命名弹窗：抽屉菜单里点「重命名」打开 */
 const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
 const [renameTitle, setRenameTitle] = useState("");
 
+// 主输入区附件
 const [pendingImages, setPendingImages] = useState<string[]>([]);
 const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
+const [composerMenuOpen, setComposerMenuOpen] = useState(false);
+
 const [viewerImage, setViewerImage] = useState<string | null>(null);
+
+// 修改消息区附件
 const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
 const [editText, setEditText] = useState("");
-const [visionEnabled, setVisionEnabled] = useState(false);
+const [editImages, setEditImages] = useState<string[]>([]);
+const [editFiles, setEditFiles] = useState<{name: string, content: string}[]>([]);
+const [editAttachMenuOpen, setEditAttachMenuOpen] = useState(false);
 
+const [visionEnabled, setVisionEnabled] = useState(false);
 const imageInputRef = useRef<HTMLInputElement | null>(null);
 const fileInputRef = useRef<HTMLInputElement | null>(null);
+
 const [apiReady, setApiReady] = useState(true);
 const [modelName, setModelName] = useState("");
 const [repoWritable, setRepoWritable] = useState(false);
@@ -842,6 +846,7 @@ void hydrateQaChat();
 refreshComposerMeta();
 }, [refreshComposerMeta]);
 
+// 清理原生 tool 调用历史（防报错）：与小卷同款——移除上下文里的工具记录与原生元数据
 const handleClearToolHistory = useCallback(() => {
 if (snapshot.isGenerating) {
 onNotice?.("小坊正在执行，完成后再清理。");
@@ -883,6 +888,8 @@ const previewApp = useMemo(
 [previewItem],
 );
 
+/* STREAMING_CHUNK:Event Handlers and Media Processing... */
+// 自动滚动：用户上滚阅读时不拉回底部
 const handleScroll = useCallback(() => {
 const el = bodyRef.current;
 if (!el) return;
@@ -916,8 +923,10 @@ requestAnimationFrame(autoGrow);
 void sendQaMessage(text, images.length ? images : undefined, files.length ? files : undefined);
 }, [input, pendingImages, pendingFiles, snapshot.isGenerating, autoGrow]);
 
-const handlePickImages = useCallback((files: FileList | null) => {
+// 附加图片：仅识图已开启的 API 显示入口；读为 dataURL，单张限 4MB
+const handlePickImages = useCallback((files: FileList | null, isEditMode = false) => {
 if (!files?.length) return;
+const setter = isEditMode ? setEditImages : setPendingImages;
 for (const file of Array.from(files).slice(0, 6)) {
 if (file.size > 4 * 1024 * 1024) {
 onNotice?.(「${file.name}」超过 4MB，已跳过。);
@@ -926,29 +935,33 @@ continue;
 const reader = new FileReader();
 reader.onload = () => {
 const url = typeof reader.result === "string" ? reader.result : "";
-if (url) setPendingImages((current) => (current.length >= 6 ? current : [...current, url]));
+if (url) setter((current) => (current.length >= 6 ? current : [...current, url]));
 };
 reader.readAsDataURL(file);
 }
 if (imageInputRef.current) imageInputRef.current.value = "";
 }, [onNotice]);
 
-const handlePickFiles = useCallback((files: FileList | null) => {
+// 附加文本文件，拦截不可读取的 docx 和 pdf 格式
+const handlePickFiles = useCallback((files: FileList | null, isEditMode = false) => {
 if (!files?.length) return;
-for (const file of Array.from(files).slice(0, 5)) {
-if (file.size > 1024 * 1024) {
-onNotice?.(「${file.name}」超过 1MB，为避免超量占用，已跳过。);
+const setter = isEditMode ? setEditFiles : setPendingFiles;
+for (const file of Array.from(files).slice(0, 6)) {
+if (/.(docx|pdf)$/i.test(file.name)) {
+onNotice?.(工坊暂不支持读取「${file.name}」格式，请上传 txt、md 等纯文本文件。);
+continue;
+}
+if (file.size > 1024 * 1024) { // 纯文本文件限 1MB
+onNotice?.(「${file.name}」太大（超过 1MB），请直接粘贴内容。);
 continue;
 }
 const reader = new FileReader();
 reader.onload = () => {
-const content = reader.result;
-if (typeof content === "string") {
-setPendingFiles((current) => {
-if (current.length >= 5) return current;
+const content = typeof reader.result === "string" ? reader.result : "";
+if (content) setter((current) => {
+if (current.length >= 6 || current.some(f => f.name === file.name)) return current;
 return [...current, { name: file.name, content }];
 });
-}
 };
 reader.readAsText(file);
 }
@@ -970,33 +983,27 @@ void navigator.clipboard?.writeText(content).then(
 const handleEditMessage = useCallback((msg: QaMsg) => {
 setEditingMsg(msg);
 setEditText(msg.content);
+setEditImages(msg.images || []);
+setEditFiles(msg.files || []);
 }, []);
 
-const handleSaveEdit = useCallback(() => {
+const handleSaveEdit = useCallback((andResend: boolean) => {
 if (!editingMsg || !snapshot.activeSessionId) return;
-updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editingMsg.images, editingMsg.files);
+if (andResend) {
+editAndResendQaMessage(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
+} else {
+updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
+}
 setEditingMsg(null);
-onNotice?.("已保存消息内容");
-}, [editingMsg, editText, snapshot.activeSessionId, onNotice]);
-
-const handleEditAndResend = useCallback(() => {
-if (!editingMsg || !snapshot.activeSessionId) return;
-void editAndResendQaMessage(
-snapshot.activeSessionId,
-editingMsg.id,
-editText,
-editingMsg.images,
-editingMsg.files
-);
-setEditingMsg(null);
-onNotice?.("已保存并重新发送，中断后续对话");
-}, [editingMsg, editText, snapshot.activeSessionId, onNotice]);
+onNotice?.(andResend ? "已提交修改" : "已保存消息内容");
+}, [editingMsg, editText, editImages, editFiles, snapshot.activeSessionId, onNotice]);
 
 const streamingMsgId =
 snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
 ? messages[messages.length - 1].id
 : null;
 
+/* STREAMING_CHUNK:Rendering Main Layout... */
 return (
 
 <QaSessionDrawer
@@ -1106,15 +1113,14 @@ setRenameTitle(title);
             </div>
           ))}
           {pendingFiles.map((file, i) => (
-            <div key={`file-${i}`} className="qa-attach-thumb is-file" style={{ display: 'flex', alignItems: 'center', gap: '4px', padding: '0 8px', background: 'var(--surface-3)', borderRadius: '6px', minWidth: 0, height: '48px', flexShrink: 0 }}>
-              <FileText size={15} style={{ flexShrink: 0, opacity: 0.8 }} />
-              <span style={{ fontSize: '12px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '80px' }}>{file.name}</span>
+            <div key={`file-${i}`} className="qa-attach-thumb" style={{ background: "rgba(128,128,128,0.2)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px" }}>
+              <FileText size={16} style={{ minWidth: "16px", marginRight: "4px" }}/>
+              <span style={{ fontSize: "11px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{file.name}</span>
               <button
                 type="button"
                 className="qa-attach-remove"
-                style={{ position: 'static', transform: 'none', marginLeft: '2px', background: 'rgba(0,0,0,0.1)' }}
                 onClick={() => setPendingFiles((current) => current.filter((_, idx) => idx !== i))}
-                aria-label="移除文件"
+                aria-label="移除附件"
               >
                 <X size={11} strokeWidth={2.4} />
               </button>
@@ -1122,7 +1128,6 @@ setRenameTitle(title);
           ))}
         </div>
       )}
-      
       <textarea
         ref={textareaRef}
         className="qa-composer-input hide-scrollbar"
@@ -1134,49 +1139,63 @@ setRenameTitle(title);
           autoGrow();
         }}
       />
+      
       <div className="qa-composer-toolbar">
-        {visionEnabled && (
-          <>
-            <input
-              ref={imageInputRef}
-              type="file"
-              accept="image/*"
-              multiple
-              style={{ display: "none" }}
-              onChange={(e) => handlePickImages(e.target.files)}
-            />
-            <button
-              type="button"
-              className="qa-circle-btn qa-attach-btn"
-              onClick={() => imageInputRef.current?.click()}
-              aria-label="发送图片"
-              title="添加图片"
-            >
-              <Plus size={17} strokeWidth={2.2} />
-            </button>
-          </>
-        )}
-        
-        <>
-          <input
+        {/* 隐藏的文件输入组件全局共用 */}
+        <input
             ref={fileInputRef}
             type="file"
-            accept=".txt,.md,.json,.js,.ts,.jsx,.tsx,.csv,.py,.html,.css"
             multiple
+            accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
             style={{ display: "none" }}
-            onChange={(e) => handlePickFiles(e.target.files)}
-          />
-          <button
-            type="button"
-            className="qa-circle-btn qa-attach-btn"
-            onClick={() => fileInputRef.current?.click()}
-            aria-label="发送文本文件"
-            title="添加文本文件"
-          >
-            <FileText size={16} strokeWidth={2} />
-          </button>
-        </>
-        
+            onChange={(e) => {
+                const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
+                handlePickFiles(e.target.files, isEditMode);
+                e.target.removeAttribute('data-edit-mode');
+            }}
+        />
+        {visionEnabled && (
+            <input
+                ref={imageInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                style={{ display: "none" }}
+                onChange={(e) => {
+                    const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
+                    handlePickImages(e.target.files, isEditMode);
+                    e.target.removeAttribute('data-edit-mode');
+                }}
+            />
+        )}
+
+        {/* 合并后的添加附件/图片菜单 */}
+        <div style={{ position: 'relative' }}>
+            <button
+                type="button"
+                className={`qa-circle-btn qa-attach-btn ${composerMenuOpen ? 'is-active' : ''}`}
+                onClick={() => setComposerMenuOpen(!composerMenuOpen)}
+                aria-label="添加附件/图片"
+            >
+                <Plus size={17} strokeWidth={2.2} />
+            </button>
+            {composerMenuOpen && (
+                <>
+                    <div style={{position: 'fixed', inset: 0, zIndex: 9}} onClick={() => setComposerMenuOpen(false)} />
+                    <div className="qa-drawer-item-menu" style={{ position: 'absolute', bottom: 'calc(100% + 8px)', left: 0, zIndex: 10, right: 'auto', top: 'auto', display: 'flex', flexDirection: 'column', minWidth: '100px' }}>
+                        <button type="button" className="qa-drawer-menu-btn" onClick={() => { fileInputRef.current?.click(); setComposerMenuOpen(false); }}>
+                            <Paperclip size={14} /> 添加附件
+                        </button>
+                        {visionEnabled && (
+                            <button type="button" className="qa-drawer-menu-btn" onClick={() => { imageInputRef.current?.click(); setComposerMenuOpen(false); }}>
+                                <ImageIcon size={14} /> 添加图片
+                            </button>
+                        )}
+                    </div>
+                </>
+            )}
+        </div>
+
         {modelName && <span className="qa-model-pill">{modelName}</span>}
 
         {repoWritable && (
@@ -1247,6 +1266,7 @@ setRenameTitle(title);
   )}
   </div>
 
+  {/* 弹窗与悬浮层组件 */}
   {renameTarget && (
     <div className="qa-rename-backdrop" role="presentation" onClick={() => setRenameTarget(null)}>
       <form
@@ -1309,41 +1329,88 @@ setRenameTitle(title);
     </div>
   )}
 
+  {/* STREAMING_CHUNK:Editing Message Dialog Rendering... */}
   {editingMsg && (
     <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
-      <div className="qa-edit-dialog" role="dialog" aria-label="编辑消息" onClick={(e) => e.stopPropagation()}>
+      <div className="qa-edit-dialog" role="dialog" aria-label="修改消息" onClick={(e) => e.stopPropagation()}>
         <div className="qa-edit-head">
-          <span className="qa-edit-title">编辑消息（未渲染原始内容）</span>
+          <span className="qa-edit-title">修改消息</span>
           <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
             <X size={16} />
           </button>
         </div>
-        <textarea
-          className="qa-edit-textarea"
-          value={editText}
-          onChange={(e) => setEditText(e.target.value)}
-          spellCheck={false}
-          autoFocus
-          placeholder="这里显示的是消息的原始内容，不会被前端渲染，可放心查看特殊标签。"
-        />
-        <div className="qa-edit-actions">
-          <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
-            取消
-          </button>
-          <button type="button" className="qa-devnotice-btn is-primary" onClick={handleSaveEdit}>
-            仅保存
-          </button>
-          {editingMsg.role === "user" && (
-            <button type="button" className="qa-devnotice-btn is-danger" onClick={handleEditAndResend}>
-              保存并重发
-            </button>
-          )}
+        
+        <div style={{ padding: "0 16px 8px 16px" }}>
+            <textarea
+              className="qa-edit-textarea"
+              value={editText}
+              onChange={(e) => setEditText(e.target.value)}
+              spellCheck={false}
+              autoFocus
+              style={{ minHeight: "120px", marginBottom: "8px" }}
+            />
+            
+            <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "8px" }}>
+                {editImages.map((url, i) => (
+                    <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "4px", overflow: "hidden", border: "1px solid rgba(255,255,255,0.1)" }}>
+                        <img src={url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+                        <button
+                            type="button"
+                            style={{ position: "absolute", top: 0, right: 0, background: "rgba(0,0,0,0.5)", color: "white", border: "none", borderRadius: "0 0 0 4px", cursor: "pointer", padding: "2px" }}
+                            onClick={() => setEditImages(current => current.filter((_, idx) => idx !== i))}
+                        >
+                            <X size={10} />
+                        </button>
+                    </div>
+                ))}
+                {editFiles.map((f, i) => (
+                     <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "rgba(255,255,255,0.1)", padding: "4px 20px 4px 8px", borderRadius: "4px", fontSize: "11px", border: "1px solid rgba(255,255,255,0.2)" }}>
+                        <FileText size={12} style={{ marginRight: "4px" }} />
+                        <span style={{ maxWidth: "80px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
+                        <button
+                            type="button"
+                            style={{ position: "absolute", right: "2px", background: "transparent", color: "inherit", border: "none", cursor: "pointer", display: "flex", alignItems: "center" }}
+                            onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}
+                        >
+                            <X size={12} />
+                        </button>
+                    </div>
+                ))}
+            </div>
         </div>
-        {editingMsg.role === "user" && (
-          <div style={{ fontSize: '11px', color: 'var(--text-secondary)', textAlign: 'right', marginTop: '6px' }}>
-            * 重发会截断此消息之后的所有回复并重新触发 AI
-          </div>
-        )}
+        
+        <div className="qa-edit-actions" style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 16px" }}>
+            {/* 左侧的附件添加菜单（精简排版，向上展开防误触） */}
+            <div style={{ position: "relative" }}>
+                <button type="button" className="qa-icon-btn" style={{ padding: "6px" }} onClick={() => setEditAttachMenuOpen(!editAttachMenuOpen)} aria-label="展开添加菜单">
+                    <Plus size={20} />
+                </button>
+                {editAttachMenuOpen && (
+                    <>
+                        <div style={{position: 'fixed', inset: 0, zIndex: 9}} onClick={() => setEditAttachMenuOpen(false)} />
+                        <div className="qa-drawer-item-menu" style={{ position: 'absolute', bottom: 'calc(100% + 4px)', left: 0, zIndex: 10, right: 'auto', top: 'auto', display: 'flex', flexDirection: 'column', minWidth: '100px' }}>
+                            <button type="button" className="qa-drawer-menu-btn" onClick={() => { fileInputRef.current?.setAttribute('data-edit-mode', 'true'); fileInputRef.current?.click(); setEditAttachMenuOpen(false); }}>
+                                <Paperclip size={14} /> 添加附件
+                            </button>
+                            {visionEnabled && (
+                                <button type="button" className="qa-drawer-menu-btn" onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); setEditAttachMenuOpen(false); }}>
+                                    <ImageIcon size={14} /> 添加图片
+                                </button>
+                            )}
+                        </div>
+                    </>
+                )}
+            </div>
+            {/* 右侧直接就是精简的保存和发送 */}
+            <div style={{ display: "flex", gap: "8px" }}>
+                <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
+                    保存
+                </button>
+                <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
+                    保存并发送
+                </button>
+            </div>
+        </div>
       </div>
     </div>
   )}

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -4,7 +4,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExterna
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
-import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, MoreVertical, Pencil, Pin, PinOff, Play, Plus, Square, Trash2, Wrench, X, Paperclip, FileText, Image as ImageIcon } from "lucide-react";
+import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, MoreVertical, Pencil, Pin, PinOff, Play, Plus, Square, Trash2, Wrench, X, Paperclip, FileText } from "lucide-react";
 import { QaFileCard } from "@/components/qa-file-card";
 import { parseQaFileMarker } from "@/lib/qa-computer-tools";
 import { mdiHammerWrench } from "@mdi/js";
@@ -15,1473 +15,1457 @@ import { BlackMarketApp } from "@/components/shopping/black-market-app";
 import { getInstalledCustomApp } from "@/lib/custom-app-storage";
 import type { QaCreatedContent } from "@/lib/qa-agent-tools";
 import {
-applyQaCommit,
-cancelQaCommit,
-clearQaToolHistory,
-createQaSession,
-deleteQaSession,
-getQaActiveContextChars,
-getQaChatSnapshot,
-getQaContextBudgetChars,
-hasQaToolHistory,
-hydrateQaChat,
-QA_CONTEXT_BUDGET_MAX,
-QA_CONTEXT_BUDGET_MIN,
-QA_DEFAULT_CONTEXT_BUDGET_CHARS,
-setQaContextBudgetChars,
-retryQaMessage,
-renameQaSession,
-revertQaAppliedCommit,
-sendQaMessage,
-stopQaGeneration,
-subscribeQaChat,
-switchQaSession,
-toggleQaSessionPin,
-updateQaMessageContent,
-editAndResendQaMessage,
-type QaMsg,
-type QaSession,
-type QaToolStatus,
+  applyQaCommit,
+  cancelQaCommit,
+  clearQaToolHistory,
+  createQaSession,
+  deleteQaSession,
+  getQaActiveContextChars,
+  getQaChatSnapshot,
+  getQaContextBudgetChars,
+  hasQaToolHistory,
+  hydrateQaChat,
+  QA_CONTEXT_BUDGET_MAX,
+  QA_CONTEXT_BUDGET_MIN,
+  QA_DEFAULT_CONTEXT_BUDGET_CHARS,
+  setQaContextBudgetChars,
+  retryQaMessage,
+  renameQaSession,
+  revertQaAppliedCommit,
+  sendQaMessage,
+  stopQaGeneration,
+  subscribeQaChat,
+  switchQaSession,
+  toggleQaSessionPin,
+  updateQaMessageContent,
+  editAndResendQaMessage,
+  type QaMsg,
+  type QaSession,
+  type QaToolStatus,
 } from "@/lib/qa-chat-store";
 import {
-getQaPageChars,
-setQaPageChars,
-QA_DEFAULT_PAGE_CHARS,
-QA_PAGE_CHARS_MIN,
-QA_PAGE_CHARS_MAX,
-getQaMaxRounds,
-setQaMaxRounds,
-QA_DEFAULT_MAX_ROUNDS,
-QA_MAX_ROUNDS_MIN,
-QA_MAX_ROUNDS_MAX,
-getQaMaxOutputTokens,
-setQaMaxOutputTokens,
-QA_DEFAULT_MAX_OUTPUT_TOKENS,
-QA_MAX_OUTPUT_TOKENS_MIN,
-QA_MAX_OUTPUT_TOKENS_MAX,
+  getQaPageChars,
+  setQaPageChars,
+  QA_DEFAULT_PAGE_CHARS,
+  QA_PAGE_CHARS_MIN,
+  QA_PAGE_CHARS_MAX,
+  getQaMaxRounds,
+  setQaMaxRounds,
+  QA_DEFAULT_MAX_ROUNDS,
+  QA_MAX_ROUNDS_MIN,
+  QA_MAX_ROUNDS_MAX,
+  getQaMaxOutputTokens,
+  setQaMaxOutputTokens,
+  QA_DEFAULT_MAX_OUTPUT_TOKENS,
+  QA_MAX_OUTPUT_TOKENS_MIN,
+  QA_MAX_OUTPUT_TOKENS_MAX,
 } from "@/lib/qa-prefs";
 import { resolveQaApiConfig } from "@/lib/qa-agent-engine";
 import {
-loadQaGithubConfig,
-saveQaGithubConfig,
-clearQaGithubConfig,
-validateQaGithubConfig,
-type QaGithubConfig,
-type QaGithubValidation,
+  loadQaGithubConfig,
+  saveQaGithubConfig,
+  clearQaGithubConfig,
+  validateQaGithubConfig,
+  type QaGithubConfig,
+  type QaGithubValidation,
 } from "@/lib/qa-github";
 import "@/lib/qa-error-log";
 
 type PhoneQaAppProps = {
-onClose: () => void;
-onNotice?: (msg: string) => void;
+  onClose: () => void;
+  onNotice?: (msg: string) => void;
 };
 
 const SUGGESTIONS = [
-"怎么添加我的 API？",
-"聊天没有回复怎么排查？",
-"怎么部署到 Netlify / Vercel？",
-"数据存在哪里，怎么备份？",
-"帮我写个小游戏装到本机",
+  "怎么添加我的 API？",
+  "聊天没有回复怎么排查？",
+  "怎么部署到 Netlify / Vercel？",
+  "数据存在哪里，怎么备份？",
+  "帮我写个小游戏装到本机",
 ];
 
-// 注意这里已经修复了反引号丢失的问题
 function formatRelativeTime(ts: number): string {
-const diff = Date.now() - ts;
-if (diff < 60_000) return "刚刚";
-if (diff < 3_600_000) return ${Math.floor(diff / 60_000)} 分钟前;
-if (diff < 86_400_000) return ${Math.floor(diff / 3_600_000)} 小时前;
-return ${Math.floor(diff / 86_400_000)} 天前;
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return "刚刚";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟前`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前`;
+  return `${Math.floor(diff / 86_400_000)} 天前`;
 }
 
 // ── 代码块（语言标签 + 一键复制）─────────────────────
 
 function QaCodeBlock({ className, children }: { className?: string; children?: React.ReactNode }) {
-const [copied, setCopied] = useState(false);
-const language = /language-(\w+)/.exec(className || "")?.[1] ?? "";
-const code = String(children ?? "").replace(/\n$/, "");
+  const [copied, setCopied] = useState(false);
+  const language = /language-(\w+)/.exec(className || "")?.[1] ?? "";
+  const code = String(children ?? "").replace(/\n$/, "");
 
-const handleCopy = useCallback(() => {
-navigator.clipboard
-?.writeText(code)
-.then(() => {
-setCopied(true);
-setTimeout(() => setCopied(false), 1500);
-})
-.catch(() => {});
-}, [code]);
+  const handleCopy = useCallback(() => {
+    navigator.clipboard
+      ?.writeText(code)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {});
+  }, [code]);
 
-return (
-
-
-{language || "code"}
-
-{copied ?  : }
-
-
-
-{code}
-
-
-);
+  return (
+    <div className="qa-codeblock">
+      <div className="qa-codeblock-head">
+        <span className="qa-codeblock-lang">{language || "code"}</span>
+        <button type="button" className="qa-codeblock-copy" onClick={handleCopy} aria-label="复制代码">
+          {copied ? <Check size={13} /> : <Copy size={13} />}
+        </button>
+      </div>
+      <pre>
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
 }
 
 const QA_MARKDOWN_COMPONENTS = {
-pre({ children }: { children?: React.ReactNode }) {
-return <>{children}</>;
-},
-code(props: { className?: string; children?: React.ReactNode }) {
-const { className, children } = props;
-const isBlock = /language-/.test(className || "") || String(children ?? "").includes("\n");
-if (isBlock) return {children};
-return {children};
-},
-a({ href, children }: { href?: string; children?: React.ReactNode }) {
-return (
-
-{children}
-
-);
-},
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+  pre({ children }: { children?: React.ReactNode }) {
+    return <>{children}</>;
+  },
+  code(props: { className?: string; children?: React.ReactNode }) {
+    const { className, children } = props;
+    const isBlock = /language-/.test(className || "") || String(children ?? "").includes("\n");
+    if (isBlock) return <QaCodeBlock className={className}>{children}</QaCodeBlock>;
+    return <code className="qa-inline-code">{children}</code>;
+  },
+  a({ href, children }: { href?: string; children?: React.ReactNode }) {
+    return (
+      <a href={href} target="_blank" rel="noreferrer noopener">
+        {children}
+      </a>
+    );
+  },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any;
 
 // ── 提交提案卡片 ─────────────────────────────────────
 
 function QaCommitCard({ msg }: { msg: QaMsg }) {
-const pending = msg.pendingCommit;
-const [busy, setBusy] = useState(false);
-if (!pending) return null;
-const { proposal, status, result, error } = pending;
-const files = proposal.files;
+  const pending = msg.pendingCommit;
+  const [busy, setBusy] = useState(false);
+  if (!pending) return null;
+  const { proposal, status, result, error } = pending;
+  const files = proposal.files;
 
-const apply = async () => {
-setBusy(true);
-await applyQaCommit(msg.id);
-setBusy(false);
-};
-const revert = async () => {
-setBusy(true);
-await revertQaAppliedCommit(msg.id);
-setBusy(false);
-};
+  const apply = async () => {
+    setBusy(true);
+    await applyQaCommit(msg.id);
+    setBusy(false);
+  };
+  const revert = async () => {
+    setBusy(true);
+    await revertQaAppliedCommit(msg.id);
+    setBusy(false);
+  };
 
-return (
-<div className={qa-commit-card status-${status}}>
-
-
-{status === "applied" ? "已提交" : status === "reverted" ? "已撤销" : status === "canceled" ? "已取消" : "修改提案"}
-
-{proposal.branch || "默认分支"} · {files.length + (proposal.deletes?.length ?? 0)} 个文件
-
-{proposal.message}
-
-{files.map((f) => (
-{f.path}
-))}
-{(proposal.deletes ?? []).map((path) => (
-<li key={del-${path}} className="qa-commit-file-delete">− {path}（删除）
-))}
-
-{error && {error}}
-{status === "pending" && (
-
-
-{busy ?  : "应用"}
-
-<button type="button" className="qa-commit-btn" onClick={() => cancelQaCommit(msg.id)} disabled={busy}>
-取消
-
-
-)}
-{(status === "applying" || status === "reverting") && (
-
-
- {status === "applying" ? "提交中…" : "撤销中…"}
-
-
-)}
-{status === "applied" && result && (
-
-
-查看 commit {result.sha.slice(0, 7)}
-
-
-撤销
-
-
-)}
-
-);
+  return (
+    <div className={`qa-commit-card status-${status}`}>
+      <div className="qa-commit-head">
+        <span className="qa-commit-title">
+          {status === "applied" ? "已提交" : status === "reverted" ? "已撤销" : status === "canceled" ? "已取消" : "修改提案"}
+        </span>
+        <span className="qa-commit-branch">{proposal.branch || "默认分支"} · {files.length + (proposal.deletes?.length ?? 0)} 个文件</span>
+      </div>
+      <div className="qa-commit-msg">{proposal.message}</div>
+      <ul className="qa-commit-files">
+        {files.map((f) => (
+          <li key={f.path}>{f.path}</li>
+        ))}
+        {(proposal.deletes ?? []).map((path) => (
+          <li key={`del-${path}`} className="qa-commit-file-delete">− {path}（删除）</li>
+        ))}
+      </ul>
+      {error && <div className="qa-commit-error">{error}</div>}
+      {status === "pending" && (
+        <div className="qa-commit-actions">
+          <button type="button" className="qa-commit-btn is-primary" onClick={apply} disabled={busy}>
+            {busy ? <Loader2 size={13} className="qa-spin" /> : "应用"}
+          </button>
+          <button type="button" className="qa-commit-btn" onClick={() => cancelQaCommit(msg.id)} disabled={busy}>
+            取消
+          </button>
+        </div>
+      )}
+      {(status === "applying" || status === "reverting") && (
+        <div className="qa-commit-actions">
+          <span className="qa-commit-progress">
+            <Loader2 size={13} className="qa-spin" /> {status === "applying" ? "提交中…" : "撤销中…"}
+          </span>
+        </div>
+      )}
+      {status === "applied" && result && (
+        <div className="qa-commit-actions">
+          <a className="qa-commit-link" href={result.htmlUrl} target="_blank" rel="noreferrer noopener">
+            查看 commit {result.sha.slice(0, 7)}
+          </a>
+          <button type="button" className="qa-commit-btn is-danger" onClick={revert} disabled={busy}>
+            撤销
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }
 
 // ── 消息渲染 ─────────────────────────────────────────
 
+// 工具调用行：折叠的单行摘要，点开展开参数与结果（Claude Code 风格）
 function QaToolRow({ tool }: { tool: QaToolStatus }) {
-const [open, setOpen] = useState(false);
-const { text: resultText, file } = parseQaFileMarker(tool.result || "");
-const hasDetail = Boolean(tool.detail || resultText);
-const summary = tool.running ? 正在${tool.name}… : tool.success === false ? ${tool.name}失败 : tool.name;
-return (
-<div className={qa-tool-row ${tool.running ? "is-running" : tool.success === false ? "is-fail" : "is-done"}}>
-<button
-type="button"
-className="qa-tool-row-head"
-onClick={() => hasDetail && setOpen((v) => !v)}
-disabled={!hasDetail}
->
-{tool.running ?  : }
-
-{summary}
-{tool.subtitle && {tool.subtitle}}
-
-{hasDetail && <ChevronRight size={14} className={qa-tool-row-chevron ${open ? "is-open" : ""}} />}
-
-{open && hasDetail && (
-
-{tool.detail && (
-<>
-参数
-{tool.detail}
-</>
-)}
-{resultText && (
-<>
-结果
-{resultText}
-</>
-)}
-
-)}
-{file && }
-
-);
+  const [open, setOpen] = useState(false);
+  // 「电脑文件 op=send」的结果里带文件卡标记：卡片常显，标记从结果文本中剥离
+  const { text: resultText, file } = parseQaFileMarker(tool.result || "");
+  const hasDetail = Boolean(tool.detail || resultText);
+  const summary = tool.running ? `正在${tool.name}…` : tool.success === false ? `${tool.name}失败` : tool.name;
+  return (
+    <div className={`qa-tool-row ${tool.running ? "is-running" : tool.success === false ? "is-fail" : "is-done"}`}>
+      <button
+        type="button"
+        className="qa-tool-row-head"
+        onClick={() => hasDetail && setOpen((v) => !v)}
+        disabled={!hasDetail}
+      >
+        {tool.running ? <Loader2 size={13} className="qa-spin" /> : <Wrench size={13} />}
+        <span className="qa-tool-row-summary">
+          {summary}
+          {tool.subtitle && <span className="qa-tool-row-sub">{tool.subtitle}</span>}
+        </span>
+        {hasDetail && <ChevronRight size={14} className={`qa-tool-row-chevron ${open ? "is-open" : ""}`} />}
+      </button>
+      {open && hasDetail && (
+        <div className="qa-tool-row-body">
+          {tool.detail && (
+            <>
+              <div className="qa-tool-row-label">参数</div>
+              <pre className="qa-tool-row-pre">{tool.detail}</pre>
+            </>
+          )}
+          {resultText && (
+            <>
+              <div className="qa-tool-row-label">结果</div>
+              <pre className="qa-tool-row-pre">{resultText}</pre>
+            </>
+          )}
+        </div>
+      )}
+      {file && <QaFileCard file={file} />}
+    </div>
+  );
 }
 
+// 已完成文本的 Markdown 渲染：memo 缓存——流式期间每次增量都全文重排 remark 是
+// 低端机 WebView OOM 崩溃的主因（几万字 × 每秒多次解析）。文本不变就不重渲。
 const QaMarkdownBlock = memo(function QaMarkdownBlock({ text }: { text: string }) {
-return (
-<ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={QA_MARKDOWN_COMPONENTS}>
-{text}
-
-);
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={QA_MARKDOWN_COMPONENTS}>
+      {text}
+    </ReactMarkdown>
+  );
 });
 
+// 正在生长的活跃段：纯文本渲染（零解析成本），生成结束后换回完整 Markdown
 function QaStreamingText({ text }: { text: string }) {
-return (
-<>
-{text}
-
-</>
-);
+  return (
+    <>
+      <div className="qa-stream-text">{text}</div>
+      <span className="qa-cursor" />
+    </>
+  );
 }
 
 const QaMessageItem = memo(function QaMessageItem({
-msg,
-isStreaming,
-onRetry,
-onViewImage,
-onCopy,
-onEdit,
+  msg,
+  isStreaming,
+  onRetry,
+  onViewImage,
+  onCopy,
+  onEdit,
 }: {
-msg: QaMsg;
-isStreaming: boolean;
-onRetry: (id: string) => void;
-onViewImage: (url: string) => void;
-onCopy: (content: string) => void;
-onEdit: (msg: QaMsg) => void;
+  msg: QaMsg;
+  isStreaming: boolean;
+  onRetry: (id: string) => void;
+  onViewImage: (url: string) => void;
+  onCopy: (content: string) => void;
+  onEdit: (msg: QaMsg) => void;
 }) {
-const thinkingOnly = isStreaming && !msg.content && (!msg.tools || msg.tools.length === 0);
-const showActions = !isStreaming && !thinkingOnly;
-const msgWrap = (node: ReactNode) => (
+  const thinkingOnly = isStreaming && !msg.content && (!msg.tools || msg.tools.length === 0);
+  const showActions = !isStreaming && !thinkingOnly;
+  const msgWrap = (node: ReactNode) => (
+    <div className="qa-msg-wrap">
+      {node}
+      {showActions && (
+        <div className="qa-msg-actions" data-role={msg.role}>
+          <button type="button" className="qa-msg-action" aria-label="复制原始内容" title="复制" onClick={() => onCopy(msg.content)}>
+            <Copy size={14} strokeWidth={2} />
+          </button>
+          <button type="button" className="qa-msg-action" aria-label="修改消息" title="修改" onClick={() => onEdit(msg)}>
+            <Pencil size={14} strokeWidth={2} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+  
+  const segmentBlocks = useMemo(() => {
+    if (!msg.segments?.length) return null;
+    const blocks: Array<{ kind: "text"; text: string } | { kind: "tools"; tools: QaToolStatus[] }> = [];
+    for (const seg of msg.segments) {
+      const last = blocks[blocks.length - 1];
+      if (seg.kind === "tool") {
+        if (last?.kind === "tools") last.tools.push(seg.tool);
+        else blocks.push({ kind: "tools", tools: [seg.tool] });
+      } else if (seg.text.trim()) {
+        if (last?.kind === "text") last.text += seg.text;
+        else blocks.push({ kind: "text", text: seg.text });
+      }
+    }
+    return blocks.length ? blocks : null;
+  }, [msg.segments]);
 
-{node}
-{showActions && (
+  if (msg.role === "user") {
+    return msgWrap(
+      <div className="qa-msg-user-row">
+        <div className="qa-msg-user">
+          {msg.images && msg.images.length > 0 && (
+            <div className="qa-msg-images">
+              {msg.images.map((url, i) => (
+                <button key={i} type="button" className="qa-msg-image" onClick={() => onViewImage(url)} aria-label="查看图片">
+                  <img src={url} alt="" />
+                </button>
+              ))}
+            </div>
+          )}
+          {msg.files && msg.files.length > 0 && (
+            <div className="qa-msg-files" style={{ display: "flex", flexDirection: "column", gap: "4px", marginBottom: "8px" }}>
+              {msg.files.map((f, i) => (
+                <div key={i} style={{ display: "flex", alignItems: "center", gap: "6px", background: "rgba(255,255,255,0.1)", padding: "4px 8px", borderRadius: "6px", fontSize: "12px", border: "1px solid rgba(255,255,255,0.2)" }}>
+                   <FileText size={14} />
+                   <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: "150px" }}>{f.name}</span>
+                </div>
+              ))}
+            </div>
+          )}
+          {msg.content}
+        </div>
+      </div>,
+    );
+  }
 
-<button type="button" className="qa-msg-action" aria-label="复制原始内容" title="复制" onClick={() => onCopy(msg.content)}>
-
-
-<button type="button" className="qa-msg-action" aria-label="修改消息" title="修改" onClick={() => onEdit(msg)}>
-
-
-
-)}
-
-);
-
-const segmentBlocks = useMemo(() => {
-if (!msg.segments?.length) return null;
-const blocks: Array<{ kind: "text"; text: string } | { kind: "tools"; tools: QaToolStatus[] }> = [];
-for (const seg of msg.segments) {
-const last = blocks[blocks.length - 1];
-if (seg.kind === "tool") {
-if (last?.kind === "tools") last.tools.push(seg.tool);
-else blocks.push({ kind: "tools", tools: [seg.tool] });
-} else if (seg.text.trim()) {
-if (last?.kind === "text") last.text += seg.text;
-else blocks.push({ kind: "text", text: seg.text });
-}
-}
-return blocks.length ? blocks : null;
-}, [msg.segments]);
-
-if (msg.role === "user") {
-return msgWrap(
-
-
-{msg.images && msg.images.length > 0 && (
-
-{msg.images.map((url, i) => (
-<button key={i} type="button" className="qa-msg-image" onClick={() => onViewImage(url)} aria-label="查看图片">
-
-
-))}
-
-)}
-{msg.files && msg.files.length > 0 && (
-<div className="qa-msg-files" style={{ display: "flex", flexDirection: "column", gap: "4px", marginBottom: "8px" }}>
-{msg.files.map((f, i) => (
-<div key={i} style={{ display: "flex", alignItems: "center", gap: "6px", background: "rgba(255,255,255,0.1)", padding: "4px 8px", borderRadius: "6px", fontSize: "12px", border: "1px solid rgba(255,255,255,0.2)" }}>
-
-<span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: "150px" }}>{f.name}
-
-))}
-
-)}
-{msg.content}
-
-,
-);
-}
-
-return msgWrap(
-
-{segmentBlocks ? (
-segmentBlocks.map((block, i) =>
-block.kind === "tools" ? (
-
-{block.tools.map((tool, j) => (
-<QaToolRow key={${tool.name}-${j}} tool={tool} />
-))}
-
-) : isStreaming && i === segmentBlocks.length - 1 ? (
-
-
-
-) : (
-
-
-
-),
-)
-) : (
-<>
-{msg.tools && msg.tools.length > 0 && (
-
-{msg.tools.map((tool, i) => (
-<QaToolRow key={${tool.name}-${i}} tool={tool} />
-))}
-
-)}
-{thinkingOnly ? (
-{msg.toolDrafting ? "正在编写工具调用…" : msg.reasoning ? "正在思考…" : "正在生成…"}
-) : isStreaming ? (
-
-
-
-) : (
-
-
-
-)}
-</>
-)}
-{isStreaming && msg.toolDrafting && !thinkingOnly && (
-正在编写工具调用…
-)}
-{msg.streamNote && {msg.streamNote}}
-{msg.pendingCommit && }
-{msg.aborted && 已停止生成}
-{msg.error && (
-
-{msg.error}
-<button type="button" className="qa-retry-btn" onClick={() => onRetry(msg.id)}>
-重试
-
-
-)}
-,
-);
+  return msgWrap(
+    <div className="qa-msg-assistant">
+      {segmentBlocks ? (
+        segmentBlocks.map((block, i) =>
+          block.kind === "tools" ? (
+            <div className="qa-tools" key={i}>
+              {block.tools.map((tool, j) => (
+                <QaToolRow key={`${tool.name}-${j}`} tool={tool} />
+              ))}
+            </div>
+          ) : isStreaming && i === segmentBlocks.length - 1 ? (
+            <div className="qa-markdown" key={i}>
+              <QaStreamingText text={block.text} />
+            </div>
+          ) : (
+            <div className="qa-markdown" key={i}>
+              <QaMarkdownBlock text={block.text} />
+            </div>
+          ),
+        )
+      ) : (
+        <>
+          {msg.tools && msg.tools.length > 0 && (
+            <div className="qa-tools">
+              {msg.tools.map((tool, i) => (
+                <QaToolRow key={`${tool.name}-${i}`} tool={tool} />
+              ))}
+            </div>
+          )}
+          {thinkingOnly ? (
+            <div className="qa-thinking">{msg.toolDrafting ? "正在编写工具调用…" : msg.reasoning ? "正在思考…" : "正在生成…"}</div>
+          ) : isStreaming ? (
+            <div className="qa-markdown">
+              <QaStreamingText text={msg.content} />
+            </div>
+          ) : (
+            <div className="qa-markdown">
+              <QaMarkdownBlock text={msg.content} />
+            </div>
+          )}
+        </>
+      )}
+      {isStreaming && msg.toolDrafting && !thinkingOnly && (
+        <div className="qa-thinking qa-tool-drafting">正在编写工具调用…</div>
+      )}
+      {msg.streamNote && <div className="qa-msg-note">{msg.streamNote}</div>}
+      {msg.pendingCommit && <QaCommitCard msg={msg} />}
+      {msg.aborted && <div className="qa-msg-note">已停止生成</div>}
+      {msg.error && (
+        <div className="qa-msg-error">
+          <div className="qa-msg-error-text">{msg.error}</div>
+          <button type="button" className="qa-retry-btn" onClick={() => onRetry(msg.id)}>
+            重试
+          </button>
+        </div>
+      )}
+    </div>,
+  );
 });
 
 // ── 会话抽屉 ─────────────────────────────────────────
 
 function QaSessionDrawer({
-sessions,
-activeId,
-onSelect,
-onDelete,
-onCreate,
-onOpenSettings,
-onRenameRequest,
+  sessions,
+  activeId,
+  onSelect,
+  onDelete,
+  onCreate,
+  onOpenSettings,
+  onRenameRequest,
 }: {
-sessions: QaSession[];
-activeId: string | null;
-onSelect: (id: string) => void;
-onDelete: (id: string) => void;
-onCreate: () => void;
-onOpenSettings: () => void;
-onRenameRequest: (id: string, title: string) => void;
+  sessions: QaSession[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
+  onCreate: () => void;
+  onOpenSettings: () => void;
+  onRenameRequest: (id: string, title: string) => void;
 }) {
-const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 
-const sortedSessions = useMemo(() => {
-return [...sessions].sort((a, b) => {
-if (Boolean(a.isPinned) !== Boolean(b.isPinned)) return a.isPinned ? -1 : 1;
-return b.updatedAt - a.updatedAt;
-});
-}, [sessions]);
+  // 置顶的排最前，其余保持时间序。只在渲染层排，存储顺序不动
+  const sortedSessions = useMemo(() => {
+    return [...sessions].sort((a, b) => {
+      if (Boolean(a.isPinned) !== Boolean(b.isPinned)) return a.isPinned ? -1 : 1;
+      return b.updatedAt - a.updatedAt;
+    });
+  }, [sessions]);
 
-return (
-
-
-对话记录
-
-<div
-className="qa-drawer-list hide-scrollbar"
-onClick={() => { if (menuOpenId) setMenuOpenId(null); }}
->
-{sortedSessions.length === 0 && 还没有对话}
-{sortedSessions.map((session) => (
-<div
-key={session.id}
-className={qa-drawer-item ${session.id === activeId ? "is-active" : ""}}
-onClick={() => onSelect(session.id)}
->
-
-
-{session.isPinned && }
-{session.title}
-
-{formatRelativeTime(session.updatedAt)}
-
-<button
-type="button"
-className="qa-icon-btn qa-drawer-item-more"
-aria-label="更多操作"
-aria-expanded={menuOpenId === session.id}
-onClick={(e) => {
-e.stopPropagation();
-setMenuOpenId(menuOpenId === session.id ? null : session.id);
-}}
->
-
-
-
-        {menuOpenId === session.id && (
-          <div className="qa-drawer-item-menu" role="menu">
-            <button
-              type="button"
-              role="menuitem"
-              className="qa-drawer-menu-btn"
-              onClick={(e) => {
-                e.stopPropagation();
-                toggleQaSessionPin(session.id);
-                setMenuOpenId(null);
-              }}
-            >
-              {session.isPinned ? <PinOff size={14} /> : <Pin size={14} />}
-              {session.isPinned ? "取消置顶" : "置顶"}
-            </button>
-            <button
-              type="button"
-              role="menuitem"
-              className="qa-drawer-menu-btn"
-              onClick={(e) => {
-                e.stopPropagation();
-                onRenameRequest(session.id, session.title);
-                setMenuOpenId(null);
-              }}
-            >
-              <Pencil size={14} /> 重命名
-            </button>
-            <button
-              type="button"
-              role="menuitem"
-              className="qa-drawer-menu-btn is-danger"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(session.id);
-                setMenuOpenId(null);
-              }}
-            >
-              <Trash2 size={14} /> 删除
-            </button>
-          </div>
-        )}
+  return (
+    <aside className="qa-drawer">
+      <div className="qa-drawer-head">
+        <span className="qa-drawer-title">对话记录</span>
       </div>
-    ))}
-  </div>
-  <div className="qa-drawer-foot">
-    <button type="button" className="qa-drawer-new qa-drawer-settings" onClick={onOpenSettings}>
-      <Wrench size={15} strokeWidth={2} />
-      <span>工坊配置</span>
-    </button>
-    <button type="button" className="qa-drawer-new" onClick={onCreate}>
-      <Plus size={16} strokeWidth={2} />
-      <span>新对话</span>
-    </button>
-  </div>
-</aside>
+      <div
+        className="qa-drawer-list hide-scrollbar"
+        onClick={() => { if (menuOpenId) setMenuOpenId(null); }}
+      >
+        {sortedSessions.length === 0 && <div className="qa-drawer-empty">还没有对话</div>}
+        {sortedSessions.map((session) => (
+          <div
+            key={session.id}
+            className={`qa-drawer-item ${session.id === activeId ? "is-active" : ""}`}
+            onClick={() => onSelect(session.id)}
+          >
+            <div className="qa-drawer-item-main">
+              <span className="qa-drawer-item-title">
+                {session.isPinned && <Pin size={12} className="qa-drawer-pin-mark" aria-label="已置顶" />}
+                {session.title}
+              </span>
+              <span className="qa-drawer-item-time">{formatRelativeTime(session.updatedAt)}</span>
+            </div>
+            <button
+              type="button"
+              className="qa-icon-btn qa-drawer-item-more"
+              aria-label="更多操作"
+              aria-expanded={menuOpenId === session.id}
+              onClick={(e) => {
+                e.stopPropagation();
+                setMenuOpenId(menuOpenId === session.id ? null : session.id);
+              }}
+            >
+              <MoreVertical size={14} />
+            </button>
 
-
-);
+            {menuOpenId === session.id && (
+              <div className="qa-drawer-item-menu" role="menu">
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="qa-drawer-menu-btn"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleQaSessionPin(session.id);
+                    setMenuOpenId(null);
+                  }}
+                >
+                  {session.isPinned ? <PinOff size={14} /> : <Pin size={14} />}
+                  {session.isPinned ? "取消置顶" : "置顶"}
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="qa-drawer-menu-btn"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRenameRequest(session.id, session.title);
+                    setMenuOpenId(null);
+                  }}
+                >
+                  <Pencil size={14} /> 重命名
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="qa-drawer-menu-btn is-danger"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete(session.id);
+                    setMenuOpenId(null);
+                  }}
+                >
+                  <Trash2 size={14} /> 删除
+                </button>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="qa-drawer-foot">
+        <button type="button" className="qa-drawer-new qa-drawer-settings" onClick={onOpenSettings}>
+          <Wrench size={15} strokeWidth={2} />
+          <span>工坊配置</span>
+        </button>
+        <button type="button" className="qa-drawer-new" onClick={onCreate}>
+          <Plus size={16} strokeWidth={2} />
+          <span>新对话</span>
+        </button>
+      </div>
+    </aside>
+  );
 }
 
 // ── 工坊配置面板 ─────────────────────────────────────
 
 function QaSettingsSheet({ onClose, onNotice }: { onClose: () => void; onNotice?: (msg: string) => void }) {
-const [budget, setBudget] = useState(() => String(getQaContextBudgetChars()));
-const [pageChars, setPageChars] = useState(() => String(getQaPageChars()));
-const [maxRounds, setMaxRounds] = useState(() => String(getQaMaxRounds()));
-const [maxOutTokens, setMaxOutTokens] = useState(() => {
-const v = getQaMaxOutputTokens();
-return v == null ? "" : String(v);
-});
-const usedChars = getQaActiveContextChars();
-const pct = Math.round((usedChars / getQaContextBudgetChars()) * 100);
+  const [budget, setBudget] = useState(() => String(getQaContextBudgetChars()));
+  const [pageChars, setPageChars] = useState(() => String(getQaPageChars()));
+  const [maxRounds, setMaxRounds] = useState(() => String(getQaMaxRounds()));
+  const [maxOutTokens, setMaxOutTokens] = useState(() => {
+    const v = getQaMaxOutputTokens();
+    return v == null ? "" : String(v);
+  });
+  const usedChars = getQaActiveContextChars();
+  const pct = Math.round((usedChars / getQaContextBudgetChars()) * 100);
 
-const save = () => {
-const parsed = Number(budget);
-if (!Number.isFinite(parsed) || parsed < QA_CONTEXT_BUDGET_MIN || parsed > QA_CONTEXT_BUDGET_MAX) {
-onNotice?.(预算需为 ${QA_CONTEXT_BUDGET_MIN.toLocaleString()} - ${QA_CONTEXT_BUDGET_MAX.toLocaleString()} 之间的数字。);
-return;
-}
-const parsedPage = Number(pageChars);
-if (!Number.isFinite(parsedPage) || parsedPage < QA_PAGE_CHARS_MIN || parsedPage > QA_PAGE_CHARS_MAX) {
-onNotice?.(单页字符数需为 ${QA_PAGE_CHARS_MIN.toLocaleString()} - ${QA_PAGE_CHARS_MAX.toLocaleString()} 之间的数字。);
-return;
-}
-const parsedRounds = Number(maxRounds);
-if (!Number.isFinite(parsedRounds) || parsedRounds < QA_MAX_ROUNDS_MIN || parsedRounds > QA_MAX_ROUNDS_MAX) {
-onNotice?.(工具调用上限需为 ${QA_MAX_ROUNDS_MIN} - ${QA_MAX_ROUNDS_MAX} 之间的数字。);
-return;
-}
-const trimmedTokens = maxOutTokens.trim();
-const parsedTokens = trimmedTokens ? Number(trimmedTokens) : null;
-if (parsedTokens != null && (!Number.isFinite(parsedTokens) || parsedTokens < QA_MAX_OUTPUT_TOKENS_MIN || parsedTokens > QA_MAX_OUTPUT_TOKENS_MAX)) {
-onNotice?.(单次最大输出 token 需留空或为 ${QA_MAX_OUTPUT_TOKENS_MIN.toLocaleString()} - ${QA_MAX_OUTPUT_TOKENS_MAX.toLocaleString()} 之间的数字。);
-return;
-}
-setQaContextBudgetChars(parsed);
-setQaPageChars(parsedPage);
-setQaMaxRounds(parsedRounds);
-setQaMaxOutputTokens(trimmedTokens ? parsedTokens : 0);
-onNotice?.("已保存工坊配置。");
-onClose();
-};
+  const save = () => {
+    const parsed = Number(budget);
+    if (!Number.isFinite(parsed) || parsed < QA_CONTEXT_BUDGET_MIN || parsed > QA_CONTEXT_BUDGET_MAX) {
+      onNotice?.(`预算需为 ${QA_CONTEXT_BUDGET_MIN.toLocaleString()} - ${QA_CONTEXT_BUDGET_MAX.toLocaleString()} 之间的数字。`);
+      return;
+    }
+    const parsedPage = Number(pageChars);
+    if (!Number.isFinite(parsedPage) || parsedPage < QA_PAGE_CHARS_MIN || parsedPage > QA_PAGE_CHARS_MAX) {
+      onNotice?.(`单页字符数需为 ${QA_PAGE_CHARS_MIN.toLocaleString()} - ${QA_PAGE_CHARS_MAX.toLocaleString()} 之间的数字。`);
+      return;
+    }
+    const parsedRounds = Number(maxRounds);
+    if (!Number.isFinite(parsedRounds) || parsedRounds < QA_MAX_ROUNDS_MIN || parsedRounds > QA_MAX_ROUNDS_MAX) {
+      onNotice?.(`工具调用上限需为 ${QA_MAX_ROUNDS_MIN} - ${QA_MAX_ROUNDS_MAX} 之间的数字。`);
+      return;
+    }
+    const trimmedTokens = maxOutTokens.trim();
+    const parsedTokens = trimmedTokens ? Number(trimmedTokens) : null;
+    if (parsedTokens != null && (!Number.isFinite(parsedTokens) || parsedTokens < QA_MAX_OUTPUT_TOKENS_MIN || parsedTokens > QA_MAX_OUTPUT_TOKENS_MAX)) {
+      onNotice?.(`单次最大输出 token 需留空或为 ${QA_MAX_OUTPUT_TOKENS_MIN.toLocaleString()} - ${QA_MAX_OUTPUT_TOKENS_MAX.toLocaleString()} 之间的数字。`);
+      return;
+    }
+    setQaContextBudgetChars(parsed);
+    setQaPageChars(parsedPage);
+    setQaMaxRounds(parsedRounds);
+    setQaMaxOutputTokens(trimmedTokens ? parsedTokens : 0);
+    onNotice?.("已保存工坊配置。");
+    onClose();
+  };
 
-const reset = () => {
-setQaContextBudgetChars(null);
-setQaPageChars(null);
-setQaMaxRounds(null);
-setQaMaxOutputTokens(null);
-setBudget(String(QA_DEFAULT_CONTEXT_BUDGET_CHARS));
-setPageChars(String(QA_DEFAULT_PAGE_CHARS));
-setMaxRounds(String(QA_DEFAULT_MAX_ROUNDS));
-setMaxOutTokens(String(QA_DEFAULT_MAX_OUTPUT_TOKENS));
-onNotice?.("已恢复默认配置。");
-};
+  const reset = () => {
+    setQaContextBudgetChars(null);
+    setQaPageChars(null);
+    setQaMaxRounds(null);
+    setQaMaxOutputTokens(null);
+    setBudget(String(QA_DEFAULT_CONTEXT_BUDGET_CHARS));
+    setPageChars(String(QA_DEFAULT_PAGE_CHARS));
+    setMaxRounds(String(QA_DEFAULT_MAX_ROUNDS));
+    setMaxOutTokens(String(QA_DEFAULT_MAX_OUTPUT_TOKENS));
+    onNotice?.("已恢复默认配置。");
+  };
 
-return (
-
-<div className="qa-devnotice" role="dialog" aria-label="工坊配置" onClick={(e) => e.stopPropagation()}>
-工坊配置
-
-上下文预算（字符）
-<input
-type="number"
-inputMode="numeric"
-min={QA_CONTEXT_BUDGET_MIN}
-max={QA_CONTEXT_BUDGET_MAX}
-step={1000}
-value={budget}
-onChange={(e) => setBudget(e.target.value)}
-/>
-
-
-上下文满 100% 时自动压缩成摘要并重新累计。中文约 1 字符 ≈ 1 token；默认 {QA_DEFAULT_CONTEXT_BUDGET_CHARS.toLocaleString()}，小上下文（32k）模型建议 30000–50000。
-
-当前会话已用 {usedChars.toLocaleString()} 字符（约 {pct}%）。
-
-单页读取字符数
-<input
-type="number"
-inputMode="numeric"
-min={QA_PAGE_CHARS_MIN}
-max={QA_PAGE_CHARS_MAX}
-step={1000}
-value={pageChars}
-onChange={(e) => setPageChars(e.target.value)}
-/>
-
-
-小坊翻页读答疑文档 / 本机内容 / 仓库源码时，每页返回的字符数。默认 {QA_DEFAULT_PAGE_CHARS.toLocaleString()}；调大读得快但更占上下文，小上下文模型建议调小。
-
-
-单轮工具调用上限（次）
-<input
-type="number"
-inputMode="numeric"
-min={QA_MAX_ROUNDS_MIN}
-max={QA_MAX_ROUNDS_MAX}
-step={1}
-value={maxRounds}
-onChange={(e) => setMaxRounds(e.target.value)}
-/>
-
-
-一次提问里小坊最多连续执行多少轮工具，用完会提示「回复继续」。默认 {QA_DEFAULT_MAX_ROUNDS}；复杂任务（写游戏、改代码）可调大，想控制 token 消耗可调小。
-
-
-单次最大输出 token
-<input
-type="number"
-inputMode="numeric"
-min={QA_MAX_OUTPUT_TOKENS_MIN}
-max={QA_MAX_OUTPUT_TOKENS_MAX}
-step={1000}
-placeholder="留空 = 不传"
-value={maxOutTokens}
-onChange={(e) => setMaxOutTokens(e.target.value)}
-/>
-
-
-输出长度护栏：每次请求带 max_tokens，小坊会按该预算分段写大文件，写超被安全截断后自动续接，不再整轮报废。默认 {QA_DEFAULT_MAX_OUTPUT_TOKENS.toLocaleString()}；留空 = 不传该参数（部分模型/中转不支持 max_tokens 时请留空）。
-
-
-恢复默认
-保存
-
-
-
-);
+  return (
+    <div className="qa-devnotice-backdrop" onClick={onClose}>
+      <div className="qa-devnotice" role="dialog" aria-label="工坊配置" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-devnotice-title">工坊配置</div>
+        <label className="qa-settings-field">
+          <span>上下文预算（字符）</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={QA_CONTEXT_BUDGET_MIN}
+            max={QA_CONTEXT_BUDGET_MAX}
+            step={1000}
+            value={budget}
+            onChange={(e) => setBudget(e.target.value)}
+          />
+        </label>
+        <div className="qa-settings-hint">
+          上下文满 100% 时自动压缩成摘要并重新累计。中文约 1 字符 ≈ 1 token；默认 {QA_DEFAULT_CONTEXT_BUDGET_CHARS.toLocaleString()}，小上下文（32k）模型建议 30000–50000。
+        </div>
+        <div className="qa-settings-hint">当前会话已用 {usedChars.toLocaleString()} 字符（约 {pct}%）。</div>
+        <label className="qa-settings-field">
+          <span>单页读取字符数</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={QA_PAGE_CHARS_MIN}
+            max={QA_PAGE_CHARS_MAX}
+            step={1000}
+            value={pageChars}
+            onChange={(e) => setPageChars(e.target.value)}
+          />
+        </label>
+        <div className="qa-settings-hint">
+          小坊翻页读答疑文档 / 本机内容 / 仓库源码时，每页返回的字符数。默认 {QA_DEFAULT_PAGE_CHARS.toLocaleString()}；调大读得快但更占上下文，小上下文模型建议调小。
+        </div>
+        <label className="qa-settings-field">
+          <span>单轮工具调用上限（次）</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={QA_MAX_ROUNDS_MIN}
+            max={QA_MAX_ROUNDS_MAX}
+            step={1}
+            value={maxRounds}
+            onChange={(e) => setMaxRounds(e.target.value)}
+          />
+        </label>
+        <div className="qa-settings-hint">
+          一次提问里小坊最多连续执行多少轮工具，用完会提示「回复继续」。默认 {QA_DEFAULT_MAX_ROUNDS}；复杂任务（写游戏、改代码）可调大，想控制 token 消耗可调小。
+        </div>
+        <label className="qa-settings-field">
+          <span>单次最大输出 token</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={QA_MAX_OUTPUT_TOKENS_MIN}
+            max={QA_MAX_OUTPUT_TOKENS_MAX}
+            step={1000}
+            placeholder="留空 = 不传"
+            value={maxOutTokens}
+            onChange={(e) => setMaxOutTokens(e.target.value)}
+          />
+        </label>
+        <div className="qa-settings-hint">
+          输出长度护栏：每次请求带 max_tokens，小坊会按该预算分段写大文件，写超被安全截断后自动续接，不再整轮报废。默认 {QA_DEFAULT_MAX_OUTPUT_TOKENS.toLocaleString()}；留空 = 不传该参数（部分模型/中转不支持 max_tokens 时请留空）。
+        </div>
+        <div className="qa-devnotice-actions is-row">
+          <button type="button" className="qa-devnotice-btn" onClick={reset}>恢复默认</button>
+          <button type="button" className="qa-devnotice-btn is-primary" onClick={save}>保存</button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 // ── GitHub 仓库配置面板 ──────────────────────────────
 
 function QaRepoSheet({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
-const existing = useMemo(() => loadQaGithubConfig(), []);
-const [owner, setOwner] = useState(existing?.owner ?? "");
-const [repo, setRepo] = useState(existing?.repo ?? "");
-const [branch, setBranch] = useState(existing?.branch ?? "");
-const [token, setToken] = useState(existing?.token ?? "");
-const [writeMode, setWriteMode] = useState<"confirm" | "auto">(existing?.writeMode ?? "confirm");
-const [checking, setChecking] = useState(false);
-const [result, setResult] = useState<QaGithubValidation | null>(null);
+  const existing = useMemo(() => loadQaGithubConfig(), []);
+  const [owner, setOwner] = useState(existing?.owner ?? "");
+  const [repo, setRepo] = useState(existing?.repo ?? "");
+  const [branch, setBranch] = useState(existing?.branch ?? "");
+  const [token, setToken] = useState(existing?.token ?? "");
+  const [writeMode, setWriteMode] = useState<"confirm" | "auto">(existing?.writeMode ?? "confirm");
+  const [checking, setChecking] = useState(false);
+  const [result, setResult] = useState<QaGithubValidation | null>(null);
 
-const buildConfig = useCallback((): QaGithubConfig => {
-const cfg: QaGithubConfig = { owner: owner.trim(), repo: repo.trim(), writeMode };
-if (branch.trim()) cfg.branch = branch.trim();
-if (token.trim()) cfg.token = token.trim();
-if (existing?.apiBase) cfg.apiBase = existing.apiBase;
-return cfg;
-}, [owner, repo, branch, token, writeMode, existing]);
+  const buildConfig = useCallback((): QaGithubConfig => {
+    const cfg: QaGithubConfig = { owner: owner.trim(), repo: repo.trim(), writeMode };
+    if (branch.trim()) cfg.branch = branch.trim();
+    if (token.trim()) cfg.token = token.trim();
+    if (existing?.apiBase) cfg.apiBase = existing.apiBase;
+    return cfg;
+  }, [owner, repo, branch, token, writeMode, existing]);
 
-const handleVerify = useCallback(async () => {
-if (!owner.trim() || !repo.trim()) {
-setResult({ ok: false, error: "请填写 owner 和 repo。" });
-return;
-}
-setChecking(true);
-setResult(null);
-const validation = await validateQaGithubConfig(buildConfig());
-setResult(validation);
-setChecking(false);
-}, [owner, repo, buildConfig]);
+  const handleVerify = useCallback(async () => {
+    if (!owner.trim() || !repo.trim()) {
+      setResult({ ok: false, error: "请填写 owner 和 repo。" });
+      return;
+    }
+    setChecking(true);
+    setResult(null);
+    const validation = await validateQaGithubConfig(buildConfig());
+    setResult(validation);
+    setChecking(false);
+  }, [owner, repo, buildConfig]);
 
-const handleSave = useCallback(() => {
-if (!owner.trim() || !repo.trim()) return;
-saveQaGithubConfig(buildConfig());
-onSaved();
-onClose();
-}, [owner, repo, buildConfig, onSaved, onClose]);
+  const handleSave = useCallback(() => {
+    if (!owner.trim() || !repo.trim()) return;
+    saveQaGithubConfig(buildConfig());
+    onSaved();
+    onClose();
+  }, [owner, repo, buildConfig, onSaved, onClose]);
 
-const handleDisconnect = useCallback(() => {
-clearQaGithubConfig();
-onSaved();
-onClose();
-}, [onSaved, onClose]);
+  const handleDisconnect = useCallback(() => {
+    clearQaGithubConfig();
+    onSaved();
+    onClose();
+  }, [onSaved, onClose]);
 
-return (
-
-<div className="qa-sheet" onClick={(e) => e.stopPropagation()}>
-
-
- 连接 GitHub 仓库
-
-
-
-
-
-
-
-连接后可以让工坊查阅这个仓库的代码来回答问题。配置只保存在你的浏览器本地，不会上传。公开仓库可不填 PAT。
-
-
-Owner（用户名 / 组织）
-<input className="qa-input" value={owner} onChange={(e) => setOwner(e.target.value)} placeholder="例：octocat" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-
-
-Repo（仓库名）
-<input className="qa-input" value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="例：hello-world" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-
-
-分支（可选，默认仓库默认分支）
-<input className="qa-input" value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="main" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-
-
-Fine-grained PAT（私有仓库或搜索代码需要）
-<input className="qa-input" type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="github_pat_…" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-
-GitHub → Settings → Menu 按钮 → Developer settings → Personal access tokens → Fine-grained tokens。创建时 Repository access 记得勾选目标仓库；Permissions 里：Contents——只查代码选 Read-only，要让工坊改代码选 Read and write；要用「创建PR」再加 Pull requests 的 Read and write（Metadata 会自动带上，其余权限都不用勾）。
-
-
-
-改代码时的模式
-
-<button type="button" className={qa-segment-btn ${writeMode === "confirm" ? "is-active" : ""}} onClick={() => setWriteMode("confirm")}>
-确认后提交
-
-<button type="button" className={qa-segment-btn ${writeMode === "auto" ? "is-active" : ""}} onClick={() => setWriteMode("auto")}>
-全自动
-
-
-
-{writeMode === "confirm"
-? "工坊改代码前会先展示改动，你点「应用」才真正提交。推荐。"
-: "工坊说完直接提交推送，不再逐次确认。仍可事后一键撤销。仅在信任后开启。"}
-
-
-{result && (
-<div className={qa-verify ${result.ok ? "is-ok" : "is-fail"}}>
-{result.ok
-? ✓ 已连接 ${result.fullName}（${result.private ? "私有" : "公开"}，默认分支 ${result.defaultBranch}）
-: ✗ ${result.error}}
-
-)}
-
-
-{existing && (
-
-断开
-
-)}
-
-{checking ?  : "验证"}
-
-<button type="button" className="qa-sheet-btn is-primary" onClick={handleSave} disabled={!owner.trim() || !repo.trim()}>
-保存
-
-
-
-
-);
+  return (
+    <div className="qa-sheet-backdrop" onClick={onClose}>
+      <div className="qa-sheet" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-sheet-head">
+          <span className="qa-sheet-title">
+            <Github size={16} /> 连接 GitHub 仓库
+          </span>
+          <button type="button" className="qa-icon-btn" onClick={onClose} aria-label="关闭">
+            <X size={16} />
+          </button>
+        </div>
+        <div className="qa-sheet-body hide-scrollbar">
+          <p className="qa-sheet-note">
+            连接后可以让工坊查阅这个仓库的代码来回答问题。配置只保存在你的浏览器本地，不会上传。公开仓库可不填 PAT。
+          </p>
+          <label className="qa-field">
+            <span className="qa-field-label">Owner（用户名 / 组织）</span>
+            <input className="qa-input" value={owner} onChange={(e) => setOwner(e.target.value)} placeholder="例：octocat" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+          </label>
+          <label className="qa-field">
+            <span className="qa-field-label">Repo（仓库名）</span>
+            <input className="qa-input" value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="例：hello-world" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+          </label>
+          <label className="qa-field">
+            <span className="qa-field-label">分支（可选，默认仓库默认分支）</span>
+            <input className="qa-input" value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="main" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+          </label>
+          <label className="qa-field">
+            <span className="qa-field-label">Fine-grained PAT（私有仓库或搜索代码需要）</span>
+            <input className="qa-input" type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="github_pat_…" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+            <span className="qa-field-hint">
+              GitHub → Settings → Menu 按钮 → Developer settings → Personal access tokens → Fine-grained tokens。创建时 Repository access 记得勾选目标仓库；Permissions 里：Contents——只查代码选 Read-only，要让工坊改代码选 Read and write；要用「创建PR」再加 Pull requests 的 Read and write（Metadata 会自动带上，其余权限都不用勾）。
+            </span>
+          </label>
+          <div className="qa-field">
+            <span className="qa-field-label">改代码时的模式</span>
+            <div className="qa-segment">
+              <button type="button" className={`qa-segment-btn ${writeMode === "confirm" ? "is-active" : ""}`} onClick={() => setWriteMode("confirm")}>
+                确认后提交
+              </button>
+              <button type="button" className={`qa-segment-btn ${writeMode === "auto" ? "is-active" : ""}`} onClick={() => setWriteMode("auto")}>
+                全自动
+              </button>
+            </div>
+            <span className="qa-field-hint">
+              {writeMode === "confirm"
+                ? "工坊改代码前会先展示改动，你点「应用」才真正提交。推荐。"
+                : "工坊说完直接提交推送，不再逐次确认。仍可事后一键撤销。仅在信任后开启。"}
+            </span>
+          </div>
+          {result && (
+            <div className={`qa-verify ${result.ok ? "is-ok" : "is-fail"}`}>
+              {result.ok
+                ? `✓ 已连接 ${result.fullName}（${result.private ? "私有" : "公开"}，默认分支 ${result.defaultBranch}）`
+                : `✗ ${result.error}`}
+            </div>
+          )}
+        </div>
+        <div className="qa-sheet-actions">
+          {existing && (
+            <button type="button" className="qa-sheet-btn is-danger" onClick={handleDisconnect}>
+              断开
+            </button>
+          )}
+          <button type="button" className="qa-sheet-btn" onClick={handleVerify} disabled={checking}>
+            {checking ? <Loader2 size={14} className="qa-spin" /> : "验证"}
+          </button>
+          <button type="button" className="qa-sheet-btn is-primary" onClick={handleSave} disabled={!owner.trim() || !repo.trim()}>
+            保存
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 // ── App 本体 ─────────────────────────────────────────
 
 export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
-const snapshot = useSyncExternalStore(subscribeQaChat, getQaChatSnapshot, getQaChatSnapshot);
-const [input, setInput] = useState("");
-const [drawerOpen, setDrawerOpen] = useState(false);
-const [repoSheetOpen, setRepoSheetOpen] = useState(false);
-const [repoConnected, setRepoConnected] = useState(false);
-const [clearToolsOpen, setClearToolsOpen] = useState(false);
-const [settingsOpen, setSettingsOpen] = useState(false);
-/ 会话重命名弹窗：抽屉菜单里点「重命名」打开 */
-const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
-const [renameTitle, setRenameTitle] = useState("");
+  const snapshot = useSyncExternalStore(subscribeQaChat, getQaChatSnapshot, getQaChatSnapshot);
+  const [input, setInput] = useState("");
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [repoSheetOpen, setRepoSheetOpen] = useState(false);
+  const [repoConnected, setRepoConnected] = useState(false);
+  const [clearToolsOpen, setClearToolsOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  /** 会话重命名弹窗：抽屉菜单里点「重命名」打开 */
+  const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
+  const [renameTitle, setRenameTitle] = useState("");
+  const [pendingImages, setPendingImages] = useState<string[]>([]);
+  const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
+  
+  const [viewerImage, setViewerImage] = useState<string | null>(null);
+  const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
+  const [editText, setEditText] = useState("");
+  const [editImages, setEditImages] = useState<string[]>([]);
+  const [editFiles, setEditFiles] = useState<{name: string, content: string}[]>([]);
+  
+  const [visionEnabled, setVisionEnabled] = useState(false);
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  
+  const [apiReady, setApiReady] = useState(true);
+  const [modelName, setModelName] = useState("");
+  const [repoWritable, setRepoWritable] = useState(false);
+  const [writeMode, setWriteMode] = useState<"confirm" | "auto">("confirm");
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const stickToBottomRef = useRef(true);
 
-// 主输入区附件
-const [pendingImages, setPendingImages] = useState<string[]>([]);
-const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
-const [composerMenuOpen, setComposerMenuOpen] = useState(false);
+  const refreshComposerMeta = useCallback(() => {
+    setApiReady(resolveQaApiConfig() != null);
+    setModelName(resolveQaApiConfig()?.defaultModel ?? "");
+    setVisionEnabled(resolveQaApiConfig()?.enableImageRecognition === true);
+    const gh = loadQaGithubConfig();
+    setRepoConnected(gh != null);
+    setRepoWritable(Boolean(gh?.token));
+    setWriteMode(gh?.writeMode ?? "confirm");
+  }, []);
 
-const [viewerImage, setViewerImage] = useState<string | null>(null);
+  useEffect(() => {
+    void hydrateQaChat();
+    refreshComposerMeta();
+  }, [refreshComposerMeta]);
 
-// 修改消息区附件
-const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
-const [editText, setEditText] = useState("");
-const [editImages, setEditImages] = useState<string[]>([]);
-const [editFiles, setEditFiles] = useState<{name: string, content: string}[]>([]);
-const [editAttachMenuOpen, setEditAttachMenuOpen] = useState(false);
+  // 清理原生 tool 调用历史（防报错）：与小卷同款——移除上下文里的工具记录与原生元数据
+  const handleClearToolHistory = useCallback(() => {
+    if (snapshot.isGenerating) {
+      onNotice?.("小坊正在执行，完成后再清理。");
+      return;
+    }
+    if (!hasQaToolHistory()) {
+      onNotice?.("没有可清理的工具调用历史。");
+      return;
+    }
+    setClearToolsOpen(true);
+  }, [snapshot.isGenerating, onNotice]);
 
-const [visionEnabled, setVisionEnabled] = useState(false);
-const imageInputRef = useRef<HTMLInputElement | null>(null);
-const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const confirmClearToolHistory = useCallback(() => {
+    setClearToolsOpen(false);
+    const result = clearQaToolHistory();
+    onNotice?.(result && result.removed + result.cleaned > 0
+      ? `已清理 ${result.removed} 条工具记录，整理 ${result.cleaned} 条消息。`
+      : "没有可清理的工具调用历史。");
+  }, [onNotice]);
 
-const [apiReady, setApiReady] = useState(true);
-const [modelName, setModelName] = useState("");
-const [repoWritable, setRepoWritable] = useState(false);
-const [writeMode, setWriteMode] = useState<"confirm" | "auto">("confirm");
-const bodyRef = useRef<HTMLDivElement | null>(null);
-const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-const stickToBottomRef = useRef(true);
+  const toggleWriteMode = useCallback(() => {
+    const gh = loadQaGithubConfig();
+    if (!gh) return;
+    const next = gh.writeMode === "auto" ? "confirm" : "auto";
+    saveQaGithubConfig({ ...gh, writeMode: next });
+    setWriteMode(next);
+  }, []);
 
-const refreshComposerMeta = useCallback(() => {
-setApiReady(resolveQaApiConfig() != null);
-setModelName(resolveQaApiConfig()?.defaultModel ?? "");
-setVisionEnabled(resolveQaApiConfig()?.enableImageRecognition === true);
-const gh = loadQaGithubConfig();
-setRepoConnected(gh != null);
-setRepoWritable(Boolean(gh?.token));
-setWriteMode(gh?.writeMode ?? "confirm");
-}, []);
+  const activeSession = useMemo(
+    () => snapshot.sessions.find((s) => s.id === snapshot.activeSessionId) ?? null,
+    [snapshot.sessions, snapshot.activeSessionId],
+  );
+  const messages = useMemo(() => activeSession?.messages ?? [], [activeSession]);
+  const createdContent = useMemo(() => activeSession?.createdContent ?? [], [activeSession]);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewItem, setPreviewItem] = useState<QaCreatedContent | null>(null);
+  const previewApp = useMemo(
+    () => (previewItem?.type === "app" ? getInstalledCustomApp(previewItem.refId) : null),
+    [previewItem],
+  );
 
-useEffect(() => {
-void hydrateQaChat();
-refreshComposerMeta();
-}, [refreshComposerMeta]);
+  // 自动滚动：用户上滚阅读时不拉回底部
+  const handleScroll = useCallback(() => {
+    const el = bodyRef.current;
+    if (!el) return;
+    stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  }, []);
 
-// 清理原生 tool 调用历史（防报错）：与小卷同款——移除上下文里的工具记录与原生元数据
-const handleClearToolHistory = useCallback(() => {
-if (snapshot.isGenerating) {
-onNotice?.("小坊正在执行，完成后再清理。");
-return;
-}
-if (!hasQaToolHistory()) {
-onNotice?.("没有可清理的工具调用历史。");
-return;
-}
-setClearToolsOpen(true);
-}, [snapshot.isGenerating, onNotice]);
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (el && stickToBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [messages]);
 
-const confirmClearToolHistory = useCallback(() => {
-setClearToolsOpen(false);
-const result = clearQaToolHistory();
-onNotice?.(result && result.removed + result.cleaned > 0
-? 已清理 ${result.removed} 条工具记录，整理 ${result.cleaned} 条消息。
-: "没有可清理的工具调用历史。");
-}, [onNotice]);
+  const autoGrow = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+  }, []);
 
-const toggleWriteMode = useCallback(() => {
-const gh = loadQaGithubConfig();
-if (!gh) return;
-const next = gh.writeMode === "auto" ? "confirm" : "auto";
-saveQaGithubConfig({ ...gh, writeMode: next });
-setWriteMode(next);
-}, []);
+  const handleSend = useCallback(() => {
+    const text = input.trim();
+    if ((!text && pendingImages.length === 0 && pendingFiles.length === 0) || snapshot.isGenerating) return;
+    setInput("");
+    const images = pendingImages;
+    const files = pendingFiles;
+    setPendingImages([]);
+    setPendingFiles([]);
+    stickToBottomRef.current = true;
+    requestAnimationFrame(autoGrow);
+    void sendQaMessage(text, images.length ? images : undefined, files.length ? files : undefined);
+  }, [input, pendingImages, pendingFiles, snapshot.isGenerating, autoGrow]);
 
-const activeSession = useMemo(
-() => snapshot.sessions.find((s) => s.id === snapshot.activeSessionId) ?? null,
-[snapshot.sessions, snapshot.activeSessionId],
-);
-const messages = useMemo(() => activeSession?.messages ?? [], [activeSession]);
-const createdContent = useMemo(() => activeSession?.createdContent ?? [], [activeSession]);
-const [previewOpen, setPreviewOpen] = useState(false);
-const [previewItem, setPreviewItem] = useState<QaCreatedContent | null>(null);
-const previewApp = useMemo(
-() => (previewItem?.type === "app" ? getInstalledCustomApp(previewItem.refId) : null),
-[previewItem],
-);
+  // 附加图片：仅识图已开启的 API 显示入口；读为 dataURL，单张限 4MB
+  const handlePickImages = useCallback((files: FileList | null, isEditMode = false) => {
+    if (!files?.length) return;
+    const setter = isEditMode ? setEditImages : setPendingImages;
+    for (const file of Array.from(files).slice(0, 6)) {
+      if (file.size > 4 * 1024 * 1024) {
+        onNotice?.(`「${file.name}」超过 4MB，已跳过。`);
+        continue;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        const url = typeof reader.result === "string" ? reader.result : "";
+        if (url) setter((current) => (current.length >= 6 ? current : [...current, url]));
+      };
+      reader.readAsDataURL(file);
+    }
+    if (imageInputRef.current) imageInputRef.current.value = "";
+  }, [onNotice]);
 
-// 自动滚动：用户上滚阅读时不拉回底部
-const handleScroll = useCallback(() => {
-const el = bodyRef.current;
-if (!el) return;
-stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
-}, []);
+  // 附加文本文件
+  const handlePickFiles = useCallback((files: FileList | null, isEditMode = false) => {
+    if (!files?.length) return;
+    const setter = isEditMode ? setEditFiles : setPendingFiles;
+    for (const file of Array.from(files).slice(0, 6)) {
+      if (file.size > 1024 * 1024) { // 纯文本文件限 1MB
+        onNotice?.(`「${file.name}」太大（超过 1MB），请直接粘贴内容。`);
+        continue;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        const content = typeof reader.result === "string" ? reader.result : "";
+        if (content) setter((current) => {
+            if (current.length >= 6 || current.some(f => f.name === file.name)) return current;
+            return [...current, { name: file.name, content }];
+        });
+      };
+      reader.readAsText(file);
+    }
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }, [onNotice]);
 
-useEffect(() => {
-const el = bodyRef.current;
-if (el && stickToBottomRef.current) {
-el.scrollTop = el.scrollHeight;
-}
-}, [messages]);
+  const handleRetry = useCallback((assistantMsgId: string) => {
+    stickToBottomRef.current = true;
+    void retryQaMessage(assistantMsgId);
+  }, []);
 
-const autoGrow = useCallback(() => {
-const el = textareaRef.current;
-if (!el) return;
-el.style.height = "auto";
-el.style.height = ${Math.min(el.scrollHeight, 120)}px;
-}, []);
+  const handleCopyMessage = useCallback((content: string) => {
+    void navigator.clipboard?.writeText(content).then(
+      () => onNotice?.("已复制原始内容"),
+      () => onNotice?.("复制失败"),
+    );
+  }, [onNotice]);
 
-const handleSend = useCallback(() => {
-const text = input.trim();
-if ((!text && pendingImages.length === 0 && pendingFiles.length === 0) || snapshot.isGenerating) return;
-setInput("");
-const images = pendingImages;
-const files = pendingFiles;
-setPendingImages([]);
-setPendingFiles([]);
-stickToBottomRef.current = true;
-requestAnimationFrame(autoGrow);
-void sendQaMessage(text, images.length ? images : undefined, files.length ? files : undefined);
-}, [input, pendingImages, pendingFiles, snapshot.isGenerating, autoGrow]);
+  const handleEditMessage = useCallback((msg: QaMsg) => {
+    setEditingMsg(msg);
+    setEditText(msg.content);
+    setEditImages(msg.images || []);
+    setEditFiles(msg.files || []);
+  }, []);
 
-// 附加图片：仅识图已开启的 API 显示入口；读为 dataURL，单张限 4MB
-const handlePickImages = useCallback((files: FileList | null, isEditMode = false) => {
-if (!files?.length) return;
-const setter = isEditMode ? setEditImages : setPendingImages;
-for (const file of Array.from(files).slice(0, 6)) {
-if (file.size > 4 * 1024 * 1024) {
-onNotice?.(「${file.name}」超过 4MB，已跳过。);
-continue;
-}
-const reader = new FileReader();
-reader.onload = () => {
-const url = typeof reader.result === "string" ? reader.result : "";
-if (url) setter((current) => (current.length >= 6 ? current : [...current, url]));
-};
-reader.readAsDataURL(file);
-}
-if (imageInputRef.current) imageInputRef.current.value = "";
-}, [onNotice]);
+  const handleSaveEdit = useCallback((andResend: boolean) => {
+    if (!editingMsg || !snapshot.activeSessionId) return;
+    if (andResend) {
+        editAndResendQaMessage(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
+    } else {
+        updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
+    }
+    setEditingMsg(null);
+    onNotice?.(andResend ? "已提交修改" : "已保存消息内容");
+  }, [editingMsg, editText, editImages, editFiles, snapshot.activeSessionId, onNotice]);
 
-// 附加文本文件，拦截不可读取的 docx 和 pdf 格式
-const handlePickFiles = useCallback((files: FileList | null, isEditMode = false) => {
-if (!files?.length) return;
-const setter = isEditMode ? setEditFiles : setPendingFiles;
-for (const file of Array.from(files).slice(0, 6)) {
-if (/.(docx|pdf)$/i.test(file.name)) {
-onNotice?.(工坊暂不支持读取「${file.name}」格式，请上传 txt、md 等纯文本文件。);
-continue;
-}
-if (file.size > 1024 * 1024) { // 纯文本文件限 1MB
-onNotice?.(「${file.name}」太大（超过 1MB），请直接粘贴内容。);
-continue;
-}
-const reader = new FileReader();
-reader.onload = () => {
-const content = typeof reader.result === "string" ? reader.result : "";
-if (content) setter((current) => {
-if (current.length >= 6 || current.some(f => f.name === file.name)) return current;
-return [...current, { name: file.name, content }];
-});
-};
-reader.readAsText(file);
-}
-if (fileInputRef.current) fileInputRef.current.value = "";
-}, [onNotice]);
+  const streamingMsgId =
+    snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
+      ? messages[messages.length - 1].id
+      : null;
 
-const handleRetry = useCallback((assistantMsgId: string) => {
-stickToBottomRef.current = true;
-void retryQaMessage(assistantMsgId);
-}, []);
-
-const handleCopyMessage = useCallback((content: string) => {
-void navigator.clipboard?.writeText(content).then(
-() => onNotice?.("已复制原始内容"),
-() => onNotice?.("复制失败"),
-);
-}, [onNotice]);
-
-const handleEditMessage = useCallback((msg: QaMsg) => {
-setEditingMsg(msg);
-setEditText(msg.content);
-setEditImages(msg.images || []);
-setEditFiles(msg.files || []);
-}, []);
-
-const handleSaveEdit = useCallback((andResend: boolean) => {
-if (!editingMsg || !snapshot.activeSessionId) return;
-if (andResend) {
-editAndResendQaMessage(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
-} else {
-updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
-}
-setEditingMsg(null);
-onNotice?.(andResend ? "已提交修改" : "已保存消息内容");
-}, [editingMsg, editText, editImages, editFiles, snapshot.activeSessionId, onNotice]);
-
-const streamingMsgId =
-snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
-? messages[messages.length - 1].id
-: null;
-
-return (
-
-<QaSessionDrawer
-sessions={snapshot.sessions}
-activeId={snapshot.activeSessionId}
-onSelect={(id) => {
-switchQaSession(id);
-setDrawerOpen(false);
-}}
-onDelete={deleteQaSession}
-onCreate={() => {
-createQaSession();
-setDrawerOpen(false);
-}}
-onOpenSettings={() => {
-setSettingsOpen(true);
-setDrawerOpen(false);
-}}
-onRenameRequest={(id, title) => {
-setRenameTarget({ id, title });
-setRenameTitle(title);
-}}
-/>
-<div className={qa-stage ${drawerOpen ? "is-pushed" : ""}}>
-
-
-
-
-
-
-
-
-工坊
-{repoConnected && 已连接仓库}
-
-
-
-
-
-<button type="button" className="qa-icon-btn" onClick={() => setDrawerOpen((v) => !v)} aria-label="对话记录">
-
-
-
-
-
-  <div className="qa-body hide-scrollbar" ref={bodyRef} onScroll={handleScroll}>
-    {messages.length === 0 ? (
-      <div className="qa-welcome">
-        <div className="qa-welcome-badge" aria-hidden>
-          <svg viewBox="0 0 24 24" width="26" height="26">
-            <path d={mdiHammerWrench} fill="currentColor" />
-          </svg>
-        </div>
-        <div className="qa-welcome-title">有什么问题？</div>
-        <div className="qa-welcome-sub">
-          我是小坊，工坊的驻场工程师。使用问题、报错排查、部署配置，都可以问我。
-          <br />
-          我还能动手：写小游戏 / APP / 剧场直接装进本机试玩；连接仓库后我会查源码答疑，填了有写权限的 PAT 还能帮你改代码。
-          <br />
-          想创作角色、世界书或美化桌面，找桌面上的小卷更合适。
-        </div>
-        {!apiReady && (
-          <div className="qa-welcome-warn">还没有可用的 API：请先到「设置 → API 设置」添加 LLM API。</div>
-        )}
-        <div className="qa-suggestions">
-          {SUGGESTIONS.map((text) => (
-            <button
-              key={text}
-              type="button"
-              className="qa-suggestion"
-              onClick={() => {
-                stickToBottomRef.current = true;
-                void sendQaMessage(text);
-              }}
-            >
-              {text}
-            </button>
-          ))}
-        </div>
-      </div>
-    ) : (
-      <div className="qa-messages">
-        {messages.map((msg) => (
-          <QaMessageItem key={msg.id} msg={msg} isStreaming={msg.id === streamingMsgId} onRetry={handleRetry} onViewImage={setViewerImage} onCopy={handleCopyMessage} onEdit={handleEditMessage} />
-        ))}
-      </div>
-    )}
-  </div>
-
-  <footer className="qa-composer-wrap">
-    <div className={`qa-composer ${snapshot.isGenerating ? "is-generating" : ""}`}>
-      {(pendingImages.length > 0 || pendingFiles.length > 0) && (
-        <div className="qa-attach-strip">
-          {pendingImages.map((url, i) => (
-            <div key={`img-${i}`} className="qa-attach-thumb">
-              <button type="button" className="qa-attach-view" onClick={() => setViewerImage(url)} aria-label="查看图片">
-                <img src={url} alt="" />
-              </button>
-              <button
-                type="button"
-                className="qa-attach-remove"
-                onClick={() => setPendingImages((current) => current.filter((_, idx) => idx !== i))}
-                aria-label="移除图片"
-              >
-                <X size={11} strokeWidth={2.4} />
-              </button>
-            </div>
-          ))}
-          {pendingFiles.map((file, i) => (
-            <div key={`file-${i}`} className="qa-attach-thumb" style={{ background: "rgba(128,128,128,0.2)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px" }}>
-              <FileText size={16} style={{ minWidth: "16px", marginRight: "4px" }}/>
-              <span style={{ fontSize: "11px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{file.name}</span>
-              <button
-                type="button"
-                className="qa-attach-remove"
-                onClick={() => setPendingFiles((current) => current.filter((_, idx) => idx !== i))}
-                aria-label="移除附件"
-              >
-                <X size={11} strokeWidth={2.4} />
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
-      <textarea
-        ref={textareaRef}
-        className="qa-composer-input hide-scrollbar"
-        placeholder="输入你的问题…"
-        rows={1}
-        value={input}
-        onChange={(e) => {
-          setInput(e.target.value);
-          autoGrow();
+  return (
+    <div className="qa-app-shell">
+      <QaSessionDrawer
+        sessions={snapshot.sessions}
+        activeId={snapshot.activeSessionId}
+        onSelect={(id) => {
+          switchQaSession(id);
+          setDrawerOpen(false);
+        }}
+        onDelete={deleteQaSession}
+        onCreate={() => {
+          createQaSession();
+          setDrawerOpen(false);
+        }}
+        onOpenSettings={() => {
+          setSettingsOpen(true);
+          setDrawerOpen(false);
+        }}
+        onRenameRequest={(id, title) => {
+          setRenameTarget({ id, title });
+          setRenameTitle(title);
         }}
       />
-      
-      <div className="qa-composer-toolbar">
-        {/* 隐藏的文件输入组件全局共用 */}
-        <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
-            style={{ display: "none" }}
-            onChange={(e) => {
-                const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
-                handlePickFiles(e.target.files, isEditMode);
-                e.target.removeAttribute('data-edit-mode');
-            }}
-        />
-        {visionEnabled && (
-            <input
-                ref={imageInputRef}
-                type="file"
-                accept="image/*"
-                multiple
-                style={{ display: "none" }}
-                onChange={(e) => {
-                    const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
-                    handlePickImages(e.target.files, isEditMode);
-                    e.target.removeAttribute('data-edit-mode');
-                }}
-            />
-        )}
+      <div className={`qa-stage ${drawerOpen ? "is-pushed" : ""}`}>
+      <div className="qa-ambient" aria-hidden />
+      <header className="qa-header">
+        <div className="qa-header-left">
+          <button type="button" className="qa-icon-btn" onClick={onClose} aria-label="返回">
+            <ChevronLeft size={22} strokeWidth={1.75} />
+          </button>
+        </div>
+        <div className="qa-header-center">
+          <span className="qa-header-title">工坊</span>
+          {repoConnected && <span className="qa-header-sub">已连接仓库</span>}
+        </div>
+        <div className="qa-header-right">
+          <button
+            type="button"
+            className="qa-icon-btn"
+            onClick={handleClearToolHistory}
+            aria-label="清理原生tool调用历史（防报错）"
+            title="清理原生tool调用历史——防报错"
+          >
+            <BrushCleaning size={17} strokeWidth={1.75} />
+          </button>
+          <button type="button" className="qa-icon-btn" onClick={() => setDrawerOpen((v) => !v)} aria-label="对话记录">
+            <Menu size={18} strokeWidth={1.75} />
+          </button>
+        </div>
+      </header>
 
-        {/* 合并后的添加附件/图片菜单 */}
-        <div style={{ position: 'relative' }}>
+      <div className="qa-body hide-scrollbar" ref={bodyRef} onScroll={handleScroll}>
+        {messages.length === 0 ? (
+          <div className="qa-welcome">
+            <div className="qa-welcome-badge" aria-hidden>
+              <svg viewBox="0 0 24 24" width="26" height="26">
+                <path d={mdiHammerWrench} fill="currentColor" />
+              </svg>
+            </div>
+            <div className="qa-welcome-title">有什么问题？</div>
+            <div className="qa-welcome-sub">
+              我是小坊，工坊的驻场工程师。使用问题、报错排查、部署配置，都可以问我。
+              <br />
+              我还能动手：写小游戏 / APP / 剧场直接装进本机试玩；连接仓库后我会查源码答疑，填了有写权限的 PAT 还能帮你改代码。
+              <br />
+              想创作角色、世界书或美化桌面，找桌面上的小卷更合适。
+            </div>
+            {!apiReady && (
+              <div className="qa-welcome-warn">还没有可用的 API：请先到「设置 → API 设置」添加 LLM API。</div>
+            )}
+            <div className="qa-suggestions">
+              {SUGGESTIONS.map((text) => (
+                <button
+                  key={text}
+                  type="button"
+                  className="qa-suggestion"
+                  onClick={() => {
+                    stickToBottomRef.current = true;
+                    void sendQaMessage(text);
+                  }}
+                >
+                  {text}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="qa-messages">
+            {messages.map((msg) => (
+              <QaMessageItem key={msg.id} msg={msg} isStreaming={msg.id === streamingMsgId} onRetry={handleRetry} onViewImage={setViewerImage} onCopy={handleCopyMessage} onEdit={handleEditMessage} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <footer className="qa-composer-wrap">
+        <div className={`qa-composer ${snapshot.isGenerating ? "is-generating" : ""}`}>
+          {(pendingImages.length > 0 || pendingFiles.length > 0) && (
+            <div className="qa-attach-strip">
+              {pendingImages.map((url, i) => (
+                <div key={`img-${i}`} className="qa-attach-thumb">
+                  <button type="button" className="qa-attach-view" onClick={() => setViewerImage(url)} aria-label="查看图片">
+                    <img src={url} alt="" />
+                  </button>
+                  <button
+                    type="button"
+                    className="qa-attach-remove"
+                    onClick={() => setPendingImages((current) => current.filter((_, idx) => idx !== i))}
+                    aria-label="移除图片"
+                  >
+                    <X size={11} strokeWidth={2.4} />
+                  </button>
+                </div>
+              ))}
+              {pendingFiles.map((file, i) => (
+                <div key={`file-${i}`} className="qa-attach-thumb" style={{ background: "rgba(128,128,128,0.2)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px" }}>
+                  <FileText size={16} style={{ minWidth: "16px", marginRight: "4px" }}/>
+                  <span style={{ fontSize: "11px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{file.name}</span>
+                  <button
+                    type="button"
+                    className="qa-attach-remove"
+                    onClick={() => setPendingFiles((current) => current.filter((_, idx) => idx !== i))}
+                    aria-label="移除附件"
+                  >
+                    <X size={11} strokeWidth={2.4} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+          <textarea
+            ref={textareaRef}
+            className="qa-composer-input hide-scrollbar"
+            placeholder="输入你的问题…"
+            rows={1}
+            value={input}
+            onChange={(e) => {
+              setInput(e.target.value);
+              autoGrow();
+            }}
+          />
+          <div className="qa-composer-toolbar">
+            <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
+                style={{ display: "none" }}
+                onChange={(e) => handlePickFiles(e.target.files)}
+            />
             <button
                 type="button"
-                className={`qa-circle-btn qa-attach-btn ${composerMenuOpen ? 'is-active' : ''}`}
-                onClick={() => setComposerMenuOpen(!composerMenuOpen)}
-                aria-label="添加附件/图片"
+                className="qa-circle-btn qa-attach-btn"
+                onClick={() => fileInputRef.current?.click()}
+                aria-label="添加附件"
             >
-                <Plus size={17} strokeWidth={2.2} />
+                <Paperclip size={17} strokeWidth={2.2} />
             </button>
-            {composerMenuOpen && (
-                <>
-                    <div style={{position: 'fixed', inset: 0, zIndex: 9}} onClick={() => setComposerMenuOpen(false)} />
-                    <div className="qa-drawer-item-menu" style={{ position: 'absolute', bottom: 'calc(100% + 8px)', left: 0, zIndex: 10, right: 'auto', top: 'auto', display: 'flex', flexDirection: 'column', minWidth: '100px' }}>
-                        <button type="button" className="qa-drawer-menu-btn" onClick={() => { fileInputRef.current?.click(); setComposerMenuOpen(false); }}>
-                            <Paperclip size={14} /> 添加附件
-                        </button>
-                        {visionEnabled && (
-                            <button type="button" className="qa-drawer-menu-btn" onClick={() => { imageInputRef.current?.click(); setComposerMenuOpen(false); }}>
-                                <ImageIcon size={14} /> 添加图片
-                            </button>
-                        )}
-                    </div>
-                </>
+
+            {visionEnabled && (
+              <>
+                <input
+                  ref={imageInputRef}
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  style={{ display: "none" }}
+                  onChange={(e) => handlePickImages(e.target.files)}
+                />
+                <button
+                  type="button"
+                  className="qa-circle-btn qa-attach-btn"
+                  onClick={() => imageInputRef.current?.click()}
+                  aria-label="发送图片"
+                >
+                  <Plus size={17} strokeWidth={2.2} />
+                </button>
+              </>
             )}
-        </div>
+            {modelName && <span className="qa-model-pill">{modelName}</span>}
 
-        {modelName && <span className="qa-model-pill">{modelName}</span>}
+            {repoWritable && (
+              <button type="button" className="qa-mode-pill" onClick={toggleWriteMode}>
+                {writeMode === "auto" ? "全自动" : "确认后提交"}
+              </button>
+            )}
 
-        {repoWritable && (
-          <button type="button" className="qa-mode-pill" onClick={toggleWriteMode}>
-            {writeMode === "auto" ? "全自动" : "确认后提交"}
-          </button>
-        )}
+            <div className="qa-composer-spacer" />
 
-        <div className="qa-composer-spacer" />
+            {createdContent.length > 0 && (
+              <button
+                type="button"
+                className="qa-circle-btn qa-preview-btn"
+                onClick={() => setPreviewOpen(true)}
+                aria-label="预览本轮创建的内容"
+              >
+                <Play size={16} />
+              </button>
+            )}
 
-        {createdContent.length > 0 && (
-          <button
-            type="button"
-            className="qa-circle-btn qa-preview-btn"
-            onClick={() => setPreviewOpen(true)}
-            aria-label="预览本轮创建的内容"
+            <button
+              type="button"
+              className={`qa-circle-btn qa-github-btn ${repoConnected ? "is-active" : ""}`}
+              onClick={() => setRepoSheetOpen(true)}
+              aria-label="连接仓库"
+            >
+              <Github size={16} strokeWidth={1.75} />
+            </button>
+
+            {snapshot.isGenerating ? (
+              <button type="button" className="qa-circle-btn qa-send-btn is-stop" onClick={stopQaGeneration} aria-label="停止生成">
+                <Square size={14} fill="currentColor" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="qa-circle-btn qa-send-btn"
+                onClick={handleSend}
+                disabled={!input.trim() && pendingImages.length === 0 && pendingFiles.length === 0}
+                aria-label="发送"
+              >
+                <ArrowUp size={20} strokeWidth={2.4} />
+              </button>
+            )}
+          </div>
+          <div
+            className={`qa-context-meter ${snapshot.isCompacting ? "is-compacting" : ""}`}
+            title="上下文用量：满 100% 时自动压缩成摘要并从头累计"
           >
-            <Play size={16} />
-          </button>
-        )}
+            <div className="qa-context-meter-track" aria-hidden>
+              <i style={{ width: `${Math.min(100, Math.round(snapshot.contextUsage * 100))}%` }} />
+            </div>
+            <span className="qa-context-meter-label">
+              {snapshot.isCompacting ? "压缩中" : `${Math.min(999, Math.round(snapshot.contextUsage * 100))}%`}
+            </span>
+          </div>
+        </div>
+      </footer>
 
+      {drawerOpen && (
         <button
           type="button"
-          className={`qa-circle-btn qa-github-btn ${repoConnected ? "is-active" : ""}`}
-          onClick={() => setRepoSheetOpen(true)}
-          aria-label="连接仓库"
-        >
-          <Github size={16} strokeWidth={1.75} />
-        </button>
-
-        {snapshot.isGenerating ? (
-          <button type="button" className="qa-circle-btn qa-send-btn is-stop" onClick={stopQaGeneration} aria-label="停止生成">
-            <Square size={14} fill="currentColor" />
-          </button>
-        ) : (
-          <button
-            type="button"
-            className="qa-circle-btn qa-send-btn"
-            onClick={handleSend}
-            disabled={!input.trim() && pendingImages.length === 0 && pendingFiles.length === 0}
-            aria-label="发送"
-          >
-            <ArrowUp size={20} strokeWidth={2.4} />
-          </button>
-        )}
-      </div>
-      <div
-        className={`qa-context-meter ${snapshot.isCompacting ? "is-compacting" : ""}`}
-        title="上下文用量：满 100% 时自动压缩成摘要并从头累计"
-      >
-        <div className="qa-context-meter-track" aria-hidden>
-          <i style={{ width: `${Math.min(100, Math.round(snapshot.contextUsage * 100))}%` }} />
-        </div>
-        <span className="qa-context-meter-label">
-          {snapshot.isCompacting ? "压缩中" : `${Math.min(999, Math.round(snapshot.contextUsage * 100))}%`}
-        </span>
-      </div>
-    </div>
-  </footer>
-
-  {drawerOpen && (
-    <button
-      type="button"
-      className="qa-stage-scrim"
-      aria-label="关闭对话列表"
-      onClick={() => setDrawerOpen(false)}
-    />
-  )}
-  </div>
-
-  {/* 弹窗与悬浮层组件 */}
-  {renameTarget && (
-    <div className="qa-rename-backdrop" role="presentation" onClick={() => setRenameTarget(null)}>
-      <form
-        className="qa-rename-dialog"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="qa-rename-dialog-title"
-        onClick={(e) => e.stopPropagation()}
-        onSubmit={(e) => {
-          e.preventDefault();
-          const title = renameTitle.trim();
-          if (!title) return;
-          renameQaSession(renameTarget.id, title);
-          setRenameTarget(null);
-        }}
-      >
-        <div id="qa-rename-dialog-title" className="qa-rename-title">重命名对话</div>
-        <input
-          className="qa-rename-input"
-          autoFocus
-          value={renameTitle}
-          maxLength={80}
-          aria-label="新对话名称"
-          onChange={(e) => setRenameTitle(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Escape") setRenameTarget(null); }}
+          className="qa-stage-scrim"
+          aria-label="关闭对话列表"
+          onClick={() => setDrawerOpen(false)}
         />
-        <div className="qa-rename-actions">
-          <button type="button" className="qa-rename-cancel" onClick={() => setRenameTarget(null)}>取消</button>
-          <button type="submit" className="qa-drawer-new qa-rename-confirm" disabled={!renameTitle.trim()}>确认</button>
-        </div>
-      </form>
-    </div>
-  )}
-
-  {clearToolsOpen && (
-    <div className="qa-devnotice-backdrop" onClick={() => setClearToolsOpen(false)}>
-      <div className="qa-devnotice" role="alertdialog" aria-label="清理工具历史确认" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-devnotice-title">清理工具调用历史？</div>
-        <div className="qa-devnotice-text">
-          将移除本会话上下文中的工具调用与工具结果记录，用于修复原生工具协议的报错。普通对话内容不会删除，之前的工具结论仍保留在小坊的回复文字里。
-        </div>
-        <div className="qa-devnotice-actions is-row">
-          <button type="button" className="qa-devnotice-btn" onClick={() => setClearToolsOpen(false)}>
-            取消
-          </button>
-          <button type="button" className="qa-devnotice-btn is-primary" onClick={confirmClearToolHistory}>
-            清理
-          </button>
-        </div>
+      )}
       </div>
-    </div>
-  )}
 
-  {viewerImage && (
-    <div className="qa-image-viewer" role="presentation" onClick={() => setViewerImage(null)}>
-      <img src={viewerImage} alt="" />
-      <button type="button" className="qa-image-viewer-close" aria-label="关闭" onClick={() => setViewerImage(null)}>
-        <X size={20} />
-      </button>
-    </div>
-  )}
-
-  {/* 修改消息弹窗 */}
-  {editingMsg && (
-    <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
-      <div className="qa-edit-dialog" role="dialog" aria-label="修改消息" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-edit-head">
-          <span className="qa-edit-title">修改消息</span>
-          <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
-            <X size={16} />
-          </button>
-        </div>
-        
-        <div style={{ padding: "0 16px 8px 16px" }}>
-            <textarea
-              className="qa-edit-textarea"
-              value={editText}
-              onChange={(e) => setEditText(e.target.value)}
-              spellCheck={false}
-              autoFocus
-              style={{ minHeight: "120px", marginBottom: "8px" }}
-            />
-            
-            <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "8px" }}>
-                {editImages.map((url, i) => (
-                    <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "4px", overflow: "hidden", border: "1px solid rgba(255,255,255,0.1)" }}>
-                        <img src={url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
-                        <button
-                            type="button"
-                            style={{ position: "absolute", top: 0, right: 0, background: "rgba(0,0,0,0.5)", color: "white", border: "none", borderRadius: "0 0 0 4px", cursor: "pointer", padding: "2px" }}
-                            onClick={() => setEditImages(current => current.filter((_, idx) => idx !== i))}
-                        >
-                            <X size={10} />
-                        </button>
-                    </div>
-                ))}
-                {editFiles.map((f, i) => (
-                     <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "rgba(255,255,255,0.1)", padding: "4px 20px 4px 8px", borderRadius: "4px", fontSize: "11px", border: "1px solid rgba(255,255,255,0.2)" }}>
-                        <FileText size={12} style={{ marginRight: "4px" }} />
-                        <span style={{ maxWidth: "80px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
-                        <button
-                            type="button"
-                            style={{ position: "absolute", right: "2px", background: "transparent", color: "inherit", border: "none", cursor: "pointer", display: "flex", alignItems: "center" }}
-                            onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}
-                        >
-                            <X size={12} />
-                        </button>
-                    </div>
-                ))}
-            </div>
-        </div>
-        
-        <div className="qa-edit-actions" style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 16px" }}>
-            {/* 左侧的附件添加菜单（精简排版，向上展开防误触） */}
-            <div style={{ position: "relative" }}>
-                <button type="button" className="qa-icon-btn" style={{ padding: "6px" }} onClick={() => setEditAttachMenuOpen(!editAttachMenuOpen)} aria-label="展开添加菜单">
-                    <Plus size={20} />
-                </button>
-                {editAttachMenuOpen && (
-                    <>
-                        <div style={{position: 'fixed', inset: 0, zIndex: 9}} onClick={() => setEditAttachMenuOpen(false)} />
-                        <div className="qa-drawer-item-menu" style={{ position: 'absolute', bottom: 'calc(100% + 4px)', left: 0, zIndex: 10, right: 'auto', top: 'auto', display: 'flex', flexDirection: 'column', minWidth: '100px' }}>
-                            <button type="button" className="qa-drawer-menu-btn" onClick={() => { fileInputRef.current?.setAttribute('data-edit-mode', 'true'); fileInputRef.current?.click(); setEditAttachMenuOpen(false); }}>
-                                <Paperclip size={14} /> 添加附件
-                            </button>
-                            {visionEnabled && (
-                                <button type="button" className="qa-drawer-menu-btn" onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); setEditAttachMenuOpen(false); }}>
-                                    <ImageIcon size={14} /> 添加图片
-                                </button>
-                            )}
-                        </div>
-                    </>
-                )}
-            </div>
-            {/* 右侧直接就是精简的保存和发送 */}
-            <div style={{ display: "flex", gap: "8px" }}>
-                <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
-                    保存
-                </button>
-                <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
-                    保存并发送
-                </button>
-            </div>
-        </div>
-      </div>
-    </div>
-  )}
-
-  {settingsOpen && (
-    <QaSettingsSheet onClose={() => setSettingsOpen(false)} onNotice={onNotice} />
-  )}
-
-  {repoSheetOpen && (
-    <QaRepoSheet onClose={() => setRepoSheetOpen(false)} onSaved={refreshComposerMeta} />
-  )}
-
-  {previewOpen && !previewItem && (
-    <div className="qa-sheet-backdrop" onClick={() => setPreviewOpen(false)}>
-      <div className="qa-sheet qa-preview-sheet" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-sheet-head">
-          <span className="qa-sheet-title">
-            <Play size={16} /> 预览本轮创建
-          </span>
-          <button type="button" className="qa-icon-btn" onClick={() => setPreviewOpen(false)} aria-label="关闭">
-            <X size={16} />
-          </button>
-        </div>
-        <div className="qa-sheet-body">
-          <p className="qa-sheet-note">本次对话里创建/更新的内容，点开直接测试，返回后回到聊天。</p>
-          {createdContent.map((item) => (
-            <button
-              key={`${item.type}-${item.refId}`}
-              type="button"
-              className="qa-preview-item"
-              onClick={() => setPreviewItem(item)}
-            >
-              {item.type === "app" ? <AppWindow size={17} /> : item.type === "game" ? <Gamepad2 size={17} /> : <Drama size={17} />}
-              <span className="qa-preview-item-title">{item.title}</span>
-              <span className="qa-preview-item-type">
-                {item.type === "app" ? "应用" : item.type === "game" ? "游戏" : "剧场"}
-              </span>
-              <ChevronRight size={15} />
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
-  )}
-
-  {previewItem && (
-    <div className="qa-preview-runtime">
-      {previewItem.type === "app" ? (
-        previewApp ? (
-          <CustomAppForegroundBoundary
-            key={previewApp.id}
-            appName={previewApp.name}
-            appId={previewApp.id}
-            appVersion={previewApp.version}
-            manifestId={previewApp.manifest?.id}
-            closeLabel="返回"
-            onClose={() => setPreviewItem(null)}
+      {renameTarget && (
+        <div className="qa-rename-backdrop" role="presentation" onClick={() => setRenameTarget(null)}>
+          <form
+            className="qa-rename-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="qa-rename-dialog-title"
+            onClick={(e) => e.stopPropagation()}
+            onSubmit={(e) => {
+              e.preventDefault();
+              const title = renameTitle.trim();
+              if (!title) return;
+              renameQaSession(renameTarget.id, title);
+              setRenameTarget(null);
+            }}
           >
-            <CustomAppRunner app={previewApp} onClose={() => setPreviewItem(null)} />
-          </CustomAppForegroundBoundary>
-        ) : (
-          <div className="qa-preview-missing">
-            <p>这个应用已被卸载或找不到了。</p>
-            <button type="button" className="qa-sheet-btn is-primary" onClick={() => setPreviewItem(null)}>
-              返回
-            </button>
+            <div id="qa-rename-dialog-title" className="qa-rename-title">重命名对话</div>
+            <input
+              className="qa-rename-input"
+              autoFocus
+              value={renameTitle}
+              maxLength={80}
+              aria-label="新对话名称"
+              onChange={(e) => setRenameTitle(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Escape") setRenameTarget(null); }}
+            />
+            <div className="qa-rename-actions">
+              <button type="button" className="qa-rename-cancel" onClick={() => setRenameTarget(null)}>取消</button>
+              <button type="submit" className="qa-drawer-new qa-rename-confirm" disabled={!renameTitle.trim()}>确认</button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {clearToolsOpen && (
+        <div className="qa-devnotice-backdrop" onClick={() => setClearToolsOpen(false)}>
+          <div className="qa-devnotice" role="alertdialog" aria-label="清理工具历史确认" onClick={(e) => e.stopPropagation()}>
+            <div className="qa-devnotice-title">清理工具调用历史？</div>
+            <div className="qa-devnotice-text">
+              将移除本会话上下文中的工具调用与工具结果记录，用于修复原生工具协议的报错。普通对话内容不会删除，之前的工具结论仍保留在小坊的回复文字里。
+            </div>
+            <div className="qa-devnotice-actions is-row">
+              <button type="button" className="qa-devnotice-btn" onClick={() => setClearToolsOpen(false)}>
+                取消
+              </button>
+              <button type="button" className="qa-devnotice-btn is-primary" onClick={confirmClearToolHistory}>
+                清理
+              </button>
+            </div>
           </div>
-        )
-      ) : previewItem.type === "game" ? (
-        <GameHubApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
-      ) : (
-        <BlackMarketApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
+        </div>
+      )}
+
+      {viewerImage && (
+        <div className="qa-image-viewer" role="presentation" onClick={() => setViewerImage(null)}>
+          <img src={viewerImage} alt="" />
+          <button type="button" className="qa-image-viewer-close" aria-label="关闭" onClick={() => setViewerImage(null)}>
+            <X size={20} />
+          </button>
+        </div>
+      )}
+
+      {editingMsg && (
+        <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
+          <div className="qa-edit-dialog" role="dialog" aria-label="修改消息" onClick={(e) => e.stopPropagation()}>
+            <div className="qa-edit-head">
+              <span className="qa-edit-title">修改消息</span>
+              <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
+                <X size={16} />
+              </button>
+            </div>
+            
+            <div style={{ padding: "0 16px 8px 16px" }}>
+                <textarea
+                  className="qa-edit-textarea"
+                  value={editText}
+                  onChange={(e) => setEditText(e.target.value)}
+                  spellCheck={false}
+                  autoFocus
+                  style={{ minHeight: "120px", marginBottom: "8px" }}
+                />
+                
+                <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "8px" }}>
+                    {editImages.map((url, i) => (
+                        <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "4px", overflow: "hidden", border: "1px solid rgba(255,255,255,0.1)" }}>
+                            <img src={url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+                            <button
+                                type="button"
+                                style={{ position: "absolute", top: 0, right: 0, background: "rgba(0,0,0,0.5)", color: "white", border: "none", borderRadius: "0 0 0 4px", cursor: "pointer", padding: "2px" }}
+                                onClick={() => setEditImages(current => current.filter((_, idx) => idx !== i))}
+                            >
+                                <X size={10} />
+                            </button>
+                        </div>
+                    ))}
+                    {editFiles.map((f, i) => (
+                         <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "rgba(255,255,255,0.1)", padding: "4px 20px 4px 8px", borderRadius: "4px", fontSize: "11px", border: "1px solid rgba(255,255,255,0.2)" }}>
+                            <FileText size={12} style={{ marginRight: "4px" }} />
+                            <span style={{ maxWidth: "80px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
+                            <button
+                                type="button"
+                                style={{ position: "absolute", right: "2px", background: "transparent", color: "inherit", border: "none", cursor: "pointer", display: "flex", alignItems: "center" }}
+                                onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}
+                            >
+                                <X size={12} />
+                            </button>
+                        </div>
+                    ))}
+                </div>
+
+                <div style={{ display: "flex", gap: "8px" }}>
+                    <button type="button" className="qa-devnotice-btn" onClick={() => fileInputRef.current?.click()} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
+                        <Paperclip size={12} /> 添加附件
+                    </button>
+                    <button type="button" className="qa-devnotice-btn" onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); }} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
+                        <Plus size={12} /> 添加图片
+                    </button>
+                     <input
+                        ref={imageInputRef}
+                        type="file"
+                        accept="image/*"
+                        multiple
+                        style={{ display: "none" }}
+                        onChange={(e) => {
+                            const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
+                            handlePickImages(e.target.files, isEditMode);
+                            e.target.removeAttribute('data-edit-mode');
+                        }}
+                    />
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
+                        style={{ display: "none" }}
+                        onChange={(e) => handlePickFiles(e.target.files, true)}
+                    />
+                </div>
+            </div>
+            
+            <div className="qa-edit-actions">
+              <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
+                取消
+              </button>
+              <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
+                仅保存
+              </button>
+              <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
+                保存并发送
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {settingsOpen && (
+        <QaSettingsSheet onClose={() => setSettingsOpen(false)} onNotice={onNotice} />
+      )}
+
+      {repoSheetOpen && (
+        <QaRepoSheet onClose={() => setRepoSheetOpen(false)} onSaved={refreshComposerMeta} />
+      )}
+
+      {previewOpen && !previewItem && (
+        <div className="qa-sheet-backdrop" onClick={() => setPreviewOpen(false)}>
+          <div className="qa-sheet qa-preview-sheet" onClick={(e) => e.stopPropagation()}>
+            <div className="qa-sheet-head">
+              <span className="qa-sheet-title">
+                <Play size={16} /> 预览本轮创建
+              </span>
+              <button type="button" className="qa-icon-btn" onClick={() => setPreviewOpen(false)} aria-label="关闭">
+                <X size={16} />
+              </button>
+            </div>
+            <div className="qa-sheet-body">
+              <p className="qa-sheet-note">本次对话里创建/更新的内容，点开直接测试，返回后回到聊天。</p>
+              {createdContent.map((item) => (
+                <button
+                  key={`${item.type}-${item.refId}`}
+                  type="button"
+                  className="qa-preview-item"
+                  onClick={() => setPreviewItem(item)}
+                >
+                  {item.type === "app" ? <AppWindow size={17} /> : item.type === "game" ? <Gamepad2 size={17} /> : <Drama size={17} />}
+                  <span className="qa-preview-item-title">{item.title}</span>
+                  <span className="qa-preview-item-type">
+                    {item.type === "app" ? "应用" : item.type === "game" ? "游戏" : "剧场"}
+                  </span>
+                  <ChevronRight size={15} />
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {previewItem && (
+        <div className="qa-preview-runtime">
+          {previewItem.type === "app" ? (
+            previewApp ? (
+              <CustomAppForegroundBoundary
+                key={previewApp.id}
+                appName={previewApp.name}
+                appId={previewApp.id}
+                appVersion={previewApp.version}
+                manifestId={previewApp.manifest?.id}
+                closeLabel="返回"
+                onClose={() => setPreviewItem(null)}
+              >
+                <CustomAppRunner app={previewApp} onClose={() => setPreviewItem(null)} />
+              </CustomAppForegroundBoundary>
+            ) : (
+              <div className="qa-preview-missing">
+                <p>这个应用已被卸载或找不到了。</p>
+                <button type="button" className="qa-sheet-btn is-primary" onClick={() => setPreviewItem(null)}>
+                  返回
+                </button>
+              </div>
+            )
+          ) : previewItem.type === "game" ? (
+            <GameHubApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
+          ) : (
+            <BlackMarketApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
+          )}
+        </div>
       )}
     </div>
-  )}
-</div>
-
-
-);
+  );
 }

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -1348,7 +1348,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                 
                 <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "8px" }}>
                     {editImages.map((url, i) => (
-                        <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "4px", overflow: "hidden", border: "1px solid rgba(255,255,255,0.1)" }}>
+                        <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "12px", overflow: "hidden", border: "1px solid rgba(255,255,255,0.1)" }}>
                             <img src={url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
                             <button
                                 type="button"
@@ -1401,7 +1401,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
             <div className="qa-edit-actions" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', marginTop: '8px' }}>
                 <div style={{ position: 'relative' }}>
                     {editAttachMenuOpen && (
-                        <div style={{ position: "absolute", bottom: "100%", left: "-8px", marginBottom: "4px", display: "flex", gap: "8px", padding: "8px", animation: "fadeIn 0.2s", whiteSpace: "nowrap" }}>
+                        <div style={{ position: "absolute", bottom: "100%", left: "0", marginBottom: "4px", display: "flex", gap: "8px", padding: "8px", animation: "fadeIn 0.2s", whiteSpace: "nowrap" }}>
                             <button
                                 type="button"
                                 onClick={() => { fileInputRef.current?.click(); setEditAttachMenuOpen(false); }}
@@ -1423,18 +1423,40 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                     <button
                         type="button"
                         onClick={() => setEditAttachMenuOpen(prev => !prev)}
-                        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '32px', height: '32px', borderRadius: '50%', background: 'transparent', border: 'none', cursor: 'pointer', color: 'inherit' }}
+                        style={{ 
+                            display: 'flex', 
+                            alignItems: 'center', 
+                            justifyContent: 'center', 
+                            width: '32px', 
+                            height: '32px', 
+                            borderRadius: '50%', 
+                            background: 'rgba(255, 255, 255, 0.9)', 
+                            border: '1px solid rgba(0, 0, 0, 0.05)', 
+                            boxShadow: '0 2px 5px rgba(0,0,0,0.08)',
+                            cursor: 'pointer', 
+                            color: '#333'
+                        }}
                         aria-label="添加附件或图片"
                     >
-                        <Plus size={22} strokeWidth={2.2} style={{ transform: editAttachMenuOpen ? 'rotate(45deg)' : 'none', transition: 'transform 0.2s ease-in-out' }} />
+                        <Plus size={18} strokeWidth={2.2} style={{ transform: editAttachMenuOpen ? 'rotate(45deg)' : 'none', transition: 'transform 0.2s ease-in-out' }} />
                     </button>
                 </div>
                 
-                <div style={{ display: 'flex', gap: '8px' }}>
-                    <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
+                <div style={{ display: 'flex', gap: '8px', alignItems: 'stretch' }}>
+                    <button 
+                        type="button" 
+                        className="qa-devnotice-btn" 
+                        onClick={() => handleSaveEdit(false)}
+                        style={{ whiteSpace: 'nowrap', padding: '0 16px' }}
+                    >
                         保存
                     </button>
-                    <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
+                    <button 
+                        type="button" 
+                        className="qa-devnotice-btn is-primary" 
+                        onClick={() => handleSaveEdit(true)}
+                        style={{ whiteSpace: 'nowrap', padding: '0 16px' }}
+                    >
                         保存并发送
                     </button>
                 </div>

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -1554,4 +1554,3 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
     </div>
   );
 }
-```eof

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -84,7 +84,7 @@ const SUGGESTIONS = [
 "帮我写个小游戏装到本机",
 ];
 
-// 注意这里的反引号修复
+// 注意这里已经修复了反引号丢失的问题
 function formatRelativeTime(ts: number): string {
 const diff = Date.now() - ts;
 if (diff < 60_000) return "刚刚";

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -3,6 +3,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, FileText, Gamepad2, Github, Loader2, Menu, MoreVertical, Pencil, Pin, PinOff, Play, Plus, Square, Trash2, Wrench, X } from "lucide-react";
+
 import { QaFileCard } from "@/components/qa-file-card";
 import { parseQaFileMarker } from "@/lib/qa-computer-tools";
 import { mdiHammerWrench } from "@mdi/js";
@@ -12,6 +13,7 @@ import { GameHubApp } from "@/components/game/game-hub-app";
 import { BlackMarketApp } from "@/components/shopping/black-market-app";
 import { getInstalledCustomApp } from "@/lib/custom-app-storage";
 import type { QaCreatedContent } from "@/lib/qa-agent-tools";
+
 import {
 applyQaCommit,
 cancelQaCommit,
@@ -213,9 +215,10 @@ return (
 
 // ── 消息渲染 ─────────────────────────────────────────
 
-// 工具调用行：折叠的单行摘要，点开展开参数与结果
+// 工具调用行：折叠的单行摘要，点开展开参数与结果（Claude Code 风格）
 function QaToolRow({ tool }: { tool: QaToolStatus }) {
 const [open, setOpen] = useState(false);
+// 「电脑文件 op=send」的结果里带文件卡标记：卡片常显，标记从结果文本中剥离
 const { text: resultText, file } = parseQaFileMarker(tool.result || "");
 const hasDetail = Boolean(tool.detail || resultText);
 const summary = tool.running ? 正在${tool.name}… : tool.success === false ? ${tool.name}失败 : tool.name;
@@ -255,7 +258,7 @@ disabled={!hasDetail}
 );
 }
 
-// 已完成文本的 Markdown 渲染：memo 缓存，流式期间不再重复渲染全文以避免 OOM
+// 已完成文本的 Markdown 渲染：memo 缓存
 const QaMarkdownBlock = memo(function QaMarkdownBlock({ text }: { text: string }) {
 return (
 
@@ -790,11 +793,7 @@ GitHub → Settings → Menu 按钮 → Developer settings → Personal access t
 // ── App 本体 ─────────────────────────────────────────
 
 export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
-// 弃用 useSyncExternalStore，改回经典的 useEffect + useState 模式。
-// LLM 流式输出的频率极高（可能几毫秒就 emit 一次），会导致 useSyncExternalStore
-// 触发 React 18 的 Concurrent Mode 防撕裂（Tearing）保护机制，抛出
-// "The result of getSnapshot should be cached to avoid an infinite loop" 的崩溃。
-// 改回传统的订阅方式能优雅地解决这个问题。
+// 使用 useState + useEffect 替换 useSyncExternalStore，完美解决 tearing 引起的无线重渲问题
 const [snapshot, setSnapshot] = useState(getQaChatSnapshot);
 useEffect(() => {
 return subscribeQaChat(() => {
@@ -812,7 +811,6 @@ const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } |
 const [renameTitle, setRenameTitle] = useState("");
 
 const [pendingImages, setPendingImages] = useState<string[]>([]);
-// 新增：文本附件的状态记录
 const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
 const [viewerImage, setViewerImage] = useState<string | null>(null);
 const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -84,6 +84,7 @@ const SUGGESTIONS = [
 "帮我写个小游戏装到本机",
 ];
 
+// 注意这里的反引号修复
 function formatRelativeTime(ts: number): string {
 const diff = Date.now() - ts;
 if (diff < 60_000) return "刚刚";
@@ -92,7 +93,6 @@ if (diff < 86_400_000) return ${Math.floor(diff / 3_600_000)} 小时前;
 return ${Math.floor(diff / 86_400_000)} 天前;
 }
 
-/* STREAMING_CHUNK:Defining UI Helper Components... */
 // ── 代码块（语言标签 + 一键复制）─────────────────────
 
 function QaCodeBlock({ className, children }: { className?: string; children?: React.ReactNode }) {
@@ -214,10 +214,8 @@ return (
 );
 }
 
-/* STREAMING_CHUNK:Rendering Chat Messages... */
 // ── 消息渲染 ─────────────────────────────────────────
 
-// 工具调用行：折叠的单行摘要，点开展开参数与结果
 function QaToolRow({ tool }: { tool: QaToolStatus }) {
 const [open, setOpen] = useState(false);
 const { text: resultText, file } = parseQaFileMarker(tool.result || "");
@@ -414,7 +412,6 @@ block.kind === "tools" ? (
 );
 });
 
-/* STREAMING_CHUNK:Session Drawers and Settings Panels... */
 // ── 会话抽屉 ─────────────────────────────────────────
 
 function QaSessionDrawer({
@@ -767,7 +764,7 @@ GitHub → Settings → Menu 按钮 → Developer settings → Personal access t
 {result && (
 <div className={qa-verify ${result.ok ? "is-ok" : "is-fail"}}>
 {result.ok
-? ✓ 已连接 ${result.fullName}（${result.private ? "私有" : "默认分支 ${result.defaultBranch}"}）
+? ✓ 已连接 ${result.fullName}（${result.private ? "私有" : "公开"}，默认分支 ${result.defaultBranch}）
 : ✗ ${result.error}}
 
 )}
@@ -790,7 +787,6 @@ GitHub → Settings → Menu 按钮 → Developer settings → Personal access t
 );
 }
 
-/* STREAMING_CHUNK:Main App Component Initialization... */
 // ── App 本体 ─────────────────────────────────────────
 
 export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
@@ -888,7 +884,6 @@ const previewApp = useMemo(
 [previewItem],
 );
 
-/* STREAMING_CHUNK:Event Handlers and Media Processing... */
 // 自动滚动：用户上滚阅读时不拉回底部
 const handleScroll = useCallback(() => {
 const el = bodyRef.current;
@@ -1003,7 +998,6 @@ snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].ro
 ? messages[messages.length - 1].id
 : null;
 
-/* STREAMING_CHUNK:Rendering Main Layout... */
 return (
 
 <QaSessionDrawer
@@ -1329,7 +1323,7 @@ setRenameTitle(title);
     </div>
   )}
 
-  {/* STREAMING_CHUNK:Editing Message Dialog Rendering... */}
+  {/* 修改消息弹窗 */}
   {editingMsg && (
     <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
       <div className="qa-edit-dialog" role="dialog" aria-label="修改消息" onClick={(e) => e.stopPropagation()}>

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -2,74 +2,71 @@
 
 import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import remarkBreaks from "remark-breaks";
-import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, MoreVertical, Pencil, Pin, PinOff, Play, Plus, Square, Trash2, Wrench, X, Paperclip, FileText, Image as ImageIcon } from "lucide-react";
-import { QaFileCard } from "@/components/qa-file-card";
-import { parseQaFileMarker } from "@/lib/qa-computer-tools";
-import { mdiHammerWrench } from "@mdi/js";
-import { CustomAppRunner } from "@/components/app-market/custom-app-runner";
-import { CustomAppForegroundBoundary } from "@/components/app-market/custom-app-failure";
-import { GameHubApp } from "@/components/game/game-hub-app";
-import { BlackMarketApp } from "@/components/shopping/black-market-app";
-import { getInstalledCustomApp } from "@/lib/custom-app-storage";
-import type { QaCreatedContent } from "@/lib/qa-agent-tools";
-import {
-  applyQaCommit,
-  cancelQaCommit,
-  clearQaToolHistory,
-  createQaSession,
-  deleteQaSession,
-  getQaActiveContextChars,
-  getQaChatSnapshot,
-  getQaContextBudgetChars,
-  hasQaToolHistory,
-  hydrateQaChat,
-  QA_CONTEXT_BUDGET_MAX,
-  QA_CONTEXT_BUDGET_MIN,
-  QA_DEFAULT_CONTEXT_BUDGET_CHARS,
-  setQaContextBudgetChars,
-  retryQaMessage,
-  renameQaSession,
-  revertQaAppliedCommit,
-  sendQaMessage,
-  stopQaGeneration,
-  subscribeQaChat,
-  switchQaSession,
-  toggleQaSessionPin,
-  updateQaMessageContent,
-  editAndResendQaMessage,
-  type QaMsg,
-  type QaSession,
-  type QaToolStatus,
-} from "@/lib/qa-chat-store";
-import {
-  getQaPageChars,
-  setQaPageChars,
-  QA_DEFAULT_PAGE_CHARS,
-  QA_PAGE_CHARS_MIN,
-  QA_PAGE_CHARS_MAX,
-  getQaMaxRounds,
-  setQaMaxRounds,
-  QA_DEFAULT_MAX_ROUNDS,
-  QA_MAX_ROUNDS_MIN,
-  QA_MAX_ROUNDS_MAX,
-  getQaMaxOutputTokens,
-  setQaMaxOutputTokens,
-  QA_DEFAULT_MAX_OUTPUT_TOKENS,
-  QA_MAX_OUTPUT_TOKENS_MIN,
-  QA_MAX_OUTPUT_TOKENS_MAX,
-} from "@/lib/qa-prefs";
-import { resolveQaApiConfig } from "@/lib/qa-agent-engine";
-import {
-  loadQaGithubConfig,
-  saveQaGithubConfig,
-  clearQaGithubConfig,
-  validateQaGithubConfig,
-  type QaGithubConfig,
-  type QaGithubValidation,
-} from "@/lib/qa-github";
-import "@/lib/qa-error-log";
+import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, FileText, Gamepad2, Github, Loader2, Menu, MoreVertical, Pencil, Pin, PinOff, Play, Plus, Square, Trash2, Wrench, X } from "lucide-react";
+
+// mock missing components and libs
+const QaFileCard = ({ file }: any) => <div className="qa-file-card">{file.name}</div>;
+const parseQaFileMarker = (text: string) => ({ text, file: null });
+const mdiHammerWrench = "M13.78 15.3L19.78 21.3L21.89 19.14L15.89 13.14L13.78 15.3M17.5 10.1C17.11 10.1 16.73 10.15 16.38 10.27L14.7 8.59L15.27 7.5L12 4.25L10.33 6H7.95L5.78 3.83L4.2 5.41L6.37 7.58V10.13L4.54 11.5L5.61 12.07L7.3 13.75C7.18 14.1 7.12 14.47 7.12 14.86C7.12 17.73 9.46 20.07 12.33 20.07C13.2 20.07 14.03 19.85 14.73 19.46L16.42 21.15L18.58 18.97L16.9 17.29C17.29 16.59 17.5 15.76 17.5 14.86C17.5 14.54 17.47 14.23 17.41 13.93L19.64 11.7L18.55 10.63L17.18 12.44C16.89 12.22 16.58 12.04 16.24 11.91L17.33 10.82C17.38 10.58 17.5 10.35 17.5 10.1Z";
+const CustomAppRunner = () => <div>App Runner</div>;
+const CustomAppForegroundBoundary = ({ children }: any) => <>{children}</>;
+const GameHubApp = () => <div>Game Hub</div>;
+const BlackMarketApp = () => <div>Black Market</div>;
+const getInstalledCustomApp = (id: string) => null;
+// mock chat store
+const applyQaCommit = async () => {};
+const cancelQaCommit = () => {};
+const clearQaToolHistory = () => ({ removed: 0, cleaned: 0 });
+const createQaSession = () => "session-1";
+const deleteQaSession = () => {};
+const getQaActiveContextChars = () => 0;
+const getQaChatSnapshot = () => ({ sessions: [], activeSessionId: null, hydrated: true, isGenerating: false, contextUsage: 0, isCompacting: false });
+const getQaContextBudgetChars = () => 100000;
+const hasQaToolHistory = () => false;
+const hydrateQaChat = async () => {};
+const QA_CONTEXT_BUDGET_MAX = 2000000;
+const QA_CONTEXT_BUDGET_MIN = 2000;
+const QA_DEFAULT_CONTEXT_BUDGET_CHARS = 1000000;
+const setQaContextBudgetChars = () => {};
+const retryQaMessage = async () => {};
+const renameQaSession = () => {};
+const revertQaAppliedCommit = async () => {};
+const sendQaMessage = async () => {};
+const stopQaGeneration = () => {};
+const subscribeQaChat = () => () => {};
+const switchQaSession = () => {};
+const toggleQaSessionPin = () => {};
+const updateQaMessageContent = () => {};
+const editAndResendQaMessage = async () => {};
+type QaMsg = any;
+type QaSession = any;
+type QaToolStatus = any;
+type QaCreatedContent = any;
+// mock prefs
+const getQaPageChars = () => 4000;
+const setQaPageChars = () => {};
+const QA_DEFAULT_PAGE_CHARS = 4000;
+const QA_PAGE_CHARS_MIN = 1000;
+const QA_PAGE_CHARS_MAX = 30000;
+const getQaMaxRounds = () => 5;
+const setQaMaxRounds = () => {};
+const QA_DEFAULT_MAX_ROUNDS = 5;
+const QA_MAX_ROUNDS_MIN = 1;
+const QA_MAX_ROUNDS_MAX = 30;
+const getQaMaxOutputTokens = () => 4000;
+const setQaMaxOutputTokens = () => {};
+const QA_DEFAULT_MAX_OUTPUT_TOKENS = 4000;
+const QA_MAX_OUTPUT_TOKENS_MIN = 500;
+const QA_MAX_OUTPUT_TOKENS_MAX = 100000;
+// mock agent engine
+const resolveQaApiConfig = () => ({ defaultModel: "mock-model", enableImageRecognition: true });
+// mock github
+const loadQaGithubConfig = () => null;
+const saveQaGithubConfig = () => {};
+const clearQaGithubConfig = () => {};
+const validateQaGithubConfig = async () => ({ ok: true });
+type QaGithubConfig = any;
+type QaGithubValidation = any;
 
 type PhoneQaAppProps = {
   onClose: () => void;
@@ -278,6 +275,15 @@ function QaStreamingText({ text }: { text: string }) {
   );
 }
 
+const QaMarkdownBlock = memo(function QaMarkdownBlock({ text }: { text: string }) {
+  return (
+    <ReactMarkdown components={QA_MARKDOWN_COMPONENTS}>
+      {text}
+    </ReactMarkdown>
+  );
+});
+
+
 const QaMessageItem = memo(function QaMessageItem({
   msg,
   isStreaming,
@@ -303,14 +309,14 @@ const QaMessageItem = memo(function QaMessageItem({
           <button type="button" className="qa-msg-action" aria-label="复制原始内容" title="复制" onClick={() => onCopy(msg.content)}>
             <Copy size={14} strokeWidth={2} />
           </button>
-          <button type="button" className="qa-msg-action" aria-label="修改消息" title="修改" onClick={() => onEdit(msg)}>
+          <button type="button" className="qa-msg-action" aria-label="编辑原始内容" title="编辑" onClick={() => onEdit(msg)}>
             <Pencil size={14} strokeWidth={2} />
           </button>
         </div>
       )}
     </div>
   );
-  
+
   const segmentBlocks = useMemo(() => {
     if (!msg.segments?.length) return null;
     const blocks: Array<{ kind: "text"; text: string } | { kind: "tools"; tools: QaToolStatus[] }> = [];
@@ -341,11 +347,11 @@ const QaMessageItem = memo(function QaMessageItem({
             </div>
           )}
           {msg.files && msg.files.length > 0 && (
-            <div className="qa-msg-files" style={{ display: "flex", flexDirection: "column", gap: "4px", marginBottom: "8px" }}>
-              {msg.files.map((f, i) => (
-                <div key={i} style={{ display: "flex", alignItems: "center", gap: "6px", background: "rgba(255,255,255,0.1)", padding: "4px 8px", borderRadius: "6px", fontSize: "12px", border: "1px solid rgba(255,255,255,0.2)" }}>
-                   <FileText size={14} />
-                   <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: "150px" }}>{f.name}</span>
+            <div className="qa-msg-files" style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '8px' }}>
+              {msg.files.map((file, i) => (
+                <div key={i} className="qa-msg-file" style={{ display: 'flex', alignItems: 'center', gap: '6px', background: 'rgba(255,255,255,0.15)', padding: '6px 10px', borderRadius: '6px', fontSize: '13px', border: '1px solid rgba(255,255,255,0.1)' }}>
+                  <FileText size={15} style={{ opacity: 0.8 }} />
+                  <span style={{ maxWidth: '160px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{file.name}</span>
                 </div>
               ))}
             </div>
@@ -437,7 +443,6 @@ function QaSessionDrawer({
 }) {
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 
-  // 置顶的排最前，其余保持时间序。只在渲染层排，存储顺序不动
   const sortedSessions = useMemo(() => {
     return [...sessions].sort((a, b) => {
       if (Boolean(a.isPinned) !== Boolean(b.isPinned)) return a.isPinned ? -1 : 1;
@@ -800,26 +805,20 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
   const [repoConnected, setRepoConnected] = useState(false);
   const [clearToolsOpen, setClearToolsOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  /** 会话重命名弹窗：抽屉菜单里点「重命名」打开 */
   const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
   const [renameTitle, setRenameTitle] = useState("");
+  
   const [pendingImages, setPendingImages] = useState<string[]>([]);
+  // 新增：文本附件的状态记录
   const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
-  
-  // 控制加号展开菜单的状态
-  const [attachMenuOpen, setAttachMenuOpen] = useState(false);
-  const [editAttachMenuOpen, setEditAttachMenuOpen] = useState(false);
-  
   const [viewerImage, setViewerImage] = useState<string | null>(null);
   const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
   const [editText, setEditText] = useState("");
-  const [editImages, setEditImages] = useState<string[]>([]);
-  const [editFiles, setEditFiles] = useState<{name: string, content: string}[]>([]);
-  
   const [visionEnabled, setVisionEnabled] = useState(false);
-  const imageInputRef = useRef<HTMLInputElement | null>(null);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
   
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
+  // 新增：文本文件的 input ref
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [apiReady, setApiReady] = useState(true);
   const [modelName, setModelName] = useState("");
   const [repoWritable, setRepoWritable] = useState(false);
@@ -843,7 +842,6 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
     refreshComposerMeta();
   }, [refreshComposerMeta]);
 
-  // 清理原生 tool 调用历史（防报错）：与小卷同款——移除上下文里的工具记录与原生元数据
   const handleClearToolHistory = useCallback(() => {
     if (snapshot.isGenerating) {
       onNotice?.("小坊正在执行，完成后再清理。");
@@ -885,7 +883,6 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
     [previewItem],
   );
 
-  // 自动滚动：用户上滚阅读时不拉回底部
   const handleScroll = useCallback(() => {
     const el = bodyRef.current;
     if (!el) return;
@@ -911,7 +908,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
     if ((!text && pendingImages.length === 0 && pendingFiles.length === 0) || snapshot.isGenerating) return;
     setInput("");
     const images = pendingImages;
-    const files = pendingFiles;
+    const files = pendingFiles; // 新增传递文本附件
     setPendingImages([]);
     setPendingFiles([]);
     stickToBottomRef.current = true;
@@ -919,10 +916,8 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
     void sendQaMessage(text, images.length ? images : undefined, files.length ? files : undefined);
   }, [input, pendingImages, pendingFiles, snapshot.isGenerating, autoGrow]);
 
-  // 附加图片：仅识图已开启的 API 显示入口；读为 dataURL，单张限 4MB
-  const handlePickImages = useCallback((files: FileList | null, isEditMode = false) => {
+  const handlePickImages = useCallback((files: FileList | null) => {
     if (!files?.length) return;
-    const setter = isEditMode ? setEditImages : setPendingImages;
     for (const file of Array.from(files).slice(0, 6)) {
       if (file.size > 4 * 1024 * 1024) {
         onNotice?.(`「${file.name}」超过 4MB，已跳过。`);
@@ -931,34 +926,30 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
       const reader = new FileReader();
       reader.onload = () => {
         const url = typeof reader.result === "string" ? reader.result : "";
-        if (url) setter((current) => (current.length >= 6 ? current : [...current, url]));
+        if (url) setPendingImages((current) => (current.length >= 6 ? current : [...current, url]));
       };
       reader.readAsDataURL(file);
     }
     if (imageInputRef.current) imageInputRef.current.value = "";
   }, [onNotice]);
 
-  // 处理编辑弹窗内的图片删除
-  const handleRemoveEditImage = useCallback((index: number) => {
-    setEditImages(current => current.filter((_, i) => i !== index));
-  }, []);
-
-  // 附加文本文件
-  const handlePickFiles = useCallback((files: FileList | null, isEditMode = false) => {
+  // 新增：提取并读取纯文本附件
+  const handlePickFiles = useCallback((files: FileList | null) => {
     if (!files?.length) return;
-    const setter = isEditMode ? setEditFiles : setPendingFiles;
-    for (const file of Array.from(files).slice(0, 6)) {
-      if (file.size > 1024 * 1024) { // 纯文本文件限 1MB
-        onNotice?.(`「${file.name}」太大（超过 1MB），请直接粘贴内容。`);
+    for (const file of Array.from(files).slice(0, 5)) {
+      if (file.size > 1024 * 1024) {
+        onNotice?.(`「${file.name}」超过 1MB，为避免超量占用，已跳过。`);
         continue;
       }
       const reader = new FileReader();
       reader.onload = () => {
-        const content = typeof reader.result === "string" ? reader.result : "";
-        if (content) setter((current) => {
-            if (current.length >= 6 || current.some(f => f.name === file.name)) return current;
+        const content = reader.result;
+        if (typeof content === "string") {
+          setPendingFiles((current) => {
+            if (current.length >= 5) return current;
             return [...current, { name: file.name, content }];
-        });
+          });
+        }
       };
       reader.readAsText(file);
     }
@@ -980,20 +971,28 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
   const handleEditMessage = useCallback((msg: QaMsg) => {
     setEditingMsg(msg);
     setEditText(msg.content);
-    setEditImages(msg.images || []);
-    setEditFiles(msg.files || []);
   }, []);
 
-  const handleSaveEdit = useCallback((andResend: boolean) => {
+  const handleSaveEdit = useCallback(() => {
     if (!editingMsg || !snapshot.activeSessionId) return;
-    if (andResend) {
-        editAndResendQaMessage(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
-    } else {
-        updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
-    }
+    updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editingMsg.images, editingMsg.files);
     setEditingMsg(null);
-    onNotice?.(andResend ? "已提交修改" : "已保存修改");
-  }, [editingMsg, editText, editImages, editFiles, snapshot.activeSessionId, onNotice]);
+    onNotice?.("已保存消息内容");
+  }, [editingMsg, editText, snapshot.activeSessionId, onNotice]);
+
+  // 新增：保存并重新发送
+  const handleEditAndResend = useCallback(() => {
+    if (!editingMsg || !snapshot.activeSessionId) return;
+    void editAndResendQaMessage(
+      snapshot.activeSessionId, 
+      editingMsg.id, 
+      editText, 
+      editingMsg.images, 
+      editingMsg.files
+    );
+    setEditingMsg(null);
+    onNotice?.("已保存并重新发送，中断后续对话");
+  }, [editingMsg, editText, snapshot.activeSessionId, onNotice]);
 
   const streamingMsgId =
     snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
@@ -1114,15 +1113,17 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                   </button>
                 </div>
               ))}
+              {/* 新增：文本附件的缩略图展示 */}
               {pendingFiles.map((file, i) => (
-                <div key={`file-${i}`} className="qa-attach-thumb" style={{ background: "var(--qa-bg-secondary)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px", border: "1px solid var(--qa-border)" }}>
-                  <FileText size={16} style={{ minWidth: "16px", marginRight: "4px", opacity: 0.7 }}/>
-                  <span style={{ fontSize: "11px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{file.name}</span>
+                <div key={`file-${i}`} className="qa-attach-thumb is-file" style={{ display: 'flex', alignItems: 'center', gap: '4px', padding: '0 8px', background: 'var(--surface-3)', borderRadius: '6px', minWidth: 0, height: '48px', flexShrink: 0 }}>
+                  <FileText size={15} style={{ flexShrink: 0, opacity: 0.8 }} />
+                  <span style={{ fontSize: '12px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '80px' }}>{file.name}</span>
                   <button
                     type="button"
                     className="qa-attach-remove"
+                    style={{ position: 'static', transform: 'none', marginLeft: '2px', background: 'rgba(0,0,0,0.1)' }}
                     onClick={() => setPendingFiles((current) => current.filter((_, idx) => idx !== i))}
-                    aria-label="移除附件"
+                    aria-label="移除文件"
                   >
                     <X size={11} strokeWidth={2.4} />
                   </button>
@@ -1130,6 +1131,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
               ))}
             </div>
           )}
+          
           <textarea
             ref={textareaRef}
             className="qa-composer-input hide-scrollbar"
@@ -1142,58 +1144,49 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
             }}
           />
           <div className="qa-composer-toolbar">
-            <input
-                ref={fileInputRef}
-                type="file"
-                multiple
-                accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv,.log,.xml,.yml,.yaml,.ini,.conf"
-                style={{ display: "none" }}
-                onChange={(e) => {
-                    handlePickFiles(e.target.files);
-                    setAttachMenuOpen(false);
-                }}
-            />
             {visionEnabled && (
+              <>
                 <input
                   ref={imageInputRef}
                   type="file"
                   accept="image/*"
                   multiple
                   style={{ display: "none" }}
-                  onChange={(e) => {
-                      handlePickImages(e.target.files);
-                      setAttachMenuOpen(false);
-                  }}
+                  onChange={(e) => handlePickImages(e.target.files)}
                 />
-            )}
-
-            <div style={{ position: "relative" }}>
                 <button
-                    type="button"
-                    className={`qa-circle-btn qa-attach-btn ${attachMenuOpen ? "is-active" : ""}`}
-                    onClick={() => setAttachMenuOpen(!attachMenuOpen)}
-                    aria-label="添加内容"
+                  type="button"
+                  className="qa-circle-btn qa-attach-btn"
+                  onClick={() => imageInputRef.current?.click()}
+                  aria-label="发送图片"
+                  title="添加图片"
                 >
-                    <Plus size={17} strokeWidth={2.2} style={{ transform: attachMenuOpen ? 'rotate(45deg)' : 'none', transition: 'transform 0.2s' }} />
+                  <Plus size={17} strokeWidth={2.2} />
                 </button>
-                
-                {attachMenuOpen && (
-                    <>
-                        <div style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, zIndex: 90 }} onClick={() => setAttachMenuOpen(false)} />
-                        <div className="qa-dropdown-menu">
-                            <button type="button" className="qa-drawer-menu-btn" onClick={() => fileInputRef.current?.click()}>
-                                <FileText size={15} className="qa-drawer-menu-icon" /> 📄 上传附件
-                            </button>
-                            {visionEnabled && (
-                                <button type="button" className="qa-drawer-menu-btn" onClick={() => imageInputRef.current?.click()}>
-                                    <ImageIcon size={15} className="qa-drawer-menu-icon" /> 🖼️ 上传图片
-                                </button>
-                            )}
-                        </div>
-                    </>
-                )}
-            </div>
-
+              </>
+            )}
+            
+            {/* 新增：上传文本附件的按钮（只要环境准备好就能用） */}
+            <>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".txt,.md,.json,.js,.ts,.jsx,.tsx,.csv,.py,.html,.css"
+                multiple
+                style={{ display: "none" }}
+                onChange={(e) => handlePickFiles(e.target.files)}
+              />
+              <button
+                type="button"
+                className="qa-circle-btn qa-attach-btn"
+                onClick={() => fileInputRef.current?.click()}
+                aria-label="发送文本文件"
+                title="添加文本文件"
+              >
+                <FileText size={16} strokeWidth={2} />
+              </button>
+            </>
+            
             {modelName && <span className="qa-model-pill">{modelName}</span>}
 
             {repoWritable && (
@@ -1328,81 +1321,40 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
 
       {editingMsg && (
         <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
-          <div className="qa-edit-dialog" role="dialog" aria-label="修改消息" onClick={(e) => e.stopPropagation()}>
+          <div className="qa-edit-dialog" role="dialog" aria-label="编辑消息" onClick={(e) => e.stopPropagation()}>
             <div className="qa-edit-head">
-              <span className="qa-edit-title">修改消息</span>
+              <span className="qa-edit-title">编辑消息（未渲染原始内容）</span>
               <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
                 <X size={16} />
               </button>
             </div>
-            
-            <div className="qa-edit-body">
-                <textarea
-                  className="qa-edit-textarea"
-                  value={editText}
-                  onChange={(e) => setEditText(e.target.value)}
-                  spellCheck={false}
-                  autoFocus
-                />
-                
-                {(editImages.length > 0 || editFiles.length > 0) && (
-                    <div className="qa-attach-strip" style={{ marginTop: "12px", padding: 0, background: "transparent", border: "none" }}>
-                        {editImages.map((url, i) => (
-                            <div key={`edit-img-${i}`} className="qa-attach-thumb">
-                                <img src={url} alt="" />
-                                <button type="button" className="qa-attach-remove" onClick={() => handleRemoveEditImage(i)}>
-                                    <X size={11} strokeWidth={2.4} />
-                                </button>
-                            </div>
-                        ))}
-                        {editFiles.map((f, i) => (
-                             <div key={`edit-file-${i}`} className="qa-attach-thumb" style={{ background: "var(--qa-bg-secondary)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px", border: "1px solid var(--qa-border)" }}>
-                                <FileText size={16} style={{ minWidth: "16px", marginRight: "4px", opacity: 0.7 }} />
-                                <span style={{ fontSize: "11px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
-                                <button type="button" className="qa-attach-remove" onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}>
-                                    <X size={11} strokeWidth={2.4} />
-                                </button>
-                            </div>
-                        ))}
-                    </div>
-                )}
+            <textarea
+              className="qa-edit-textarea"
+              value={editText}
+              onChange={(e) => setEditText(e.target.value)}
+              spellCheck={false}
+              autoFocus
+              placeholder="这里显示的是消息的原始内容，不会被前端渲染，可放心查看特殊标签。"
+            />
+            <div className="qa-edit-actions">
+              <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
+                取消
+              </button>
+              <button type="button" className="qa-devnotice-btn is-primary" onClick={handleSaveEdit}>
+                仅保存
+              </button>
+              {/* 新增：如果消息是你自己发的，支持截断保存并重发 */}
+              {editingMsg.role === "user" && (
+                <button type="button" className="qa-devnotice-btn is-danger" onClick={handleEditAndResend}>
+                  保存并重发
+                </button>
+              )}
             </div>
-            
-            <div className="qa-edit-actions is-row">
-                <div style={{ position: "relative" }}>
-                    <button type="button" className={`qa-circle-btn qa-attach-btn ${editAttachMenuOpen ? "is-active" : ""}`} onClick={() => setEditAttachMenuOpen(!editAttachMenuOpen)}>
-                         <Plus size={17} strokeWidth={2.2} style={{ transform: editAttachMenuOpen ? 'rotate(45deg)' : 'none', transition: 'transform 0.2s' }} />
-                    </button>
-                    {editAttachMenuOpen && (
-                        <>
-                            <div style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, zIndex: 90 }} onClick={() => setEditAttachMenuOpen(false)} />
-                            <div className="qa-dropdown-menu">
-                                <button type="button" className="qa-drawer-menu-btn" onClick={() => { setEditAttachMenuOpen(false); fileInputRef.current?.click(); }}>
-                                    <FileText size={15} className="qa-drawer-menu-icon" /> 📄 上传附件
-                                </button>
-                                {visionEnabled && (
-                                    <button type="button" className="qa-drawer-menu-btn" onClick={() => {
-                                        setEditAttachMenuOpen(false);
-                                        imageInputRef.current?.setAttribute('data-edit-mode', 'true');
-                                        imageInputRef.current?.click();
-                                    }}>
-                                        <ImageIcon size={15} className="qa-drawer-menu-icon" /> 🖼️ 上传图片
-                                    </button>
-                                )}
-                            </div>
-                        </>
-                    )}
-                </div>
-
-                <div className="qa-edit-buttons">
-                    <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
-                        保存
-                    </button>
-                    <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
-                        保存并发送
-                    </button>
-                </div>
-            </div>
+            {editingMsg.role === "user" && (
+              <div style={{ fontSize: '11px', color: 'var(--text-secondary)', textAlign: 'right', marginTop: '6px' }}>
+                * 重发会截断此消息之后的所有回复并重新触发 AI
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -953,8 +953,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
       // 新增：拦截非文本文件并动态提取后缀名提示
       if (!allowedExts.some(ext => fileName.endsWith(ext))) {
         const ext = fileName.includes('.') ? `.${fileName.split('.').pop()}` : '无后缀';
-        // 使用 \n 进行换行
-        onNotice?.(`不支持阅读 ${ext} 文件\n小坊目前只能读取纯文本或代码文件哦。`);
+        onNotice?.(`不支持阅读 ${ext} 文件，小坊目前只能读取纯文本或代码文件。`);
         continue;
       }
 
@@ -1555,3 +1554,4 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
     </div>
   );
 }
+```eof

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -15,1479 +15,1477 @@ import { BlackMarketApp } from "@/components/shopping/black-market-app";
 import { getInstalledCustomApp } from "@/lib/custom-app-storage";
 import type { QaCreatedContent } from "@/lib/qa-agent-tools";
 import {
-  applyQaCommit,
-  cancelQaCommit,
-  clearQaToolHistory,
-  createQaSession,
-  deleteQaSession,
-  getQaActiveContextChars,
-  getQaChatSnapshot,
-  getQaContextBudgetChars,
-  hasQaToolHistory,
-  hydrateQaChat,
-  QA_CONTEXT_BUDGET_MAX,
-  QA_CONTEXT_BUDGET_MIN,
-  QA_DEFAULT_CONTEXT_BUDGET_CHARS,
-  setQaContextBudgetChars,
-  retryQaMessage,
-  renameQaSession,
-  revertQaAppliedCommit,
-  sendQaMessage,
-  stopQaGeneration,
-  subscribeQaChat,
-  switchQaSession,
-  toggleQaSessionPin,
-  updateQaMessageContent,
-  editAndResendQaMessage,
-  type QaMsg,
-  type QaSession,
-  type QaToolStatus,
+applyQaCommit,
+cancelQaCommit,
+clearQaToolHistory,
+createQaSession,
+deleteQaSession,
+getQaActiveContextChars,
+getQaChatSnapshot,
+getQaContextBudgetChars,
+hasQaToolHistory,
+hydrateQaChat,
+QA_CONTEXT_BUDGET_MAX,
+QA_CONTEXT_BUDGET_MIN,
+QA_DEFAULT_CONTEXT_BUDGET_CHARS,
+setQaContextBudgetChars,
+retryQaMessage,
+renameQaSession,
+revertQaAppliedCommit,
+sendQaMessage,
+stopQaGeneration,
+subscribeQaChat,
+switchQaSession,
+toggleQaSessionPin,
+updateQaMessageContent,
+editAndResendQaMessage,
+type QaMsg,
+type QaSession,
+type QaToolStatus,
 } from "@/lib/qa-chat-store";
 import {
-  getQaPageChars,
-  setQaPageChars,
-  QA_DEFAULT_PAGE_CHARS,
-  QA_PAGE_CHARS_MIN,
-  QA_PAGE_CHARS_MAX,
-  getQaMaxRounds,
-  setQaMaxRounds,
-  QA_DEFAULT_MAX_ROUNDS,
-  QA_MAX_ROUNDS_MIN,
-  QA_MAX_ROUNDS_MAX,
-  getQaMaxOutputTokens,
-  setQaMaxOutputTokens,
-  QA_DEFAULT_MAX_OUTPUT_TOKENS,
-  QA_MAX_OUTPUT_TOKENS_MIN,
-  QA_MAX_OUTPUT_TOKENS_MAX,
+getQaPageChars,
+setQaPageChars,
+QA_DEFAULT_PAGE_CHARS,
+QA_PAGE_CHARS_MIN,
+QA_PAGE_CHARS_MAX,
+getQaMaxRounds,
+setQaMaxRounds,
+QA_DEFAULT_MAX_ROUNDS,
+QA_MAX_ROUNDS_MIN,
+QA_MAX_ROUNDS_MAX,
+getQaMaxOutputTokens,
+setQaMaxOutputTokens,
+QA_DEFAULT_MAX_OUTPUT_TOKENS,
+QA_MAX_OUTPUT_TOKENS_MIN,
+QA_MAX_OUTPUT_TOKENS_MAX,
 } from "@/lib/qa-prefs";
 import { resolveQaApiConfig } from "@/lib/qa-agent-engine";
 import {
-  loadQaGithubConfig,
-  saveQaGithubConfig,
-  clearQaGithubConfig,
-  validateQaGithubConfig,
-  type QaGithubConfig,
-  type QaGithubValidation,
+loadQaGithubConfig,
+saveQaGithubConfig,
+clearQaGithubConfig,
+validateQaGithubConfig,
+type QaGithubConfig,
+type QaGithubValidation,
 } from "@/lib/qa-github";
 import "@/lib/qa-error-log";
 
 type PhoneQaAppProps = {
-  onClose: () => void;
-  onNotice?: (msg: string) => void;
+onClose: () => void;
+onNotice?: (msg: string) => void;
 };
 
 const SUGGESTIONS = [
-  "怎么添加我的 API？",
-  "聊天没有回复怎么排查？",
-  "怎么部署到 Netlify / Vercel？",
-  "数据存在哪里，怎么备份？",
-  "帮我写个小游戏装到本机",
+"怎么添加我的 API？",
+"聊天没有回复怎么排查？",
+"怎么部署到 Netlify / Vercel？",
+"数据存在哪里，怎么备份？",
+"帮我写个小游戏装到本机",
 ];
 
 function formatRelativeTime(ts: number): string {
-  const diff = Date.now() - ts;
-  if (diff < 60_000) return "刚刚";
-  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟前`;
-  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前`;
-  return `${Math.floor(diff / 86_400_000)} 天前`;
+const diff = Date.now() - ts;
+if (diff < 60_000) return "刚刚";
+if (diff < 3_600_000) return ${Math.floor(diff / 60_000)} 分钟前;
+if (diff < 86_400_000) return ${Math.floor(diff / 3_600_000)} 小时前;
+return ${Math.floor(diff / 86_400_000)} 天前;
 }
 
 // ── 代码块（语言标签 + 一键复制）─────────────────────
 
 function QaCodeBlock({ className, children }: { className?: string; children?: React.ReactNode }) {
-  const [copied, setCopied] = useState(false);
-  const language = /language-(\w+)/.exec(className || "")?.[1] ?? "";
-  const code = String(children ?? "").replace(/\n$/, "");
+const [copied, setCopied] = useState(false);
+const language = /language-(\w+)/.exec(className || "")?.[1] ?? "";
+const code = String(children ?? "").replace(/\n$/, "");
 
-  const handleCopy = useCallback(() => {
-    navigator.clipboard
-      ?.writeText(code)
-      .then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      })
-      .catch(() => {});
-  }, [code]);
+const handleCopy = useCallback(() => {
+navigator.clipboard
+?.writeText(code)
+.then(() => {
+setCopied(true);
+setTimeout(() => setCopied(false), 1500);
+})
+.catch(() => {});
+}, [code]);
 
-  return (
-    <div className="qa-codeblock">
-      <div className="qa-codeblock-head">
-        <span className="qa-codeblock-lang">{language || "code"}</span>
-        <button type="button" className="qa-codeblock-copy" onClick={handleCopy} aria-label="复制代码">
-          {copied ? <Check size={13} /> : <Copy size={13} />}
-        </button>
-      </div>
-      <pre>
-        <code>{code}</code>
-      </pre>
-    </div>
-  );
+return (
+
+
+{language || "code"}
+
+{copied ?  : }
+
+
+
+{code}
+
+
+);
 }
 
 const QA_MARKDOWN_COMPONENTS = {
-  pre({ children }: { children?: React.ReactNode }) {
-    return <>{children}</>;
-  },
-  code(props: { className?: string; children?: React.ReactNode }) {
-    const { className, children } = props;
-    const isBlock = /language-/.test(className || "") || String(children ?? "").includes("\n");
-    if (isBlock) return <QaCodeBlock className={className}>{children}</QaCodeBlock>;
-    return <code className="qa-inline-code">{children}</code>;
-  },
-  a({ href, children }: { href?: string; children?: React.ReactNode }) {
-    return (
-      <a href={href} target="_blank" rel="noreferrer noopener">
-        {children}
-      </a>
-    );
-  },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+pre({ children }: { children?: React.ReactNode }) {
+return <>{children}</>;
+},
+code(props: { className?: string; children?: React.ReactNode }) {
+const { className, children } = props;
+const isBlock = /language-/.test(className || "") || String(children ?? "").includes("\n");
+if (isBlock) return {children};
+return {children};
+},
+a({ href, children }: { href?: string; children?: React.ReactNode }) {
+return (
+
+{children}
+
+);
+},
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any;
 
 // ── 提交提案卡片 ─────────────────────────────────────
 
 function QaCommitCard({ msg }: { msg: QaMsg }) {
-  const pending = msg.pendingCommit;
-  const [busy, setBusy] = useState(false);
-  if (!pending) return null;
-  const { proposal, status, result, error } = pending;
-  const files = proposal.files;
+const pending = msg.pendingCommit;
+const [busy, setBusy] = useState(false);
+if (!pending) return null;
+const { proposal, status, result, error } = pending;
+const files = proposal.files;
 
-  const apply = async () => {
-    setBusy(true);
-    await applyQaCommit(msg.id);
-    setBusy(false);
-  };
-  const revert = async () => {
-    setBusy(true);
-    await revertQaAppliedCommit(msg.id);
-    setBusy(false);
-  };
+const apply = async () => {
+setBusy(true);
+await applyQaCommit(msg.id);
+setBusy(false);
+};
+const revert = async () => {
+setBusy(true);
+await revertQaAppliedCommit(msg.id);
+setBusy(false);
+};
 
-  return (
-    <div className={`qa-commit-card status-${status}`}>
-      <div className="qa-commit-head">
-        <span className="qa-commit-title">
-          {status === "applied" ? "已提交" : status === "reverted" ? "已撤销" : status === "canceled" ? "已取消" : "修改提案"}
-        </span>
-        <span className="qa-commit-branch">{proposal.branch || "默认分支"} · {files.length + (proposal.deletes?.length ?? 0)} 个文件</span>
-      </div>
-      <div className="qa-commit-msg">{proposal.message}</div>
-      <ul className="qa-commit-files">
-        {files.map((f) => (
-          <li key={f.path}>{f.path}</li>
-        ))}
-        {(proposal.deletes ?? []).map((path) => (
-          <li key={`del-${path}`} className="qa-commit-file-delete">− {path}（删除）</li>
-        ))}
-      </ul>
-      {error && <div className="qa-commit-error">{error}</div>}
-      {status === "pending" && (
-        <div className="qa-commit-actions">
-          <button type="button" className="qa-commit-btn is-primary" onClick={apply} disabled={busy}>
-            {busy ? <Loader2 size={13} className="qa-spin" /> : "应用"}
-          </button>
-          <button type="button" className="qa-commit-btn" onClick={() => cancelQaCommit(msg.id)} disabled={busy}>
-            取消
-          </button>
-        </div>
-      )}
-      {(status === "applying" || status === "reverting") && (
-        <div className="qa-commit-actions">
-          <span className="qa-commit-progress">
-            <Loader2 size={13} className="qa-spin" /> {status === "applying" ? "提交中…" : "撤销中…"}
-          </span>
-        </div>
-      )}
-      {status === "applied" && result && (
-        <div className="qa-commit-actions">
-          <a className="qa-commit-link" href={result.htmlUrl} target="_blank" rel="noreferrer noopener">
-            查看 commit {result.sha.slice(0, 7)}
-          </a>
-          <button type="button" className="qa-commit-btn is-danger" onClick={revert} disabled={busy}>
-            撤销
-          </button>
-        </div>
-      )}
-    </div>
-  );
+return (
+<div className={qa-commit-card status-${status}}>
+
+
+{status === "applied" ? "已提交" : status === "reverted" ? "已撤销" : status === "canceled" ? "已取消" : "修改提案"}
+
+{proposal.branch || "默认分支"} · {files.length + (proposal.deletes?.length ?? 0)} 个文件
+
+{proposal.message}
+
+{files.map((f) => (
+{f.path}
+))}
+{(proposal.deletes ?? []).map((path) => (
+<li key={del-${path}} className="qa-commit-file-delete">− {path}（删除）
+))}
+
+{error && {error}}
+{status === "pending" && (
+
+
+{busy ?  : "应用"}
+
+<button type="button" className="qa-commit-btn" onClick={() => cancelQaCommit(msg.id)} disabled={busy}>
+取消
+
+
+)}
+{(status === "applying" || status === "reverting") && (
+
+
+ {status === "applying" ? "提交中…" : "撤销中…"}
+
+
+)}
+{status === "applied" && result && (
+
+
+查看 commit {result.sha.slice(0, 7)}
+
+
+撤销
+
+
+)}
+
+);
 }
 
 // ── 消息渲染 ─────────────────────────────────────────
 
 // 工具调用行：折叠的单行摘要，点开展开参数与结果（Claude Code 风格）
 function QaToolRow({ tool }: { tool: QaToolStatus }) {
-  const [open, setOpen] = useState(false);
-  // 「电脑文件 op=send」的结果里带文件卡标记：卡片常显，标记从结果文本中剥离
-  const { text: resultText, file } = parseQaFileMarker(tool.result || "");
-  const hasDetail = Boolean(tool.detail || resultText);
-  const summary = tool.running ? `正在${tool.name}…` : tool.success === false ? `${tool.name}失败` : tool.name;
-  return (
-    <div className={`qa-tool-row ${tool.running ? "is-running" : tool.success === false ? "is-fail" : "is-done"}`}>
-      <button
-        type="button"
-        className="qa-tool-row-head"
-        onClick={() => hasDetail && setOpen((v) => !v)}
-        disabled={!hasDetail}
-      >
-        {tool.running ? <Loader2 size={13} className="qa-spin" /> : <Wrench size={13} />}
-        <span className="qa-tool-row-summary">
-          {summary}
-          {tool.subtitle && <span className="qa-tool-row-sub">{tool.subtitle}</span>}
-        </span>
-        {hasDetail && <ChevronRight size={14} className={`qa-tool-row-chevron ${open ? "is-open" : ""}`} />}
-      </button>
-      {open && hasDetail && (
-        <div className="qa-tool-row-body">
-          {tool.detail && (
-            <>
-              <div className="qa-tool-row-label">参数</div>
-              <pre className="qa-tool-row-pre">{tool.detail}</pre>
-            </>
-          )}
-          {resultText && (
-            <>
-              <div className="qa-tool-row-label">结果</div>
-              <pre className="qa-tool-row-pre">{resultText}</pre>
-            </>
-          )}
-        </div>
-      )}
-      {file && <QaFileCard file={file} />}
-    </div>
-  );
+const [open, setOpen] = useState(false);
+// 「电脑文件 op=send」的结果里带文件卡标记：卡片常显，标记从结果文本中剥离
+const { text: resultText, file } = parseQaFileMarker(tool.result || "");
+const hasDetail = Boolean(tool.detail || resultText);
+const summary = tool.running ? 正在${tool.name}… : tool.success === false ? ${tool.name}失败 : tool.name;
+return (
+<div className={qa-tool-row ${tool.running ? "is-running" : tool.success === false ? "is-fail" : "is-done"}}>
+<button
+type="button"
+className="qa-tool-row-head"
+onClick={() => hasDetail && setOpen((v) => !v)}
+disabled={!hasDetail}
+>
+{tool.running ?  : }
+
+{summary}
+{tool.subtitle && {tool.subtitle}}
+
+{hasDetail && <ChevronRight size={14} className={qa-tool-row-chevron ${open ? "is-open" : ""}} />}
+
+{open && hasDetail && (
+
+{tool.detail && (
+<>
+参数
+{tool.detail}
+</>
+)}
+{resultText && (
+<>
+结果
+{resultText}
+</>
+)}
+
+)}
+{file && }
+
+);
 }
 
 // 已完成文本的 Markdown 渲染：memo 缓存——流式期间每次增量都全文重排 remark 是
 // 低端机 WebView OOM 崩溃的主因（几万字 × 每秒多次解析）。文本不变就不重渲。
 const QaMarkdownBlock = memo(function QaMarkdownBlock({ text }: { text: string }) {
-  return (
-    <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={QA_MARKDOWN_COMPONENTS}>
-      {text}
-    </ReactMarkdown>
-  );
+return (
+<ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={QA_MARKDOWN_COMPONENTS}>
+{text}
+
+);
 });
 
 // 正在生长的活跃段：纯文本渲染（零解析成本），生成结束后换回完整 Markdown
 function QaStreamingText({ text }: { text: string }) {
-  return (
-    <>
-      <div className="qa-stream-text">{text}</div>
-      <span className="qa-cursor" />
-    </>
-  );
+return (
+<>
+{text}
+
+</>
+);
 }
 
 const QaMessageItem = memo(function QaMessageItem({
-  msg,
-  isStreaming,
-  onRetry,
-  onViewImage,
-  onCopy,
-  onEdit,
+msg,
+isStreaming,
+onRetry,
+onViewImage,
+onCopy,
+onEdit,
 }: {
-  msg: QaMsg;
-  isStreaming: boolean;
-  onRetry: (id: string) => void;
-  onViewImage: (url: string) => void;
-  onCopy: (content: string) => void;
-  onEdit: (msg: QaMsg) => void;
+msg: QaMsg;
+isStreaming: boolean;
+onRetry: (id: string) => void;
+onViewImage: (url: string) => void;
+onCopy: (content: string) => void;
+onEdit: (msg: QaMsg) => void;
 }) {
-  const thinkingOnly = isStreaming && !msg.content && (!msg.tools || msg.tools.length === 0);
-  const showActions = !isStreaming && !thinkingOnly;
-  const msgWrap = (node: ReactNode) => (
-    <div className="qa-msg-wrap">
-      {node}
-      {showActions && (
-        <div className="qa-msg-actions" data-role={msg.role}>
-          <button type="button" className="qa-msg-action" aria-label="复制原始内容" title="复制" onClick={() => onCopy(msg.content)}>
-            <Copy size={14} strokeWidth={2} />
-          </button>
-          <button type="button" className="qa-msg-action" aria-label="修改消息" title="修改" onClick={() => onEdit(msg)}>
-            <Pencil size={14} strokeWidth={2} />
-          </button>
-        </div>
-      )}
-    </div>
-  );
-  
-  const segmentBlocks = useMemo(() => {
-    if (!msg.segments?.length) return null;
-    const blocks: Array<{ kind: "text"; text: string } | { kind: "tools"; tools: QaToolStatus[] }> = [];
-    for (const seg of msg.segments) {
-      const last = blocks[blocks.length - 1];
-      if (seg.kind === "tool") {
-        if (last?.kind === "tools") last.tools.push(seg.tool);
-        else blocks.push({ kind: "tools", tools: [seg.tool] });
-      } else if (seg.text.trim()) {
-        if (last?.kind === "text") last.text += seg.text;
-        else blocks.push({ kind: "text", text: seg.text });
-      }
-    }
-    return blocks.length ? blocks : null;
-  }, [msg.segments]);
+const thinkingOnly = isStreaming && !msg.content && (!msg.tools || msg.tools.length === 0);
+const showActions = !isStreaming && !thinkingOnly;
+const msgWrap = (node: ReactNode) => (
 
-  if (msg.role === "user") {
-    return msgWrap(
-      <div className="qa-msg-user-row">
-        <div className="qa-msg-user">
-          {msg.images && msg.images.length > 0 && (
-            <div className="qa-msg-images">
-              {msg.images.map((url, i) => (
-                <button key={i} type="button" className="qa-msg-image" onClick={() => onViewImage(url)} aria-label="查看图片">
-                  <img src={url} alt="" />
-                </button>
-              ))}
-            </div>
-          )}
-          {msg.files && msg.files.length > 0 && (
-            <div className="qa-msg-files" style={{ display: "flex", flexDirection: "column", gap: "4px", marginBottom: "8px" }}>
-              {msg.files.map((f, i) => (
-                <div key={i} style={{ display: "flex", alignItems: "center", gap: "6px", background: "rgba(255,255,255,0.1)", padding: "4px 8px", borderRadius: "6px", fontSize: "12px", border: "1px solid rgba(255,255,255,0.2)" }}>
-                   <FileText size={14} />
-                   <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: "150px" }}>{f.name}</span>
-                </div>
-              ))}
-            </div>
-          )}
-          {msg.content}
-        </div>
-      </div>,
-    );
-  }
+{node}
+{showActions && (
 
-  return msgWrap(
-    <div className="qa-msg-assistant">
-      {segmentBlocks ? (
-        segmentBlocks.map((block, i) =>
-          block.kind === "tools" ? (
-            <div className="qa-tools" key={i}>
-              {block.tools.map((tool, j) => (
-                <QaToolRow key={`${tool.name}-${j}`} tool={tool} />
-              ))}
-            </div>
-          ) : isStreaming && i === segmentBlocks.length - 1 ? (
-            <div className="qa-markdown" key={i}>
-              <QaStreamingText text={block.text} />
-            </div>
-          ) : (
-            <div className="qa-markdown" key={i}>
-              <QaMarkdownBlock text={block.text} />
-            </div>
-          ),
-        )
-      ) : (
-        <>
-          {msg.tools && msg.tools.length > 0 && (
-            <div className="qa-tools">
-              {msg.tools.map((tool, i) => (
-                <QaToolRow key={`${tool.name}-${i}`} tool={tool} />
-              ))}
-            </div>
-          )}
-          {thinkingOnly ? (
-            <div className="qa-thinking">{msg.toolDrafting ? "正在编写工具调用…" : msg.reasoning ? "正在思考…" : "正在生成…"}</div>
-          ) : isStreaming ? (
-            <div className="qa-markdown">
-              <QaStreamingText text={msg.content} />
-            </div>
-          ) : (
-            <div className="qa-markdown">
-              <QaMarkdownBlock text={msg.content} />
-            </div>
-          )}
-        </>
-      )}
-      {isStreaming && msg.toolDrafting && !thinkingOnly && (
-        <div className="qa-thinking qa-tool-drafting">正在编写工具调用…</div>
-      )}
-      {msg.streamNote && <div className="qa-msg-note">{msg.streamNote}</div>}
-      {msg.pendingCommit && <QaCommitCard msg={msg} />}
-      {msg.aborted && <div className="qa-msg-note">已停止生成</div>}
-      {msg.error && (
-        <div className="qa-msg-error">
-          <div className="qa-msg-error-text">{msg.error}</div>
-          <button type="button" className="qa-retry-btn" onClick={() => onRetry(msg.id)}>
-            重试
-          </button>
-        </div>
-      )}
-    </div>,
-  );
+<button type="button" className="qa-msg-action" aria-label="复制原始内容" title="复制" onClick={() => onCopy(msg.content)}>
+
+
+<button type="button" className="qa-msg-action" aria-label="修改消息" title="修改" onClick={() => onEdit(msg)}>
+
+
+
+)}
+
+);
+
+const segmentBlocks = useMemo(() => {
+if (!msg.segments?.length) return null;
+const blocks: Array<{ kind: "text"; text: string } | { kind: "tools"; tools: QaToolStatus[] }> = [];
+for (const seg of msg.segments) {
+const last = blocks[blocks.length - 1];
+if (seg.kind === "tool") {
+if (last?.kind === "tools") last.tools.push(seg.tool);
+else blocks.push({ kind: "tools", tools: [seg.tool] });
+} else if (seg.text.trim()) {
+if (last?.kind === "text") last.text += seg.text;
+else blocks.push({ kind: "text", text: seg.text });
+}
+}
+return blocks.length ? blocks : null;
+}, [msg.segments]);
+
+if (msg.role === "user") {
+return msgWrap(
+
+
+{msg.images && msg.images.length > 0 && (
+
+{msg.images.map((url, i) => (
+<button key={i} type="button" className="qa-msg-image" onClick={() => onViewImage(url)} aria-label="查看图片">
+
+
+))}
+
+)}
+{msg.files && msg.files.length > 0 && (
+<div className="qa-msg-files" style={{ display: "flex", flexDirection: "column", gap: "4px", marginBottom: "8px" }}>
+{msg.files.map((f, i) => (
+<div key={i} style={{ display: "flex", alignItems: "center", gap: "6px", background: "rgba(255,255,255,0.1)", padding: "4px 8px", borderRadius: "12px", fontSize: "12px", border: "1px solid rgba(255,255,255,0.2)" }}>
+
+<span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: "150px" }}>{f.name}
+
+))}
+
+)}
+{msg.content}
+
+,
+);
+}
+
+return msgWrap(
+
+{segmentBlocks ? (
+segmentBlocks.map((block, i) =>
+block.kind === "tools" ? (
+
+{block.tools.map((tool, j) => (
+<QaToolRow key={${tool.name}-${j}} tool={tool} />
+))}
+
+) : isStreaming && i === segmentBlocks.length - 1 ? (
+
+
+
+) : (
+
+
+
+),
+)
+) : (
+<>
+{msg.tools && msg.tools.length > 0 && (
+
+{msg.tools.map((tool, i) => (
+<QaToolRow key={${tool.name}-${i}} tool={tool} />
+))}
+
+)}
+{thinkingOnly ? (
+{msg.toolDrafting ? "正在编写工具调用…" : msg.reasoning ? "正在思考…" : "正在生成…"}
+) : isStreaming ? (
+
+
+
+) : (
+
+
+
+)}
+</>
+)}
+{isStreaming && msg.toolDrafting && !thinkingOnly && (
+正在编写工具调用…
+)}
+{msg.streamNote && {msg.streamNote}}
+{msg.pendingCommit && }
+{msg.aborted && 已停止生成}
+{msg.error && (
+
+{msg.error}
+<button type="button" className="qa-retry-btn" onClick={() => onRetry(msg.id)}>
+重试
+
+
+)}
+,
+);
 });
 
 // ── 会话抽屉 ─────────────────────────────────────────
 
 function QaSessionDrawer({
-  sessions,
-  activeId,
-  onSelect,
-  onDelete,
-  onCreate,
-  onOpenSettings,
-  onRenameRequest,
+sessions,
+activeId,
+onSelect,
+onDelete,
+onCreate,
+onOpenSettings,
+onRenameRequest,
 }: {
-  sessions: QaSession[];
-  activeId: string | null;
-  onSelect: (id: string) => void;
-  onDelete: (id: string) => void;
-  onCreate: () => void;
-  onOpenSettings: () => void;
-  onRenameRequest: (id: string, title: string) => void;
+sessions: QaSession[];
+activeId: string | null;
+onSelect: (id: string) => void;
+onDelete: (id: string) => void;
+onCreate: () => void;
+onOpenSettings: () => void;
+onRenameRequest: (id: string, title: string) => void;
 }) {
-  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 
-  // 置顶的排最前，其余保持时间序。只在渲染层排，存储顺序不动
-  const sortedSessions = useMemo(() => {
-    return [...sessions].sort((a, b) => {
-      if (Boolean(a.isPinned) !== Boolean(b.isPinned)) return a.isPinned ? -1 : 1;
-      return b.updatedAt - a.updatedAt;
-    });
-  }, [sessions]);
+// 置顶的排最前，其余保持时间序。只在渲染层排，存储顺序不动
+const sortedSessions = useMemo(() => {
+return [...sessions].sort((a, b) => {
+if (Boolean(a.isPinned) !== Boolean(b.isPinned)) return a.isPinned ? -1 : 1;
+return b.updatedAt - a.updatedAt;
+});
+}, [sessions]);
 
-  return (
-    <aside className="qa-drawer">
-      <div className="qa-drawer-head">
-        <span className="qa-drawer-title">对话记录</span>
-      </div>
-      <div
-        className="qa-drawer-list hide-scrollbar"
-        onClick={() => { if (menuOpenId) setMenuOpenId(null); }}
-      >
-        {sortedSessions.length === 0 && <div className="qa-drawer-empty">还没有对话</div>}
-        {sortedSessions.map((session) => (
-          <div
-            key={session.id}
-            className={`qa-drawer-item ${session.id === activeId ? "is-active" : ""}`}
-            onClick={() => onSelect(session.id)}
-          >
-            <div className="qa-drawer-item-main">
-              <span className="qa-drawer-item-title">
-                {session.isPinned && <Pin size={12} className="qa-drawer-pin-mark" aria-label="已置顶" />}
-                {session.title}
-              </span>
-              <span className="qa-drawer-item-time">{formatRelativeTime(session.updatedAt)}</span>
-            </div>
+return (
+
+
+对话记录
+
+<div
+className="qa-drawer-list hide-scrollbar"
+onClick={() => { if (menuOpenId) setMenuOpenId(null); }}
+>
+{sortedSessions.length === 0 && 还没有对话}
+{sortedSessions.map((session) => (
+<div
+key={session.id}
+className={qa-drawer-item ${session.id === activeId ? "is-active" : ""}}
+onClick={() => onSelect(session.id)}
+>
+
+
+{session.isPinned && }
+{session.title}
+
+{formatRelativeTime(session.updatedAt)}
+
+<button
+type="button"
+className="qa-icon-btn qa-drawer-item-more"
+aria-label="更多操作"
+aria-expanded={menuOpenId === session.id}
+onClick={(e) => {
+e.stopPropagation();
+setMenuOpenId(menuOpenId === session.id ? null : session.id);
+}}
+>
+
+
+
+        {menuOpenId === session.id && (
+          <div className="qa-drawer-item-menu" role="menu">
             <button
               type="button"
-              className="qa-icon-btn qa-drawer-item-more"
-              aria-label="更多操作"
-              aria-expanded={menuOpenId === session.id}
+              role="menuitem"
+              className="qa-drawer-menu-btn"
               onClick={(e) => {
                 e.stopPropagation();
-                setMenuOpenId(menuOpenId === session.id ? null : session.id);
+                toggleQaSessionPin(session.id);
+                setMenuOpenId(null);
               }}
             >
-              <MoreVertical size={14} />
+              {session.isPinned ? <PinOff size={14} /> : <Pin size={14} />}
+              {session.isPinned ? "取消置顶" : "置顶"}
             </button>
-
-            {menuOpenId === session.id && (
-              <div className="qa-drawer-item-menu" role="menu">
-                <button
-                  type="button"
-                  role="menuitem"
-                  className="qa-drawer-menu-btn"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    toggleQaSessionPin(session.id);
-                    setMenuOpenId(null);
-                  }}
-                >
-                  {session.isPinned ? <PinOff size={14} /> : <Pin size={14} />}
-                  {session.isPinned ? "取消置顶" : "置顶"}
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className="qa-drawer-menu-btn"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onRenameRequest(session.id, session.title);
-                    setMenuOpenId(null);
-                  }}
-                >
-                  <Pencil size={14} /> 重命名
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className="qa-drawer-menu-btn is-danger"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDelete(session.id);
-                    setMenuOpenId(null);
-                  }}
-                >
-                  <Trash2 size={14} /> 删除
-                </button>
-              </div>
-            )}
+            <button
+              type="button"
+              role="menuitem"
+              className="qa-drawer-menu-btn"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRenameRequest(session.id, session.title);
+                setMenuOpenId(null);
+              }}
+            >
+              <Pencil size={14} /> 重命名
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className="qa-drawer-menu-btn is-danger"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(session.id);
+                setMenuOpenId(null);
+              }}
+            >
+              <Trash2 size={14} /> 删除
+            </button>
           </div>
-        ))}
+        )}
       </div>
-      <div className="qa-drawer-foot">
-        <button type="button" className="qa-drawer-new qa-drawer-settings" onClick={onOpenSettings}>
-          <Wrench size={15} strokeWidth={2} />
-          <span>工坊配置</span>
-        </button>
-        <button type="button" className="qa-drawer-new" onClick={onCreate}>
-          <Plus size={16} strokeWidth={2} />
-          <span>新对话</span>
-        </button>
-      </div>
-    </aside>
-  );
+    ))}
+  </div>
+  <div className="qa-drawer-foot">
+    <button type="button" className="qa-drawer-new qa-drawer-settings" onClick={onOpenSettings}>
+      <Wrench size={15} strokeWidth={2} />
+      <span>工坊配置</span>
+    </button>
+    <button type="button" className="qa-drawer-new" onClick={onCreate}>
+      <Plus size={16} strokeWidth={2} />
+      <span>新对话</span>
+    </button>
+  </div>
+</aside>
+
+
+);
 }
 
 // ── 工坊配置面板 ─────────────────────────────────────
 
 function QaSettingsSheet({ onClose, onNotice }: { onClose: () => void; onNotice?: (msg: string) => void }) {
-  const [budget, setBudget] = useState(() => String(getQaContextBudgetChars()));
-  const [pageChars, setPageChars] = useState(() => String(getQaPageChars()));
-  const [maxRounds, setMaxRounds] = useState(() => String(getQaMaxRounds()));
-  const [maxOutTokens, setMaxOutTokens] = useState(() => {
-    const v = getQaMaxOutputTokens();
-    return v == null ? "" : String(v);
-  });
-  const usedChars = getQaActiveContextChars();
-  const pct = Math.round((usedChars / getQaContextBudgetChars()) * 100);
+const [budget, setBudget] = useState(() => String(getQaContextBudgetChars()));
+const [pageChars, setPageChars] = useState(() => String(getQaPageChars()));
+const [maxRounds, setMaxRounds] = useState(() => String(getQaMaxRounds()));
+const [maxOutTokens, setMaxOutTokens] = useState(() => {
+const v = getQaMaxOutputTokens();
+return v == null ? "" : String(v);
+});
+const usedChars = getQaActiveContextChars();
+const pct = Math.round((usedChars / getQaContextBudgetChars()) * 100);
 
-  const save = () => {
-    const parsed = Number(budget);
-    if (!Number.isFinite(parsed) || parsed < QA_CONTEXT_BUDGET_MIN || parsed > QA_CONTEXT_BUDGET_MAX) {
-      onNotice?.(`预算需为 ${QA_CONTEXT_BUDGET_MIN.toLocaleString()} - ${QA_CONTEXT_BUDGET_MAX.toLocaleString()} 之间的数字。`);
-      return;
-    }
-    const parsedPage = Number(pageChars);
-    if (!Number.isFinite(parsedPage) || parsedPage < QA_PAGE_CHARS_MIN || parsedPage > QA_PAGE_CHARS_MAX) {
-      onNotice?.(`单页字符数需为 ${QA_PAGE_CHARS_MIN.toLocaleString()} - ${QA_PAGE_CHARS_MAX.toLocaleString()} 之间的数字。`);
-      return;
-    }
-    const parsedRounds = Number(maxRounds);
-    if (!Number.isFinite(parsedRounds) || parsedRounds < QA_MAX_ROUNDS_MIN || parsedRounds > QA_MAX_ROUNDS_MAX) {
-      onNotice?.(`工具调用上限需为 ${QA_MAX_ROUNDS_MIN} - ${QA_MAX_ROUNDS_MAX} 之间的数字。`);
-      return;
-    }
-    const trimmedTokens = maxOutTokens.trim();
-    const parsedTokens = trimmedTokens ? Number(trimmedTokens) : null;
-    if (parsedTokens != null && (!Number.isFinite(parsedTokens) || parsedTokens < QA_MAX_OUTPUT_TOKENS_MIN || parsedTokens > QA_MAX_OUTPUT_TOKENS_MAX)) {
-      onNotice?.(`单次最大输出 token 需留空或为 ${QA_MAX_OUTPUT_TOKENS_MIN.toLocaleString()} - ${QA_MAX_OUTPUT_TOKENS_MAX.toLocaleString()} 之间的数字。`);
-      return;
-    }
-    setQaContextBudgetChars(parsed);
-    setQaPageChars(parsedPage);
-    setQaMaxRounds(parsedRounds);
-    setQaMaxOutputTokens(trimmedTokens ? parsedTokens : 0);
-    onNotice?.("已保存工坊配置。");
-    onClose();
-  };
+const save = () => {
+const parsed = Number(budget);
+if (!Number.isFinite(parsed) || parsed < QA_CONTEXT_BUDGET_MIN || parsed > QA_CONTEXT_BUDGET_MAX) {
+onNotice?.(预算需为 ${QA_CONTEXT_BUDGET_MIN.toLocaleString()} - ${QA_CONTEXT_BUDGET_MAX.toLocaleString()} 之间的数字。);
+return;
+}
+const parsedPage = Number(pageChars);
+if (!Number.isFinite(parsedPage) || parsedPage < QA_PAGE_CHARS_MIN || parsedPage > QA_PAGE_CHARS_MAX) {
+onNotice?.(单页字符数需为 ${QA_PAGE_CHARS_MIN.toLocaleString()} - ${QA_PAGE_CHARS_MAX.toLocaleString()} 之间的数字。);
+return;
+}
+const parsedRounds = Number(maxRounds);
+if (!Number.isFinite(parsedRounds) || parsedRounds < QA_MAX_ROUNDS_MIN || parsedRounds > QA_MAX_ROUNDS_MAX) {
+onNotice?.(工具调用上限需为 ${QA_MAX_ROUNDS_MIN} - ${QA_MAX_ROUNDS_MAX} 之间的数字。);
+return;
+}
+const trimmedTokens = maxOutTokens.trim();
+const parsedTokens = trimmedTokens ? Number(trimmedTokens) : null;
+if (parsedTokens != null && (!Number.isFinite(parsedTokens) || parsedTokens < QA_MAX_OUTPUT_TOKENS_MIN || parsedTokens > QA_MAX_OUTPUT_TOKENS_MAX)) {
+onNotice?.(单次最大输出 token 需留空或为 ${QA_MAX_OUTPUT_TOKENS_MIN.toLocaleString()} - ${QA_MAX_OUTPUT_TOKENS_MAX.toLocaleString()} 之间的数字。);
+return;
+}
+setQaContextBudgetChars(parsed);
+setQaPageChars(parsedPage);
+setQaMaxRounds(parsedRounds);
+setQaMaxOutputTokens(trimmedTokens ? parsedTokens : 0);
+onNotice?.("已保存工坊配置。");
+onClose();
+};
 
-  const reset = () => {
-    setQaContextBudgetChars(null);
-    setQaPageChars(null);
-    setQaMaxRounds(null);
-    setQaMaxOutputTokens(null);
-    setBudget(String(QA_DEFAULT_CONTEXT_BUDGET_CHARS));
-    setPageChars(String(QA_DEFAULT_PAGE_CHARS));
-    setMaxRounds(String(QA_DEFAULT_MAX_ROUNDS));
-    setMaxOutTokens(String(QA_DEFAULT_MAX_OUTPUT_TOKENS));
-    onNotice?.("已恢复默认配置。");
-  };
+const reset = () => {
+setQaContextBudgetChars(null);
+setQaPageChars(null);
+setQaMaxRounds(null);
+setQaMaxOutputTokens(null);
+setBudget(String(QA_DEFAULT_CONTEXT_BUDGET_CHARS));
+setPageChars(String(QA_DEFAULT_PAGE_CHARS));
+setMaxRounds(String(QA_DEFAULT_MAX_ROUNDS));
+setMaxOutTokens(String(QA_DEFAULT_MAX_OUTPUT_TOKENS));
+onNotice?.("已恢复默认配置。");
+};
 
-  return (
-    <div className="qa-devnotice-backdrop" onClick={onClose}>
-      <div className="qa-devnotice" role="dialog" aria-label="工坊配置" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-devnotice-title">工坊配置</div>
-        <label className="qa-settings-field">
-          <span>上下文预算（字符）</span>
-          <input
-            type="number"
-            inputMode="numeric"
-            min={QA_CONTEXT_BUDGET_MIN}
-            max={QA_CONTEXT_BUDGET_MAX}
-            step={1000}
-            value={budget}
-            onChange={(e) => setBudget(e.target.value)}
-          />
-        </label>
-        <div className="qa-settings-hint">
-          上下文满 100% 时自动压缩成摘要并重新累计。中文约 1 字符 ≈ 1 token；默认 {QA_DEFAULT_CONTEXT_BUDGET_CHARS.toLocaleString()}，小上下文（32k）模型建议 30000–50000。
-        </div>
-        <div className="qa-settings-hint">当前会话已用 {usedChars.toLocaleString()} 字符（约 {pct}%）。</div>
-        <label className="qa-settings-field">
-          <span>单页读取字符数</span>
-          <input
-            type="number"
-            inputMode="numeric"
-            min={QA_PAGE_CHARS_MIN}
-            max={QA_PAGE_CHARS_MAX}
-            step={1000}
-            value={pageChars}
-            onChange={(e) => setPageChars(e.target.value)}
-          />
-        </label>
-        <div className="qa-settings-hint">
-          小坊翻页读答疑文档 / 本机内容 / 仓库源码时，每页返回的字符数。默认 {QA_DEFAULT_PAGE_CHARS.toLocaleString()}；调大读得快但更占上下文，小上下文模型建议调小。
-        </div>
-        <label className="qa-settings-field">
-          <span>单轮工具调用上限（次）</span>
-          <input
-            type="number"
-            inputMode="numeric"
-            min={QA_MAX_ROUNDS_MIN}
-            max={QA_MAX_ROUNDS_MAX}
-            step={1}
-            value={maxRounds}
-            onChange={(e) => setMaxRounds(e.target.value)}
-          />
-        </label>
-        <div className="qa-settings-hint">
-          一次提问里小坊最多连续执行多少轮工具，用完会提示「回复继续」。默认 {QA_DEFAULT_MAX_ROUNDS}；复杂任务（写游戏、改代码）可调大，想控制 token 消耗可调小。
-        </div>
-        <label className="qa-settings-field">
-          <span>单次最大输出 token</span>
-          <input
-            type="number"
-            inputMode="numeric"
-            min={QA_MAX_OUTPUT_TOKENS_MIN}
-            max={QA_MAX_OUTPUT_TOKENS_MAX}
-            step={1000}
-            placeholder="留空 = 不传"
-            value={maxOutTokens}
-            onChange={(e) => setMaxOutTokens(e.target.value)}
-          />
-        </label>
-        <div className="qa-settings-hint">
-          输出长度护栏：每次请求带 max_tokens，小坊会按该预算分段写大文件，写超被安全截断后自动续接，不再整轮报废。默认 {QA_DEFAULT_MAX_OUTPUT_TOKENS.toLocaleString()}；留空 = 不传该参数（部分模型/中转不支持 max_tokens 时请留空）。
-        </div>
-        <div className="qa-devnotice-actions is-row">
-          <button type="button" className="qa-devnotice-btn" onClick={reset}>恢复默认</button>
-          <button type="button" className="qa-devnotice-btn is-primary" onClick={save}>保存</button>
-        </div>
-      </div>
-    </div>
-  );
+return (
+
+<div className="qa-devnotice" role="dialog" aria-label="工坊配置" onClick={(e) => e.stopPropagation()}>
+工坊配置
+
+上下文预算（字符）
+<input
+type="number"
+inputMode="numeric"
+min={QA_CONTEXT_BUDGET_MIN}
+max={QA_CONTEXT_BUDGET_MAX}
+step={1000}
+value={budget}
+onChange={(e) => setBudget(e.target.value)}
+/>
+
+
+上下文满 100% 时自动压缩成摘要并重新累计。中文约 1 字符 ≈ 1 token；默认 {QA_DEFAULT_CONTEXT_BUDGET_CHARS.toLocaleString()}，小上下文（32k）模型建议 30000–50000。
+
+当前会话已用 {usedChars.toLocaleString()} 字符（约 {pct}%）。
+
+单页读取字符数
+<input
+type="number"
+inputMode="numeric"
+min={QA_PAGE_CHARS_MIN}
+max={QA_PAGE_CHARS_MAX}
+step={1000}
+value={pageChars}
+onChange={(e) => setPageChars(e.target.value)}
+/>
+
+
+小坊翻页读答疑文档 / 本机内容 / 仓库源码时，每页返回的字符数。默认 {QA_DEFAULT_PAGE_CHARS.toLocaleString()}；调大读得快但更占上下文，小上下文模型建议调小。
+
+
+单轮工具调用上限（次）
+<input
+type="number"
+inputMode="numeric"
+min={QA_MAX_ROUNDS_MIN}
+max={QA_MAX_ROUNDS_MAX}
+step={1}
+value={maxRounds}
+onChange={(e) => setMaxRounds(e.target.value)}
+/>
+
+
+一次提问里小坊最多连续执行多少轮工具，用完会提示「回复继续」。默认 {QA_DEFAULT_MAX_ROUNDS}；复杂任务（写游戏、改代码）可调大，想控制 token 消耗可调小。
+
+
+单次最大输出 token
+<input
+type="number"
+inputMode="numeric"
+min={QA_MAX_OUTPUT_TOKENS_MIN}
+max={QA_MAX_OUTPUT_TOKENS_MAX}
+step={1000}
+placeholder="留空 = 不传"
+value={maxOutTokens}
+onChange={(e) => setMaxOutTokens(e.target.value)}
+/>
+
+
+输出长度护栏：每次请求带 max_tokens，小坊会按该预算分段写大文件，写超被安全截断后自动续接，不再整轮报废。默认 {QA_DEFAULT_MAX_OUTPUT_TOKENS.toLocaleString()}；留空 = 不传该参数（部分模型/中转不支持 max_tokens 时请留空）。
+
+
+恢复默认
+保存
+
+
+
+);
 }
 
 // ── GitHub 仓库配置面板 ──────────────────────────────
 
 function QaRepoSheet({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
-  const existing = useMemo(() => loadQaGithubConfig(), []);
-  const [owner, setOwner] = useState(existing?.owner ?? "");
-  const [repo, setRepo] = useState(existing?.repo ?? "");
-  const [branch, setBranch] = useState(existing?.branch ?? "");
-  const [token, setToken] = useState(existing?.token ?? "");
-  const [writeMode, setWriteMode] = useState<"confirm" | "auto">(existing?.writeMode ?? "confirm");
-  const [checking, setChecking] = useState(false);
-  const [result, setResult] = useState<QaGithubValidation | null>(null);
+const existing = useMemo(() => loadQaGithubConfig(), []);
+const [owner, setOwner] = useState(existing?.owner ?? "");
+const [repo, setRepo] = useState(existing?.repo ?? "");
+const [branch, setBranch] = useState(existing?.branch ?? "");
+const [token, setToken] = useState(existing?.token ?? "");
+const [writeMode, setWriteMode] = useState<"confirm" | "auto">(existing?.writeMode ?? "confirm");
+const [checking, setChecking] = useState(false);
+const [result, setResult] = useState<QaGithubValidation | null>(null);
 
-  const buildConfig = useCallback((): QaGithubConfig => {
-    const cfg: QaGithubConfig = { owner: owner.trim(), repo: repo.trim(), writeMode };
-    if (branch.trim()) cfg.branch = branch.trim();
-    if (token.trim()) cfg.token = token.trim();
-    if (existing?.apiBase) cfg.apiBase = existing.apiBase;
-    return cfg;
-  }, [owner, repo, branch, token, writeMode, existing]);
+const buildConfig = useCallback((): QaGithubConfig => {
+const cfg: QaGithubConfig = { owner: owner.trim(), repo: repo.trim(), writeMode };
+if (branch.trim()) cfg.branch = branch.trim();
+if (token.trim()) cfg.token = token.trim();
+if (existing?.apiBase) cfg.apiBase = existing.apiBase;
+return cfg;
+}, [owner, repo, branch, token, writeMode, existing]);
 
-  const handleVerify = useCallback(async () => {
-    if (!owner.trim() || !repo.trim()) {
-      setResult({ ok: false, error: "请填写 owner 和 repo。" });
-      return;
-    }
-    setChecking(true);
-    setResult(null);
-    const validation = await validateQaGithubConfig(buildConfig());
-    setResult(validation);
-    setChecking(false);
-  }, [owner, repo, buildConfig]);
+const handleVerify = useCallback(async () => {
+if (!owner.trim() || !repo.trim()) {
+setResult({ ok: false, error: "请填写 owner 和 repo。" });
+return;
+}
+setChecking(true);
+setResult(null);
+const validation = await validateQaGithubConfig(buildConfig());
+setResult(validation);
+setChecking(false);
+}, [owner, repo, buildConfig]);
 
-  const handleSave = useCallback(() => {
-    if (!owner.trim() || !repo.trim()) return;
-    saveQaGithubConfig(buildConfig());
-    onSaved();
-    onClose();
-  }, [owner, repo, buildConfig, onSaved, onClose]);
+const handleSave = useCallback(() => {
+if (!owner.trim() || !repo.trim()) return;
+saveQaGithubConfig(buildConfig());
+onSaved();
+onClose();
+}, [owner, repo, buildConfig, onSaved, onClose]);
 
-  const handleDisconnect = useCallback(() => {
-    clearQaGithubConfig();
-    onSaved();
-    onClose();
-  }, [onSaved, onClose]);
+const handleDisconnect = useCallback(() => {
+clearQaGithubConfig();
+onSaved();
+onClose();
+}, [onSaved, onClose]);
 
-  return (
-    <div className="qa-sheet-backdrop" onClick={onClose}>
-      <div className="qa-sheet" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-sheet-head">
-          <span className="qa-sheet-title">
-            <Github size={16} /> 连接 GitHub 仓库
-          </span>
-          <button type="button" className="qa-icon-btn" onClick={onClose} aria-label="关闭">
-            <X size={16} />
-          </button>
-        </div>
-        <div className="qa-sheet-body hide-scrollbar">
-          <p className="qa-sheet-note">
-            连接后可以让工坊查阅这个仓库的代码来回答问题。配置只保存在你的浏览器本地，不会上传。公开仓库可不填 PAT。
-          </p>
-          <label className="qa-field">
-            <span className="qa-field-label">Owner（用户名 / 组织）</span>
-            <input className="qa-input" value={owner} onChange={(e) => setOwner(e.target.value)} placeholder="例：octocat" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-          </label>
-          <label className="qa-field">
-            <span className="qa-field-label">Repo（仓库名）</span>
-            <input className="qa-input" value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="例：hello-world" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-          </label>
-          <label className="qa-field">
-            <span className="qa-field-label">分支（可选，默认仓库默认分支）</span>
-            <input className="qa-input" value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="main" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-          </label>
-          <label className="qa-field">
-            <span className="qa-field-label">Fine-grained PAT（私有仓库或搜索代码需要）</span>
-            <input className="qa-input" type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="github_pat_…" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-            <span className="qa-field-hint">
-              GitHub → Settings → Menu 按钮 → Developer settings → Personal access tokens → Fine-grained tokens。创建时 Repository access 记得勾选目标仓库；Permissions 里：Contents——只查代码选 Read-only，要让工坊改代码选 Read and write；要用「创建PR」再加 Pull requests 的 Read and write（Metadata 会自动带上，其余权限都不用勾）。
-            </span>
-          </label>
-          <div className="qa-field">
-            <span className="qa-field-label">改代码时的模式</span>
-            <div className="qa-segment">
-              <button type="button" className={`qa-segment-btn ${writeMode === "confirm" ? "is-active" : ""}`} onClick={() => setWriteMode("confirm")}>
-                确认后提交
-              </button>
-              <button type="button" className={`qa-segment-btn ${writeMode === "auto" ? "is-active" : ""}`} onClick={() => setWriteMode("auto")}>
-                全自动
-              </button>
-            </div>
-            <span className="qa-field-hint">
-              {writeMode === "confirm"
-                ? "工坊改代码前会先展示改动，你点「应用」才真正提交。推荐。"
-                : "工坊说完直接提交推送，不再逐次确认。仍可事后一键撤销。仅在信任后开启。"}
-            </span>
-          </div>
-          {result && (
-            <div className={`qa-verify ${result.ok ? "is-ok" : "is-fail"}`}>
-              {result.ok
-                ? `✓ 已连接 ${result.fullName}（${result.private ? "私有" : "公开"}，默认分支 ${result.defaultBranch}）`
-                : `✗ ${result.error}`}
-            </div>
-          )}
-        </div>
-        <div className="qa-sheet-actions">
-          {existing && (
-            <button type="button" className="qa-sheet-btn is-danger" onClick={handleDisconnect}>
-              断开
-            </button>
-          )}
-          <button type="button" className="qa-sheet-btn" onClick={handleVerify} disabled={checking}>
-            {checking ? <Loader2 size={14} className="qa-spin" /> : "验证"}
-          </button>
-          <button type="button" className="qa-sheet-btn is-primary" onClick={handleSave} disabled={!owner.trim() || !repo.trim()}>
-            保存
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+return (
+
+<div className="qa-sheet" onClick={(e) => e.stopPropagation()}>
+
+
+ 连接 GitHub 仓库
+
+
+
+
+
+
+
+连接后可以让工坊查阅这个仓库的代码来回答问题。配置只保存在你的浏览器本地，不会上传。公开仓库可不填 PAT。
+
+
+Owner（用户名 / 组织）
+<input className="qa-input" value={owner} onChange={(e) => setOwner(e.target.value)} placeholder="例：octocat" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+
+
+Repo（仓库名）
+<input className="qa-input" value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="例：hello-world" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+
+
+分支（可选，默认仓库默认分支）
+<input className="qa-input" value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="main" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+
+
+Fine-grained PAT（私有仓库或搜索代码需要）
+<input className="qa-input" type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="github_pat_…" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+
+GitHub → Settings → Menu 按钮 → Developer settings → Personal access tokens → Fine-grained tokens。创建时 Repository access 记得勾选目标仓库；Permissions 里：Contents——只查代码选 Read-only，要让工坊改代码选 Read and write；要用「创建PR」再加 Pull requests 的 Read and write（Metadata 会自动带上，其余权限都不用勾）。
+
+
+
+改代码时的模式
+
+<button type="button" className={qa-segment-btn ${writeMode === "confirm" ? "is-active" : ""}} onClick={() => setWriteMode("confirm")}>
+确认后提交
+
+<button type="button" className={qa-segment-btn ${writeMode === "auto" ? "is-active" : ""}} onClick={() => setWriteMode("auto")}>
+全自动
+
+
+
+{writeMode === "confirm"
+? "工坊改代码前会先展示改动，你点「应用」才真正提交。推荐。"
+: "工坊说完直接提交推送，不再逐次确认。仍可事后一键撤销。仅在信任后开启。"}
+
+
+{result && (
+<div className={qa-verify ${result.ok ? "is-ok" : "is-fail"}}>
+{result.ok
+? ✓ 已连接 ${result.fullName}（${result.private ? "私有" : "公开"}，默认分支 ${result.defaultBranch}）
+: ✗ ${result.error}}
+
+)}
+
+
+{existing && (
+
+断开
+
+)}
+
+{checking ?  : "验证"}
+
+<button type="button" className="qa-sheet-btn is-primary" onClick={handleSave} disabled={!owner.trim() || !repo.trim()}>
+保存
+
+
+
+
+);
 }
 
 // ── App 本体 ─────────────────────────────────────────
 
 export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
-  const snapshot = useSyncExternalStore(subscribeQaChat, getQaChatSnapshot, getQaChatSnapshot);
-  const [input, setInput] = useState("");
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const [repoSheetOpen, setRepoSheetOpen] = useState(false);
-  const [repoConnected, setRepoConnected] = useState(false);
-  const [clearToolsOpen, setClearToolsOpen] = useState(false);
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [attachMenuOpen, setAttachMenuOpen] = useState(false); // 控制上方悬浮菜单状态
-  
-  /** 会话重命名弹窗：抽屉菜单里点「重命名」打开 */
-  const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
-  const [renameTitle, setRenameTitle] = useState("");
-  const [pendingImages, setPendingImages] = useState<string[]>([]);
-  const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
-  
-  const [viewerImage, setViewerImage] = useState<string | null>(null);
-  const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
-  const [editText, setEditText] = useState("");
-  const [editImages, setEditImages] = useState<string[]>([]);
-  const [editFiles, setEditFiles] = useState<{name: string, content: string}[]>([]);
-  
-  const [visionEnabled, setVisionEnabled] = useState(false);
-  const imageInputRef = useRef<HTMLInputElement | null>(null);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
-  
-  const [apiReady, setApiReady] = useState(true);
-  const [modelName, setModelName] = useState("");
-  const [repoWritable, setRepoWritable] = useState(false);
-  const [writeMode, setWriteMode] = useState<"confirm" | "auto">("confirm");
-  const bodyRef = useRef<HTMLDivElement | null>(null);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const stickToBottomRef = useRef(true);
+const snapshot = useSyncExternalStore(subscribeQaChat, getQaChatSnapshot, getQaChatSnapshot);
+const [input, setInput] = useState("");
+const [drawerOpen, setDrawerOpen] = useState(false);
+const [repoSheetOpen, setRepoSheetOpen] = useState(false);
+const [repoConnected, setRepoConnected] = useState(false);
+const [clearToolsOpen, setClearToolsOpen] = useState(false);
+const [settingsOpen, setSettingsOpen] = useState(false);
+const [attachMenuOpen, setAttachMenuOpen] = useState(false); // 控制上方悬浮菜单状态
 
-  const refreshComposerMeta = useCallback(() => {
-    setApiReady(resolveQaApiConfig() != null);
-    setModelName(resolveQaApiConfig()?.defaultModel ?? "");
-    setVisionEnabled(resolveQaApiConfig()?.enableImageRecognition === true);
-    const gh = loadQaGithubConfig();
-    setRepoConnected(gh != null);
-    setRepoWritable(Boolean(gh?.token));
-    setWriteMode(gh?.writeMode ?? "confirm");
-  }, []);
+/ 会话重命名弹窗：抽屉菜单里点「重命名」打开 */
+const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
+const [renameTitle, setRenameTitle] = useState("");
+const [pendingImages, setPendingImages] = useState<string[]>([]);
+const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
 
-  useEffect(() => {
-    void hydrateQaChat();
-    refreshComposerMeta();
-  }, [refreshComposerMeta]);
+const [viewerImage, setViewerImage] = useState<string | null>(null);
+const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
+const [editText, setEditText] = useState("");
+const [editImages, setEditImages] = useState<string[]>([]);
+const [editFiles, setEditFiles] = useState<{name: string, content: string}[]>([]);
 
-  // 清理原生 tool 调用历史（防报错）：与小卷同款——移除上下文里的工具记录与原生元数据
-  const handleClearToolHistory = useCallback(() => {
-    if (snapshot.isGenerating) {
-      onNotice?.("小坊正在执行，完成后再清理。");
-      return;
-    }
-    if (!hasQaToolHistory()) {
-      onNotice?.("没有可清理的工具调用历史。");
-      return;
-    }
-    setClearToolsOpen(true);
-  }, [snapshot.isGenerating, onNotice]);
+const [visionEnabled, setVisionEnabled] = useState(false);
+const imageInputRef = useRef<HTMLInputElement | null>(null);
+const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-  const confirmClearToolHistory = useCallback(() => {
-    setClearToolsOpen(false);
-    const result = clearQaToolHistory();
-    onNotice?.(result && result.removed + result.cleaned > 0
-      ? `已清理 ${result.removed} 条工具记录，整理 ${result.cleaned} 条消息。`
-      : "没有可清理的工具调用历史。");
-  }, [onNotice]);
+const [apiReady, setApiReady] = useState(true);
+const [modelName, setModelName] = useState("");
+const [repoWritable, setRepoWritable] = useState(false);
+const [writeMode, setWriteMode] = useState<"confirm" | "auto">("confirm");
+const bodyRef = useRef<HTMLDivElement | null>(null);
+const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+const stickToBottomRef = useRef(true);
 
-  const toggleWriteMode = useCallback(() => {
-    const gh = loadQaGithubConfig();
-    if (!gh) return;
-    const next = gh.writeMode === "auto" ? "confirm" : "auto";
-    saveQaGithubConfig({ ...gh, writeMode: next });
-    setWriteMode(next);
-  }, []);
+const refreshComposerMeta = useCallback(() => {
+setApiReady(resolveQaApiConfig() != null);
+setModelName(resolveQaApiConfig()?.defaultModel ?? "");
+setVisionEnabled(resolveQaApiConfig()?.enableImageRecognition === true);
+const gh = loadQaGithubConfig();
+setRepoConnected(gh != null);
+setRepoWritable(Boolean(gh?.token));
+setWriteMode(gh?.writeMode ?? "confirm");
+}, []);
 
-  const activeSession = useMemo(
-    () => snapshot.sessions.find((s) => s.id === snapshot.activeSessionId) ?? null,
-    [snapshot.sessions, snapshot.activeSessionId],
-  );
-  const messages = useMemo(() => activeSession?.messages ?? [], [activeSession]);
-  const createdContent = useMemo(() => activeSession?.createdContent ?? [], [activeSession]);
-  const [previewOpen, setPreviewOpen] = useState(false);
-  const [previewItem, setPreviewItem] = useState<QaCreatedContent | null>(null);
-  const previewApp = useMemo(
-    () => (previewItem?.type === "app" ? getInstalledCustomApp(previewItem.refId) : null),
-    [previewItem],
-  );
+useEffect(() => {
+void hydrateQaChat();
+refreshComposerMeta();
+}, [refreshComposerMeta]);
 
-  // 自动滚动：用户上滚阅读时不拉回底部
-  const handleScroll = useCallback(() => {
-    const el = bodyRef.current;
-    if (!el) return;
-    stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
-  }, []);
+// 清理原生 tool 调用历史（防报错）：与小卷同款——移除上下文里的工具记录与原生元数据
+const handleClearToolHistory = useCallback(() => {
+if (snapshot.isGenerating) {
+onNotice?.("小坊正在执行，完成后再清理。");
+return;
+}
+if (!hasQaToolHistory()) {
+onNotice?.("没有可清理的工具调用历史。");
+return;
+}
+setClearToolsOpen(true);
+}, [snapshot.isGenerating, onNotice]);
 
-  useEffect(() => {
-    const el = bodyRef.current;
-    if (el && stickToBottomRef.current) {
-      el.scrollTop = el.scrollHeight;
-    }
-  }, [messages]);
+const confirmClearToolHistory = useCallback(() => {
+setClearToolsOpen(false);
+const result = clearQaToolHistory();
+onNotice?.(result && result.removed + result.cleaned > 0
+? 已清理 ${result.removed} 条工具记录，整理 ${result.cleaned} 条消息。
+: "没有可清理的工具调用历史。");
+}, [onNotice]);
 
-  const autoGrow = useCallback(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
-  }, []);
+const toggleWriteMode = useCallback(() => {
+const gh = loadQaGithubConfig();
+if (!gh) return;
+const next = gh.writeMode === "auto" ? "confirm" : "auto";
+saveQaGithubConfig({ ...gh, writeMode: next });
+setWriteMode(next);
+}, []);
 
-  const handleSend = useCallback(() => {
-    const text = input.trim();
-    if ((!text && pendingImages.length === 0 && pendingFiles.length === 0) || snapshot.isGenerating) return;
-    setInput("");
-    setAttachMenuOpen(false); // 发送时关闭菜单
-    const images = pendingImages;
-    const files = pendingFiles;
-    setPendingImages([]);
-    setPendingFiles([]);
-    stickToBottomRef.current = true;
-    requestAnimationFrame(autoGrow);
-    void sendQaMessage(text, images.length ? images : undefined, files.length ? files : undefined);
-  }, [input, pendingImages, pendingFiles, snapshot.isGenerating, autoGrow]);
+const activeSession = useMemo(
+() => snapshot.sessions.find((s) => s.id === snapshot.activeSessionId) ?? null,
+[snapshot.sessions, snapshot.activeSessionId],
+);
+const messages = useMemo(() => activeSession?.messages ?? [], [activeSession]);
+const createdContent = useMemo(() => activeSession?.createdContent ?? [], [activeSession]);
+const [previewOpen, setPreviewOpen] = useState(false);
+const [previewItem, setPreviewItem] = useState<QaCreatedContent | null>(null);
+const previewApp = useMemo(
+() => (previewItem?.type === "app" ? getInstalledCustomApp(previewItem.refId) : null),
+[previewItem],
+);
 
-  // 附加图片：仅识图已开启的 API 显示入口；读为 dataURL，单张限 4MB
-  const handlePickImages = useCallback((files: FileList | null, isEditMode = false) => {
-    if (!files?.length) return;
-    const setter = isEditMode ? setEditImages : setPendingImages;
-    for (const file of Array.from(files).slice(0, 6)) {
-      if (file.size > 4 * 1024 * 1024) {
-        onNotice?.(`「${file.name}」超过 4MB，已跳过。`);
-        continue;
-      }
-      const reader = new FileReader();
-      reader.onload = () => {
-        const url = typeof reader.result === "string" ? reader.result : "";
-        if (url) setter((current) => (current.length >= 6 ? current : [...current, url]));
-      };
-      reader.readAsDataURL(file);
-    }
-    if (imageInputRef.current) imageInputRef.current.value = "";
-  }, [onNotice]);
+// 自动滚动：用户上滚阅读时不拉回底部
+const handleScroll = useCallback(() => {
+const el = bodyRef.current;
+if (!el) return;
+stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+}, []);
 
-  // 附加文本文件
-  const handlePickFiles = useCallback((files: FileList | null, isEditMode = false) => {
-    if (!files?.length) return;
-    const setter = isEditMode ? setEditFiles : setPendingFiles;
-    for (const file of Array.from(files).slice(0, 6)) {
-      if (file.size > 1024 * 1024) { // 纯文本文件限 1MB
-        onNotice?.(`「${file.name}」太大（超过 1MB），请直接粘贴内容。`);
-        continue;
-      }
-      const reader = new FileReader();
-      reader.onload = () => {
-        const content = typeof reader.result === "string" ? reader.result : "";
-        if (content) setter((current) => {
-            if (current.length >= 6 || current.some(f => f.name === file.name)) return current;
-            return [...current, { name: file.name, content }];
-        });
-      };
-      reader.readAsText(file);
-    }
-    if (fileInputRef.current) fileInputRef.current.value = "";
-  }, [onNotice]);
+useEffect(() => {
+const el = bodyRef.current;
+if (el && stickToBottomRef.current) {
+el.scrollTop = el.scrollHeight;
+}
+}, [messages]);
 
-  const handleRetry = useCallback((assistantMsgId: string) => {
-    stickToBottomRef.current = true;
-    void retryQaMessage(assistantMsgId);
-  }, []);
+const autoGrow = useCallback(() => {
+const el = textareaRef.current;
+if (!el) return;
+el.style.height = "auto";
+el.style.height = ${Math.min(el.scrollHeight, 120)}px;
+}, []);
 
-  const handleCopyMessage = useCallback((content: string) => {
-    void navigator.clipboard?.writeText(content).then(
-      () => onNotice?.("已复制原始内容"),
-      () => onNotice?.("复制失败"),
-    );
-  }, [onNotice]);
+const handleSend = useCallback(() => {
+const text = input.trim();
+if ((!text && pendingImages.length === 0 && pendingFiles.length === 0) || snapshot.isGenerating) return;
+setInput("");
+setAttachMenuOpen(false); // 发送时关闭菜单
+const images = pendingImages;
+const files = pendingFiles;
+setPendingImages([]);
+setPendingFiles([]);
+stickToBottomRef.current = true;
+requestAnimationFrame(autoGrow);
+void sendQaMessage(text, images.length ? images : undefined, files.length ? files : undefined);
+}, [input, pendingImages, pendingFiles, snapshot.isGenerating, autoGrow]);
 
-  const handleEditMessage = useCallback((msg: QaMsg) => {
-    setEditingMsg(msg);
-    setEditText(msg.content);
-    setEditImages(msg.images || []);
-    setEditFiles(msg.files || []);
-  }, []);
+// 附加图片：仅识图已开启的 API 显示入口；读为 dataURL，单张限 4MB
+const handlePickImages = useCallback((files: FileList | null, isEditMode = false) => {
+if (!files?.length) return;
+const setter = isEditMode ? setEditImages : setPendingImages;
+for (const file of Array.from(files).slice(0, 6)) {
+if (file.size > 4 * 1024 * 1024) {
+onNotice?.(「${file.name}」超过 4MB，已跳过。);
+continue;
+}
+const reader = new FileReader();
+reader.onload = () => {
+const url = typeof reader.result === "string" ? reader.result : "";
+if (url) setter((current) => (current.length >= 6 ? current : [...current, url]));
+};
+reader.readAsDataURL(file);
+}
+if (imageInputRef.current) imageInputRef.current.value = "";
+}, [onNotice]);
 
-  const handleSaveEdit = useCallback((andResend: boolean) => {
-    if (!editingMsg || !snapshot.activeSessionId) return;
-    if (andResend) {
-        editAndResendQaMessage(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
-    } else {
-        updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
-    }
-    setEditingMsg(null);
-    onNotice?.(andResend ? "已提交修改" : "已保存消息内容");
-  }, [editingMsg, editText, editImages, editFiles, snapshot.activeSessionId, onNotice]);
+// 附加文本文件
+const handlePickFiles = useCallback((files: FileList | null, isEditMode = false) => {
+if (!files?.length) return;
+const setter = isEditMode ? setEditFiles : setPendingFiles;
+for (const file of Array.from(files).slice(0, 6)) {
+if (file.size > 1024 * 1024) { // 纯文本文件限 1MB
+onNotice?.(「${file.name}」太大（超过 1MB），请直接粘贴内容。);
+continue;
+}
+const reader = new FileReader();
+reader.onload = () => {
+const content = typeof reader.result === "string" ? reader.result : "";
+if (content) setter((current) => {
+if (current.length >= 6 || current.some(f => f.name === file.name)) return current;
+return [...current, { name: file.name, content }];
+});
+};
+reader.readAsText(file);
+}
+if (fileInputRef.current) fileInputRef.current.value = "";
+}, [onNotice]);
 
-  const streamingMsgId =
-    snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
-      ? messages[messages.length - 1].id
-      : null;
+const handleRetry = useCallback((assistantMsgId: string) => {
+stickToBottomRef.current = true;
+void retryQaMessage(assistantMsgId);
+}, []);
 
-  return (
-    <div className="qa-app-shell">
-      <QaSessionDrawer
-        sessions={snapshot.sessions}
-        activeId={snapshot.activeSessionId}
-        onSelect={(id) => {
-          switchQaSession(id);
-          setDrawerOpen(false);
-        }}
-        onDelete={deleteQaSession}
-        onCreate={() => {
-          createQaSession();
-          setDrawerOpen(false);
-        }}
-        onOpenSettings={() => {
-          setSettingsOpen(true);
-          setDrawerOpen(false);
-        }}
-        onRenameRequest={(id, title) => {
-          setRenameTarget({ id, title });
-          setRenameTitle(title);
-        }}
-      />
-      <div className={`qa-stage ${drawerOpen ? "is-pushed" : ""}`}>
-      <div className="qa-ambient" aria-hidden />
-      <header className="qa-header">
-        <div className="qa-header-left">
-          <button type="button" className="qa-icon-btn" onClick={onClose} aria-label="返回">
-            <ChevronLeft size={22} strokeWidth={1.75} />
-          </button>
+const handleCopyMessage = useCallback((content: string) => {
+void navigator.clipboard?.writeText(content).then(
+() => onNotice?.("已复制原始内容"),
+() => onNotice?.("复制失败"),
+);
+}, [onNotice]);
+
+const handleEditMessage = useCallback((msg: QaMsg) => {
+setEditingMsg(msg);
+setEditText(msg.content);
+setEditImages(msg.images || []);
+setEditFiles(msg.files || []);
+}, []);
+
+const handleSaveEdit = useCallback((andResend: boolean) => {
+if (!editingMsg || !snapshot.activeSessionId) return;
+if (andResend) {
+editAndResendQaMessage(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
+} else {
+updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
+}
+setEditingMsg(null);
+onNotice?.(andResend ? "已提交修改" : "已保存消息内容");
+}, [editingMsg, editText, editImages, editFiles, snapshot.activeSessionId, onNotice]);
+
+const streamingMsgId =
+snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
+? messages[messages.length - 1].id
+: null;
+
+return (
+
+<QaSessionDrawer
+sessions={snapshot.sessions}
+activeId={snapshot.activeSessionId}
+onSelect={(id) => {
+switchQaSession(id);
+setDrawerOpen(false);
+}}
+onDelete={deleteQaSession}
+onCreate={() => {
+createQaSession();
+setDrawerOpen(false);
+}}
+onOpenSettings={() => {
+setSettingsOpen(true);
+setDrawerOpen(false);
+}}
+onRenameRequest={(id, title) => {
+setRenameTarget({ id, title });
+setRenameTitle(title);
+}}
+/>
+<div className={qa-stage ${drawerOpen ? "is-pushed" : ""}}>
+
+
+
+
+
+
+
+
+工坊
+{repoConnected && 已连接仓库}
+
+
+
+
+
+<button type="button" className="qa-icon-btn" onClick={() => setDrawerOpen((v) => !v)} aria-label="对话记录">
+
+
+
+
+
+  <div className="qa-body hide-scrollbar" ref={bodyRef} onScroll={handleScroll} onClick={() => { if (attachMenuOpen) setAttachMenuOpen(false); }}>
+    {messages.length === 0 ? (
+      <div className="qa-welcome">
+        <div className="qa-welcome-badge" aria-hidden>
+          <svg viewBox="0 0 24 24" width="26" height="26">
+            <path d={mdiHammerWrench} fill="currentColor" />
+          </svg>
         </div>
-        <div className="qa-header-center">
-          <span className="qa-header-title">工坊</span>
-          {repoConnected && <span className="qa-header-sub">已连接仓库</span>}
+        <div className="qa-welcome-title">有什么问题？</div>
+        <div className="qa-welcome-sub">
+          我是小坊，工坊的驻场工程师。使用问题、报错排查、部署配置，都可以问我。
+          <br />
+          我还能动手：写小游戏 / APP / 剧场直接装进本机试玩；连接仓库后我会查源码答疑，填了有写权限的 PAT 还能帮你改代码。
+          <br />
+          想创作角色、世界书或美化桌面，找桌面上的小卷更合适。
         </div>
-        <div className="qa-header-right">
+        {!apiReady && (
+          <div className="qa-welcome-warn">还没有可用的 API：请先到「设置 → API 设置」添加 LLM API。</div>
+        )}
+        <div className="qa-suggestions">
+          {SUGGESTIONS.map((text) => (
+            <button
+              key={text}
+              type="button"
+              className="qa-suggestion"
+              onClick={() => {
+                stickToBottomRef.current = true;
+                void sendQaMessage(text);
+              }}
+            >
+              {text}
+            </button>
+          ))}
+        </div>
+      </div>
+    ) : (
+      <div className="qa-messages">
+        {messages.map((msg) => (
+          <QaMessageItem key={msg.id} msg={msg} isStreaming={msg.id === streamingMsgId} onRetry={handleRetry} onViewImage={setViewerImage} onCopy={handleCopyMessage} onEdit={handleEditMessage} />
+        ))}
+      </div>
+    )}
+  </div>
+
+  <footer className="qa-composer-wrap">
+    <div className={`qa-composer ${snapshot.isGenerating ? "is-generating" : ""}`}>
+      {(pendingImages.length > 0 || pendingFiles.length > 0) && (
+        <div className="qa-attach-strip">
+          {pendingImages.map((url, i) => (
+            <div key={`img-${i}`} className="qa-attach-thumb">
+              <button type="button" className="qa-attach-view" onClick={() => setViewerImage(url)} aria-label="查看图片">
+                <img src={url} alt="" />
+              </button>
+              <button
+                type="button"
+                className="qa-attach-remove"
+                onClick={() => setPendingImages((current) => current.filter((_, idx) => idx !== i))}
+                aria-label="移除图片"
+              >
+                <X size={11} strokeWidth={2.4} />
+              </button>
+            </div>
+          ))}
+          {pendingFiles.map((file, i) => (
+            <div key={`file-${i}`} className="qa-attach-thumb" style={{ background: "rgba(128,128,128,0.2)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px", borderRadius: "12px" }}>
+              <FileText size={16} style={{ minWidth: "16px", marginRight: "4px" }}/>
+              <span style={{ fontSize: "11px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{file.name}</span>
+              <button
+                type="button"
+                className="qa-attach-remove"
+                onClick={() => setPendingFiles((current) => current.filter((_, idx) => idx !== i))}
+                aria-label="移除附件"
+              >
+                <X size={11} strokeWidth={2.4} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      
+      {/* 在输入框上方的悬浮选择菜单 */}
+      {attachMenuOpen && (
+        <div className="qa-attach-menu" style={{ display: "flex", gap: "8px", padding: "8px 12px 4px 2px", animation: "fadeIn 0.2s" }}>
           <button
             type="button"
-            className="qa-icon-btn"
-            onClick={handleClearToolHistory}
-            aria-label="清理原生tool调用历史（防报错）"
-            title="清理原生tool调用历史——防报错"
+            onClick={() => { fileInputRef.current?.click(); setAttachMenuOpen(false); }}
+            style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
           >
-            <BrushCleaning size={17} strokeWidth={1.75} />
+            <Paperclip size={15} strokeWidth={2} /> 上传附件
           </button>
-          <button type="button" className="qa-icon-btn" onClick={() => setDrawerOpen((v) => !v)} aria-label="对话记录">
-            <Menu size={18} strokeWidth={1.75} />
-          </button>
-        </div>
-      </header>
-
-      <div className="qa-body hide-scrollbar" ref={bodyRef} onScroll={handleScroll} onClick={() => { if (attachMenuOpen) setAttachMenuOpen(false); }}>
-        {messages.length === 0 ? (
-          <div className="qa-welcome">
-            <div className="qa-welcome-badge" aria-hidden>
-              <svg viewBox="0 0 24 24" width="26" height="26">
-                <path d={mdiHammerWrench} fill="currentColor" />
-              </svg>
-            </div>
-            <div className="qa-welcome-title">有什么问题？</div>
-            <div className="qa-welcome-sub">
-              我是小坊，工坊的驻场工程师。使用问题、报错排查、部署配置，都可以问我。
-              <br />
-              我还能动手：写小游戏 / APP / 剧场直接装进本机试玩；连接仓库后我会查源码答疑，填了有写权限的 PAT 还能帮你改代码。
-              <br />
-              想创作角色、世界书或美化桌面，找桌面上的小卷更合适。
-            </div>
-            {!apiReady && (
-              <div className="qa-welcome-warn">还没有可用的 API：请先到「设置 → API 设置」添加 LLM API。</div>
-            )}
-            <div className="qa-suggestions">
-              {SUGGESTIONS.map((text) => (
-                <button
-                  key={text}
-                  type="button"
-                  className="qa-suggestion"
-                  onClick={() => {
-                    stickToBottomRef.current = true;
-                    void sendQaMessage(text);
-                  }}
-                >
-                  {text}
-                </button>
-              ))}
-            </div>
-          </div>
-        ) : (
-          <div className="qa-messages">
-            {messages.map((msg) => (
-              <QaMessageItem key={msg.id} msg={msg} isStreaming={msg.id === streamingMsgId} onRetry={handleRetry} onViewImage={setViewerImage} onCopy={handleCopyMessage} onEdit={handleEditMessage} />
-            ))}
-          </div>
-        )}
-      </div>
-
-      <footer className="qa-composer-wrap">
-        <div className={`qa-composer ${snapshot.isGenerating ? "is-generating" : ""}`}>
-          {(pendingImages.length > 0 || pendingFiles.length > 0) && (
-            <div className="qa-attach-strip">
-              {pendingImages.map((url, i) => (
-                <div key={`img-${i}`} className="qa-attach-thumb">
-                  <button type="button" className="qa-attach-view" onClick={() => setViewerImage(url)} aria-label="查看图片">
-                    <img src={url} alt="" />
-                  </button>
-                  <button
-                    type="button"
-                    className="qa-attach-remove"
-                    onClick={() => setPendingImages((current) => current.filter((_, idx) => idx !== i))}
-                    aria-label="移除图片"
-                  >
-                    <X size={11} strokeWidth={2.4} />
-                  </button>
-                </div>
-              ))}
-              {pendingFiles.map((file, i) => (
-                <div key={`file-${i}`} className="qa-attach-thumb" style={{ background: "rgba(128,128,128,0.2)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px" }}>
-                  <FileText size={16} style={{ minWidth: "16px", marginRight: "4px" }}/>
-                  <span style={{ fontSize: "11px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{file.name}</span>
-                  <button
-                    type="button"
-                    className="qa-attach-remove"
-                    onClick={() => setPendingFiles((current) => current.filter((_, idx) => idx !== i))}
-                    aria-label="移除附件"
-                  >
-                    <X size={11} strokeWidth={2.4} />
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-          
-          {/* 在输入框上方的悬浮选择菜单 */}
-          {attachMenuOpen && (
-            <div className="qa-attach-menu" style={{ display: "flex", gap: "8px", padding: "8px 12px 4px 12px", animation: "fadeIn 0.2s" }}>
-              <button
-                type="button"
-                onClick={() => { fileInputRef.current?.click(); setAttachMenuOpen(false); }}
-                style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
-              >
-                <Paperclip size={15} strokeWidth={2} /> 上传附件
-              </button>
-              {visionEnabled && (
-                <button
-                  type="button"
-                  onClick={() => { imageInputRef.current?.click(); setAttachMenuOpen(false); }}
-                  style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
-                >
-                  <Image size={15} strokeWidth={2} /> 添加图片
-                </button>
-              )}
-            </div>
-          )}
-
-          <textarea
-            ref={textareaRef}
-            className="qa-composer-input hide-scrollbar"
-            placeholder="输入你的问题…"
-            rows={1}
-            value={input}
-            onChange={(e) => {
-              setInput(e.target.value);
-              if (attachMenuOpen) setAttachMenuOpen(false);
-              autoGrow();
-            }}
-            onClick={() => {
-              if (attachMenuOpen) setAttachMenuOpen(false);
-            }}
-          />
-          <div className="qa-composer-toolbar">
-            <input
-                ref={fileInputRef}
-                type="file"
-                multiple
-                accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
-                style={{ display: "none" }}
-                onChange={(e) => handlePickFiles(e.target.files)}
-            />
-            {visionEnabled && (
-                <input
-                  ref={imageInputRef}
-                  type="file"
-                  accept="image/*"
-                  multiple
-                  style={{ display: "none" }}
-                  onChange={(e) => handlePickImages(e.target.files)}
-                />
-            )}
-            
-            {/* 统一的附件加号菜单按钮 */}
-            <button
-                type="button"
-                className={`qa-circle-btn qa-attach-btn ${attachMenuOpen ? 'is-active' : ''}`}
-                onClick={() => setAttachMenuOpen((prev) => !prev)}
-                aria-label="添加附件或图片"
-            >
-                <Plus size={17} strokeWidth={2.2} style={{ transform: attachMenuOpen ? 'rotate(45deg)' : 'none', transition: 'transform 0.2s ease-in-out' }} />
-            </button>
-
-            {modelName && <span className="qa-model-pill">{modelName}</span>}
-
-            {repoWritable && (
-              <button type="button" className="qa-mode-pill" onClick={toggleWriteMode}>
-                {writeMode === "auto" ? "全自动" : "确认后提交"}
-              </button>
-            )}
-
-            <div className="qa-composer-spacer" />
-
-            {createdContent.length > 0 && (
-              <button
-                type="button"
-                className="qa-circle-btn qa-preview-btn"
-                onClick={() => setPreviewOpen(true)}
-                aria-label="预览本轮创建的内容"
-              >
-                <Play size={16} />
-              </button>
-            )}
-
+          {visionEnabled && (
             <button
               type="button"
-              className={`qa-circle-btn qa-github-btn ${repoConnected ? "is-active" : ""}`}
-              onClick={() => setRepoSheetOpen(true)}
-              aria-label="连接仓库"
+              onClick={() => { imageInputRef.current?.click(); setAttachMenuOpen(false); }}
+              style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
             >
-              <Github size={16} strokeWidth={1.75} />
+              <Image size={15} strokeWidth={2} /> 添加图片
             </button>
-
-            {snapshot.isGenerating ? (
-              <button type="button" className="qa-circle-btn qa-send-btn is-stop" onClick={stopQaGeneration} aria-label="停止生成">
-                <Square size={14} fill="currentColor" />
-              </button>
-            ) : (
-              <button
-                type="button"
-                className="qa-circle-btn qa-send-btn"
-                onClick={handleSend}
-                disabled={!input.trim() && pendingImages.length === 0 && pendingFiles.length === 0}
-                aria-label="发送"
-              >
-                <ArrowUp size={20} strokeWidth={2.4} />
-              </button>
-            )}
-          </div>
-          <div
-            className={`qa-context-meter ${snapshot.isCompacting ? "is-compacting" : ""}`}
-            title="上下文用量：满 100% 时自动压缩成摘要并从头累计"
-          >
-            <div className="qa-context-meter-track" aria-hidden>
-              <i style={{ width: `${Math.min(100, Math.round(snapshot.contextUsage * 100))}%` }} />
-            </div>
-            <span className="qa-context-meter-label">
-              {snapshot.isCompacting ? "压缩中" : `${Math.min(999, Math.round(snapshot.contextUsage * 100))}%`}
-            </span>
-          </div>
-        </div>
-      </footer>
-
-      {drawerOpen && (
-        <button
-          type="button"
-          className="qa-stage-scrim"
-          aria-label="关闭对话列表"
-          onClick={() => setDrawerOpen(false)}
-        />
-      )}
-      </div>
-
-      {renameTarget && (
-        <div className="qa-rename-backdrop" role="presentation" onClick={() => setRenameTarget(null)}>
-          <form
-            className="qa-rename-dialog"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="qa-rename-dialog-title"
-            onClick={(e) => e.stopPropagation()}
-            onSubmit={(e) => {
-              e.preventDefault();
-              const title = renameTitle.trim();
-              if (!title) return;
-              renameQaSession(renameTarget.id, title);
-              setRenameTarget(null);
-            }}
-          >
-            <div id="qa-rename-dialog-title" className="qa-rename-title">重命名对话</div>
-            <input
-              className="qa-rename-input"
-              autoFocus
-              value={renameTitle}
-              maxLength={80}
-              aria-label="新对话名称"
-              onChange={(e) => setRenameTitle(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Escape") setRenameTarget(null); }}
-            />
-            <div className="qa-rename-actions">
-              <button type="button" className="qa-rename-cancel" onClick={() => setRenameTarget(null)}>取消</button>
-              <button type="submit" className="qa-drawer-new qa-rename-confirm" disabled={!renameTitle.trim()}>确认</button>
-            </div>
-          </form>
-        </div>
-      )}
-
-      {clearToolsOpen && (
-        <div className="qa-devnotice-backdrop" onClick={() => setClearToolsOpen(false)}>
-          <div className="qa-devnotice" role="alertdialog" aria-label="清理工具历史确认" onClick={(e) => e.stopPropagation()}>
-            <div className="qa-devnotice-title">清理工具调用历史？</div>
-            <div className="qa-devnotice-text">
-              将移除本会话上下文中的工具调用与工具结果记录，用于修复原生工具协议的报错。普通对话内容不会删除，之前的工具结论仍保留在小坊的回复文字里。
-            </div>
-            <div className="qa-devnotice-actions is-row">
-              <button type="button" className="qa-devnotice-btn" onClick={() => setClearToolsOpen(false)}>
-                取消
-              </button>
-              <button type="button" className="qa-devnotice-btn is-primary" onClick={confirmClearToolHistory}>
-                清理
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {viewerImage && (
-        <div className="qa-image-viewer" role="presentation" onClick={() => setViewerImage(null)}>
-          <img src={viewerImage} alt="" />
-          <button type="button" className="qa-image-viewer-close" aria-label="关闭" onClick={() => setViewerImage(null)}>
-            <X size={20} />
-          </button>
-        </div>
-      )}
-
-      {editingMsg && (
-        <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
-          <div className="qa-edit-dialog" role="dialog" aria-label="修改消息" onClick={(e) => e.stopPropagation()}>
-            <div className="qa-edit-head">
-              <span className="qa-edit-title">修改消息</span>
-              <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
-                <X size={16} />
-              </button>
-            </div>
-            
-            <div style={{ padding: "0 16px 8px 16px" }}>
-                <textarea
-                  className="qa-edit-textarea"
-                  value={editText}
-                  onChange={(e) => setEditText(e.target.value)}
-                  spellCheck={false}
-                  autoFocus
-                  style={{ minHeight: "120px", marginBottom: "8px" }}
-                />
-                
-                <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "8px" }}>
-                    {editImages.map((url, i) => (
-                        <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "4px", overflow: "hidden", border: "1px solid rgba(255,255,255,0.1)" }}>
-                            <img src={url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
-                            <button
-                                type="button"
-                                style={{ position: "absolute", top: 0, right: 0, background: "rgba(0,0,0,0.5)", color: "white", border: "none", borderRadius: "0 0 0 4px", cursor: "pointer", padding: "2px" }}
-                                onClick={() => setEditImages(current => current.filter((_, idx) => idx !== i))}
-                            >
-                                <X size={10} />
-                            </button>
-                        </div>
-                    ))}
-                    {editFiles.map((f, i) => (
-                         <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "rgba(255,255,255,0.1)", padding: "4px 20px 4px 8px", borderRadius: "4px", fontSize: "11px", border: "1px solid rgba(255,255,255,0.2)" }}>
-                            <FileText size={12} style={{ marginRight: "4px" }} />
-                            <span style={{ maxWidth: "80px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
-                            <button
-                                type="button"
-                                style={{ position: "absolute", right: "2px", background: "transparent", color: "inherit", border: "none", cursor: "pointer", display: "flex", alignItems: "center" }}
-                                onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}
-                            >
-                                <X size={12} />
-                            </button>
-                        </div>
-                    ))}
-                </div>
-
-                <div style={{ display: "flex", gap: "8px" }}>
-                    <button type="button" className="qa-devnotice-btn" onClick={() => fileInputRef.current?.click()} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
-                        <Paperclip size={12} /> 添加附件
-                    </button>
-                    <button type="button" className="qa-devnotice-btn" onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); }} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
-                        <Plus size={12} /> 添加图片
-                    </button>
-                     <input
-                        ref={imageInputRef}
-                        type="file"
-                        accept="image/*"
-                        multiple
-                        style={{ display: "none" }}
-                        onChange={(e) => {
-                            const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
-                            handlePickImages(e.target.files, isEditMode);
-                            e.target.removeAttribute('data-edit-mode');
-                        }}
-                    />
-                    <input
-                        ref={fileInputRef}
-                        type="file"
-                        multiple
-                        accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
-                        style={{ display: "none" }}
-                        onChange={(e) => handlePickFiles(e.target.files, true)}
-                    />
-                </div>
-            </div>
-            
-            <div className="qa-edit-actions">
-              <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
-                取消
-              </button>
-              <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
-                仅保存
-              </button>
-              <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
-                保存并发送
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {settingsOpen && (
-        <QaSettingsSheet onClose={() => setSettingsOpen(false)} onNotice={onNotice} />
-      )}
-
-      {repoSheetOpen && (
-        <QaRepoSheet onClose={() => setRepoSheetOpen(false)} onSaved={refreshComposerMeta} />
-      )}
-
-      {previewOpen && !previewItem && (
-        <div className="qa-sheet-backdrop" onClick={() => setPreviewOpen(false)}>
-          <div className="qa-sheet qa-preview-sheet" onClick={(e) => e.stopPropagation()}>
-            <div className="qa-sheet-head">
-              <span className="qa-sheet-title">
-                <Play size={16} /> 预览本轮创建
-              </span>
-              <button type="button" className="qa-icon-btn" onClick={() => setPreviewOpen(false)} aria-label="关闭">
-                <X size={16} />
-              </button>
-            </div>
-            <div className="qa-sheet-body">
-              <p className="qa-sheet-note">本次对话里创建/更新的内容，点开直接测试，返回后回到聊天。</p>
-              {createdContent.map((item) => (
-                <button
-                  key={`${item.type}-${item.refId}`}
-                  type="button"
-                  className="qa-preview-item"
-                  onClick={() => setPreviewItem(item)}
-                >
-                  {item.type === "app" ? <AppWindow size={17} /> : item.type === "game" ? <Gamepad2 size={17} /> : <Drama size={17} />}
-                  <span className="qa-preview-item-title">{item.title}</span>
-                  <span className="qa-preview-item-type">
-                    {item.type === "app" ? "应用" : item.type === "game" ? "游戏" : "剧场"}
-                  </span>
-                  <ChevronRight size={15} />
-                </button>
-              ))}
-            </div>
-          </div>
-        </div>
-      )}
-
-      {previewItem && (
-        <div className="qa-preview-runtime">
-          {previewItem.type === "app" ? (
-            previewApp ? (
-              <CustomAppForegroundBoundary
-                key={previewApp.id}
-                appName={previewApp.name}
-                appId={previewApp.id}
-                appVersion={previewApp.version}
-                manifestId={previewApp.manifest?.id}
-                closeLabel="返回"
-                onClose={() => setPreviewItem(null)}
-              >
-                <CustomAppRunner app={previewApp} onClose={() => setPreviewItem(null)} />
-              </CustomAppForegroundBoundary>
-            ) : (
-              <div className="qa-preview-missing">
-                <p>这个应用已被卸载或找不到了。</p>
-                <button type="button" className="qa-sheet-btn is-primary" onClick={() => setPreviewItem(null)}>
-                  返回
-                </button>
-              </div>
-            )
-          ) : previewItem.type === "game" ? (
-            <GameHubApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
-          ) : (
-            <BlackMarketApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
           )}
         </div>
       )}
+
+      <textarea
+        ref={textareaRef}
+        className="qa-composer-input hide-scrollbar"
+        placeholder="输入你的问题…"
+        rows={1}
+        value={input}
+        onChange={(e) => {
+          setInput(e.target.value);
+          if (attachMenuOpen) setAttachMenuOpen(false);
+          autoGrow();
+        }}
+        onClick={() => {
+          if (attachMenuOpen) setAttachMenuOpen(false);
+        }}
+      />
+      <div className="qa-composer-toolbar">
+        <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
+            style={{ display: "none" }}
+            onChange={(e) => handlePickFiles(e.target.files)}
+        />
+        {visionEnabled && (
+            <input
+              ref={imageInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              style={{ display: "none" }}
+              onChange={(e) => handlePickImages(e.target.files)}
+            />
+        )}
+        
+        {/* 统一的附件加号菜单按钮 */}
+        <button
+            type="button"
+            className={`qa-circle-btn qa-attach-btn ${attachMenuOpen ? 'is-active' : ''}`}
+            onClick={() => setAttachMenuOpen((prev) => !prev)}
+            aria-label="添加附件或图片"
+        >
+            <Plus size={17} strokeWidth={2.2} style={{ transform: attachMenuOpen ? 'rotate(45deg)' : 'none', transition: 'transform 0.2s ease-in-out' }} />
+        </button>
+
+        {modelName && <span className="qa-model-pill">{modelName}</span>}
+
+        {repoWritable && (
+          <button type="button" className="qa-mode-pill" onClick={toggleWriteMode}>
+            {writeMode === "auto" ? "全自动" : "确认后提交"}
+          </button>
+        )}
+
+        <div className="qa-composer-spacer" />
+
+        {createdContent.length > 0 && (
+          <button
+            type="button"
+            className="qa-circle-btn qa-preview-btn"
+            onClick={() => setPreviewOpen(true)}
+            aria-label="预览本轮创建的内容"
+          >
+            <Play size={16} />
+          </button>
+        )}
+
+        <button
+          type="button"
+          className={`qa-circle-btn qa-github-btn ${repoConnected ? "is-active" : ""}`}
+          onClick={() => setRepoSheetOpen(true)}
+          aria-label="连接仓库"
+        >
+          <Github size={16} strokeWidth={1.75} />
+        </button>
+
+        {snapshot.isGenerating ? (
+          <button type="button" className="qa-circle-btn qa-send-btn is-stop" onClick={stopQaGeneration} aria-label="停止生成">
+            <Square size={14} fill="currentColor" />
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="qa-circle-btn qa-send-btn"
+            onClick={handleSend}
+            disabled={!input.trim() && pendingImages.length === 0 && pendingFiles.length === 0}
+            aria-label="发送"
+          >
+            <ArrowUp size={20} strokeWidth={2.4} />
+          </button>
+        )}
+      </div>
+      <div
+        className={`qa-context-meter ${snapshot.isCompacting ? "is-compacting" : ""}`}
+        title="上下文用量：满 100% 时自动压缩成摘要并从头累计"
+      >
+        <div className="qa-context-meter-track" aria-hidden>
+          <i style={{ width: `${Math.min(100, Math.round(snapshot.contextUsage * 100))}%` }} />
+        </div>
+        <span className="qa-context-meter-label">
+          {snapshot.isCompacting ? "压缩中" : `${Math.min(999, Math.round(snapshot.contextUsage * 100))}%`}
+        </span>
+      </div>
     </div>
-  );
+  </footer>
+
+  {drawerOpen && (
+    <button
+      type="button"
+      className="qa-stage-scrim"
+      aria-label="关闭对话列表"
+      onClick={() => setDrawerOpen(false)}
+    />
+  )}
+  </div>
+
+  {renameTarget && (
+    <div className="qa-rename-backdrop" role="presentation" onClick={() => setRenameTarget(null)}>
+      <form
+        className="qa-rename-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="qa-rename-dialog-title"
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={(e) => {
+          e.preventDefault();
+          const title = renameTitle.trim();
+          if (!title) return;
+          renameQaSession(renameTarget.id, title);
+          setRenameTarget(null);
+        }}
+      >
+        <div id="qa-rename-dialog-title" className="qa-rename-title">重命名对话</div>
+        <input
+          className="qa-rename-input"
+          autoFocus
+          value={renameTitle}
+          maxLength={80}
+          aria-label="新对话名称"
+          onChange={(e) => setRenameTitle(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Escape") setRenameTarget(null); }}
+        />
+        <div className="qa-rename-actions">
+          <button type="button" className="qa-rename-cancel" onClick={() => setRenameTarget(null)}>取消</button>
+          <button type="submit" className="qa-drawer-new qa-rename-confirm" disabled={!renameTitle.trim()}>确认</button>
+        </div>
+      </form>
+    </div>
+  )}
+
+  {clearToolsOpen && (
+    <div className="qa-devnotice-backdrop" onClick={() => setClearToolsOpen(false)}>
+      <div className="qa-devnotice" role="alertdialog" aria-label="清理工具历史确认" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-devnotice-title">清理工具调用历史？</div>
+        <div className="qa-devnotice-text">
+          将移除本会话上下文中的工具调用与工具结果记录，用于修复原生工具协议的报错。普通对话内容不会删除，之前的工具结论仍保留在小坊的回复文字里。
+        </div>
+        <div className="qa-devnotice-actions is-row">
+          <button type="button" className="qa-devnotice-btn" onClick={() => setClearToolsOpen(false)}>
+            取消
+          </button>
+          <button type="button" className="qa-devnotice-btn is-primary" onClick={confirmClearToolHistory}>
+            清理
+          </button>
+        </div>
+      </div>
+    </div>
+  )}
+
+  {viewerImage && (
+    <div className="qa-image-viewer" role="presentation" onClick={() => setViewerImage(null)}>
+      <img src={viewerImage} alt="" />
+      <button type="button" className="qa-image-viewer-close" aria-label="关闭" onClick={() => setViewerImage(null)}>
+        <X size={20} />
+      </button>
+    </div>
+  )}
+
+  {editingMsg && (
+    <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
+      <div className="qa-edit-dialog" role="dialog" aria-label="修改消息" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-edit-head">
+          <span className="qa-edit-title">修改消息</span>
+          <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
+            <X size={16} />
+          </button>
+        </div>
+        
+        <div style={{ padding: "0 16px 8px 16px" }}>
+            <textarea
+              className="qa-edit-textarea"
+              value={editText}
+              onChange={(e) => setEditText(e.target.value)}
+              spellCheck={false}
+              autoFocus
+              style={{ minHeight: "120px", marginBottom: "8px" }}
+            />
+            
+            <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "8px" }}>
+                {editImages.map((url, i) => (
+                    <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "4px", overflow: "hidden", border: "1px solid rgba(255,255,255,0.1)" }}>
+                        <img src={url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+                        <button
+                            type="button"
+                            style={{ position: "absolute", top: 0, right: 0, background: "rgba(0,0,0,0.5)", color: "white", border: "none", borderRadius: "0 0 0 4px", cursor: "pointer", padding: "2px" }}
+                            onClick={() => setEditImages(current => current.filter((_, idx) => idx !== i))}
+                        >
+                            <X size={10} />
+                        </button>
+                    </div>
+                ))}
+                {editFiles.map((f, i) => (
+                     <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "rgba(255,255,255,0.1)", padding: "4px 20px 4px 8px", borderRadius: "12px", fontSize: "11px", border: "1px solid rgba(255,255,255,0.2)" }}>
+                        <FileText size={12} style={{ marginRight: "4px" }} />
+                        <span style={{ maxWidth: "80px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
+                        <button
+                            type="button"
+                            style={{ position: "absolute", right: "2px", background: "transparent", color: "inherit", border: "none", cursor: "pointer", display: "flex", alignItems: "center" }}
+                            onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}
+                        >
+                            <X size={12} />
+                        </button>
+                    </div>
+                ))}
+            </div>
+
+            <div style={{ display: "flex", gap: "8px" }}>
+                <button type="button" className="qa-devnotice-btn" onClick={() => fileInputRef.current?.click()} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
+                    <Paperclip size={12} /> 添加附件
+                </button>
+                <button type="button" className="qa-devnotice-btn" onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); }} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
+                    <Plus size={12} /> 添加图片
+                </button>
+                 <input
+                    ref={imageInputRef}
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    style={{ display: "none" }}
+                    onChange={(e) => {
+                        const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
+                        handlePickImages(e.target.files, isEditMode);
+                        e.target.removeAttribute('data-edit-mode');
+                    }}
+                />
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    multiple
+                    accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
+                    style={{ display: "none" }}
+                    onChange={(e) => handlePickFiles(e.target.files, true)}
+                />
+            </div>
+        </div>
+        
+        <div className="qa-edit-actions">
+          <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
+            取消
+          </button>
+          <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
+            仅保存
+          </button>
+          <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
+            保存并发送
+          </button>
+        </div>
+      </div>
+    </div>
+  )}
+
+  {settingsOpen && (
+    <QaSettingsSheet onClose={() => setSettingsOpen(false)} onNotice={onNotice} />
+  )}
+
+  {repoSheetOpen && (
+    <QaRepoSheet onClose={() => setRepoSheetOpen(false)} onSaved={refreshComposerMeta} />
+  )}
+
+  {previewOpen && !previewItem && (
+    <div className="qa-sheet-backdrop" onClick={() => setPreviewOpen(false)}>
+      <div className="qa-sheet qa-preview-sheet" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-sheet-head">
+          <span className="qa-sheet-title">
+            <Play size={16} /> 预览本轮创建
+          </span>
+          <button type="button" className="qa-icon-btn" onClick={() => setPreviewOpen(false)} aria-label="关闭">
+            <X size={16} />
+          </button>
+        </div>
+        <div className="qa-sheet-body">
+          <p className="qa-sheet-note">本次对话里创建/更新的内容，点开直接测试，返回后回到聊天。</p>
+          {createdContent.map((item) => (
+            <button
+              key={`${item.type}-${item.refId}`}
+              type="button"
+              className="qa-preview-item"
+              onClick={() => setPreviewItem(item)}
+            >
+              {item.type === "app" ? <AppWindow size={17} /> : item.type === "game" ? <Gamepad2 size={17} /> : <Drama size={17} />}
+              <span className="qa-preview-item-title">{item.title}</span>
+              <span className="qa-preview-item-type">
+                {item.type === "app" ? "应用" : item.type === "game" ? "游戏" : "剧场"}
+              </span>
+              <ChevronRight size={15} />
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )}
+
+  {previewItem && (
+    <div className="qa-preview-runtime">
+      {previewItem.type === "app" ? (
+        previewApp ? (
+          <CustomAppForegroundBoundary
+            key={previewApp.id}
+            appName={previewApp.name}
+            appId={previewApp.id}
+            appVersion={previewApp.version}
+            manifestId={previewApp.manifest?.id}
+            closeLabel="返回"
+            onClose={() => setPreviewItem(null)}
+          >
+            <CustomAppRunner app={previewApp} onClose={() => setPreviewItem(null)} />
+          </CustomAppForegroundBoundary>
+        ) : (
+          <div className="qa-preview-missing">
+            <p>这个应用已被卸载或找不到了。</p>
+            <button type="button" className="qa-sheet-btn is-primary" onClick={() => setPreviewItem(null)}>
+              返回
+            </button>
+          </div>
+        )
+      ) : previewItem.type === "game" ? (
+        <GameHubApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
+      ) : (
+        <BlackMarketApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
+      )}
+    </div>
+  )}
+</div>
+
+
+);
 }

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -1444,12 +1444,12 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                     </button>
                 </div>
                 
-                <div style={{ display: 'flex', gap: '8px', alignItems: 'stretch' }}>
+                <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
                     <button 
                         type="button" 
                         className="qa-devnotice-btn" 
                         onClick={() => handleSaveEdit(false)}
-                        style={{ whiteSpace: 'nowrap', padding: '0 24px', borderRadius: '8px' }}
+                        style={{ whiteSpace: 'nowrap', padding: '0 32px', height: '36px', borderRadius: '12px' }}
                     >
                         保存
                     </button>
@@ -1457,7 +1457,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                         type="button" 
                         className="qa-devnotice-btn is-primary" 
                         onClick={() => handleSaveEdit(true)}
-                        style={{ whiteSpace: 'nowrap', padding: '0 24px', borderRadius: '8px' }}
+                        style={{ whiteSpace: 'nowrap', padding: '0 32px', height: '36px', borderRadius: '12px' }}
                     >
                         保存并发送
                     </button>

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -4,7 +4,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExterna
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
-import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, MoreVertical, Pencil, Pin, PinOff, Play, Plus, Square, Trash2, Wrench, X, Paperclip, FileText } from "lucide-react";
+import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, MoreVertical, Pencil, Pin, PinOff, Play, Plus, Square, Trash2, Wrench, X, Paperclip, FileText, Image } from "lucide-react";
 import { QaFileCard } from "@/components/qa-file-card";
 import { parseQaFileMarker } from "@/lib/qa-computer-tools";
 import { mdiHammerWrench } from "@mdi/js";
@@ -800,6 +800,8 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
   const [repoConnected, setRepoConnected] = useState(false);
   const [clearToolsOpen, setClearToolsOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [attachMenuOpen, setAttachMenuOpen] = useState(false); // 控制上方悬浮菜单状态
+  
   /** 会话重命名弹窗：抽屉菜单里点「重命名」打开 */
   const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
   const [renameTitle, setRenameTitle] = useState("");
@@ -906,6 +908,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
     const text = input.trim();
     if ((!text && pendingImages.length === 0 && pendingFiles.length === 0) || snapshot.isGenerating) return;
     setInput("");
+    setAttachMenuOpen(false); // 发送时关闭菜单
     const images = pendingImages;
     const files = pendingFiles;
     setPendingImages([]);
@@ -1042,7 +1045,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
         </div>
       </header>
 
-      <div className="qa-body hide-scrollbar" ref={bodyRef} onScroll={handleScroll}>
+      <div className="qa-body hide-scrollbar" ref={bodyRef} onScroll={handleScroll} onClick={() => { if (attachMenuOpen) setAttachMenuOpen(false); }}>
         {messages.length === 0 ? (
           <div className="qa-welcome">
             <div className="qa-welcome-badge" aria-hidden>
@@ -1121,6 +1124,29 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
               ))}
             </div>
           )}
+          
+          {/* 在输入框上方的悬浮选择菜单 */}
+          {attachMenuOpen && (
+            <div className="qa-attach-menu" style={{ display: "flex", gap: "8px", padding: "8px 12px 4px 12px", animation: "fadeIn 0.2s" }}>
+              <button
+                type="button"
+                onClick={() => { fileInputRef.current?.click(); setAttachMenuOpen(false); }}
+                style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
+              >
+                <Paperclip size={15} strokeWidth={2} /> 上传附件
+              </button>
+              {visionEnabled && (
+                <button
+                  type="button"
+                  onClick={() => { imageInputRef.current?.click(); setAttachMenuOpen(false); }}
+                  style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
+                >
+                  <Image size={15} strokeWidth={2} /> 添加图片
+                </button>
+              )}
+            </div>
+          )}
+
           <textarea
             ref={textareaRef}
             className="qa-composer-input hide-scrollbar"
@@ -1129,7 +1155,11 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
             value={input}
             onChange={(e) => {
               setInput(e.target.value);
+              if (attachMenuOpen) setAttachMenuOpen(false);
               autoGrow();
+            }}
+            onClick={() => {
+              if (attachMenuOpen) setAttachMenuOpen(false);
             }}
           />
           <div className="qa-composer-toolbar">
@@ -1141,17 +1171,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                 style={{ display: "none" }}
                 onChange={(e) => handlePickFiles(e.target.files)}
             />
-            <button
-                type="button"
-                className="qa-circle-btn qa-attach-btn"
-                onClick={() => fileInputRef.current?.click()}
-                aria-label="添加附件"
-            >
-                <Paperclip size={17} strokeWidth={2.2} />
-            </button>
-
             {visionEnabled && (
-              <>
                 <input
                   ref={imageInputRef}
                   type="file"
@@ -1160,16 +1180,18 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                   style={{ display: "none" }}
                   onChange={(e) => handlePickImages(e.target.files)}
                 />
-                <button
-                  type="button"
-                  className="qa-circle-btn qa-attach-btn"
-                  onClick={() => imageInputRef.current?.click()}
-                  aria-label="发送图片"
-                >
-                  <Plus size={17} strokeWidth={2.2} />
-                </button>
-              </>
             )}
+            
+            {/* 统一的附件加号菜单按钮 */}
+            <button
+                type="button"
+                className={`qa-circle-btn qa-attach-btn ${attachMenuOpen ? 'is-active' : ''}`}
+                onClick={() => setAttachMenuOpen((prev) => !prev)}
+                aria-label="添加附件或图片"
+            >
+                <Plus size={17} strokeWidth={2.2} style={{ transform: attachMenuOpen ? 'rotate(45deg)' : 'none', transition: 'transform 0.2s ease-in-out' }} />
+            </button>
+
             {modelName && <span className="qa-model-pill">{modelName}</span>}
 
             {repoWritable && (

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -943,7 +943,20 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
   const handlePickFiles = useCallback((files: FileList | null, isEditMode = false) => {
     if (!files?.length) return;
     const setter = isEditMode ? setEditFiles : setPendingFiles;
+    
+    // 定义允许的纯文本后缀（你可以根据需要在这里增删）
+    const allowedExts = [".txt", ".md", ".json", ".js", ".ts", ".tsx", ".jsx", ".html", ".css", ".csv"];
+    
     for (const file of Array.from(files).slice(0, 6)) {
+      const fileName = file.name.toLowerCase();
+      
+      // 新增：拦截非文本文件并动态提取后缀名提示
+      if (!allowedExts.some(ext => fileName.endsWith(ext))) {
+        const ext = fileName.includes('.') ? `.${fileName.split('.').pop()}` : '无后缀';
+        onNotice?.(`不支持阅读 ${ext} 文件，小坊目前只能读取纯文本或代码文件哦。`);
+        continue;
+      }
+
       if (file.size > 1024 * 1024) { // 纯文本文件限 1MB
         onNotice?.(`「${file.name}」太大（超过 1MB），请直接粘贴内容。`);
         continue;
@@ -1444,12 +1457,12 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                     </button>
                 </div>
                 
-                <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
+                <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
                     <button 
                         type="button" 
                         className="qa-devnotice-btn" 
                         onClick={() => handleSaveEdit(false)}
-                        style={{ whiteSpace: 'nowrap', padding: '0 32px', height: '36px', borderRadius: '12px' }}
+                        style={{ whiteSpace: 'nowrap', padding: '0 24px', height: '44px', borderRadius: '14px', fontSize: '14px' }}
                     >
                         保存
                     </button>
@@ -1457,7 +1470,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                         type="button" 
                         className="qa-devnotice-btn is-primary" 
                         onClick={() => handleSaveEdit(true)}
-                        style={{ whiteSpace: 'nowrap', padding: '0 32px', height: '36px', borderRadius: '12px' }}
+                        style={{ whiteSpace: 'nowrap', padding: '0 24px', height: '44px', borderRadius: '14px', fontSize: '14px' }}
                     >
                         保存并发送
                     </button>

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -4,7 +4,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExterna
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
-import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, MoreVertical, Pencil, Pin, PinOff, Play, Plus, Square, Trash2, Wrench, X, Paperclip, FileText } from "lucide-react";
+import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, MoreVertical, Pencil, Pin, PinOff, Play, Plus, Square, Trash2, Wrench, X, Paperclip, FileText, Image as ImageIcon } from "lucide-react";
 import { QaFileCard } from "@/components/qa-file-card";
 import { parseQaFileMarker } from "@/lib/qa-computer-tools";
 import { mdiHammerWrench } from "@mdi/js";
@@ -806,6 +806,10 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
   const [pendingImages, setPendingImages] = useState<string[]>([]);
   const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
   
+  // 控制加号展开菜单的状态
+  const [attachMenuOpen, setAttachMenuOpen] = useState(false);
+  const [editAttachMenuOpen, setEditAttachMenuOpen] = useState(false);
+  
   const [viewerImage, setViewerImage] = useState<string | null>(null);
   const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
   const [editText, setEditText] = useState("");
@@ -934,6 +938,11 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
     if (imageInputRef.current) imageInputRef.current.value = "";
   }, [onNotice]);
 
+  // 处理编辑弹窗内的图片删除
+  const handleRemoveEditImage = useCallback((index: number) => {
+    setEditImages(current => current.filter((_, i) => i !== index));
+  }, []);
+
   // 附加文本文件
   const handlePickFiles = useCallback((files: FileList | null, isEditMode = false) => {
     if (!files?.length) return;
@@ -983,7 +992,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
         updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
     }
     setEditingMsg(null);
-    onNotice?.(andResend ? "已提交修改" : "已保存消息内容");
+    onNotice?.(andResend ? "已提交修改" : "已保存修改");
   }, [editingMsg, editText, editImages, editFiles, snapshot.activeSessionId, onNotice]);
 
   const streamingMsgId =
@@ -1137,39 +1146,54 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                 ref={fileInputRef}
                 type="file"
                 multiple
-                accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
+                accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv,.log,.xml,.yml,.yaml,.ini,.conf"
                 style={{ display: "none" }}
-                onChange={(e) => handlePickFiles(e.target.files)}
+                onChange={(e) => {
+                    handlePickFiles(e.target.files);
+                    setAttachMenuOpen(false);
+                }}
             />
-            <button
-                type="button"
-                className="qa-circle-btn qa-attach-btn"
-                onClick={() => fileInputRef.current?.click()}
-                aria-label="添加附件"
-            >
-                <Paperclip size={17} strokeWidth={2.2} />
-            </button>
-
             {visionEnabled && (
-              <>
                 <input
                   ref={imageInputRef}
                   type="file"
                   accept="image/*"
                   multiple
                   style={{ display: "none" }}
-                  onChange={(e) => handlePickImages(e.target.files)}
+                  onChange={(e) => {
+                      handlePickImages(e.target.files);
+                      setAttachMenuOpen(false);
+                  }}
                 />
-                <button
-                  type="button"
-                  className="qa-circle-btn qa-attach-btn"
-                  onClick={() => imageInputRef.current?.click()}
-                  aria-label="发送图片"
-                >
-                  <Plus size={17} strokeWidth={2.2} />
-                </button>
-              </>
             )}
+
+            <div style={{ position: "relative" }}>
+                <button
+                    type="button"
+                    className={`qa-circle-btn qa-attach-btn ${attachMenuOpen ? "is-active" : ""}`}
+                    onClick={() => setAttachMenuOpen(!attachMenuOpen)}
+                    aria-label="添加内容"
+                >
+                    <Plus size={17} strokeWidth={2.2} style={{ transform: attachMenuOpen ? 'rotate(45deg)' : 'none', transition: 'transform 0.2s' }} />
+                </button>
+                
+                {attachMenuOpen && (
+                    <>
+                        <div style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, zIndex: 90 }} onClick={() => setAttachMenuOpen(false)} />
+                        <div style={{ position: "absolute", bottom: "100%", left: 0, marginBottom: "8px", background: "var(--qa-bg-elevated)", border: "1px solid var(--qa-border)", borderRadius: "12px", padding: "6px", display: "flex", flexDirection: "column", gap: "2px", zIndex: 100, boxShadow: "0 4px 12px rgba(0,0,0,0.1)", minWidth: "110px" }}>
+                            <button type="button" className="qa-drawer-menu-btn" style={{ justifyContent: "flex-start", padding: "8px 12px" }} onClick={() => fileInputRef.current?.click()}>
+                                <FileText size={15} style={{ marginRight: "8px", opacity: 0.7 }} /> 上传附件
+                            </button>
+                            {visionEnabled && (
+                                <button type="button" className="qa-drawer-menu-btn" style={{ justifyContent: "flex-start", padding: "8px 12px" }} onClick={() => imageInputRef.current?.click()}>
+                                    <ImageIcon size={15} style={{ marginRight: "8px", opacity: 0.7 }} /> 上传图片
+                                </button>
+                            )}
+                        </div>
+                    </>
+                )}
+            </div>
+
             {modelName && <span className="qa-model-pill">{modelName}</span>}
 
             {repoWritable && (
@@ -1312,84 +1336,73 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
               </button>
             </div>
             
-            <div style={{ padding: "0 16px 8px 16px" }}>
+            <div style={{ padding: "0 16px 4px 16px" }}>
                 <textarea
                   className="qa-edit-textarea"
                   value={editText}
                   onChange={(e) => setEditText(e.target.value)}
                   spellCheck={false}
                   autoFocus
-                  style={{ minHeight: "120px", marginBottom: "8px" }}
+                  style={{ minHeight: "100px", marginBottom: "12px", border: "1px solid var(--qa-border)", borderRadius: "8px", padding: "10px", background: "transparent", color: "inherit", width: "100%", boxSizing: "border-box" }}
                 />
                 
-                <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "8px" }}>
-                    {editImages.map((url, i) => (
-                        <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "4px", overflow: "hidden", border: "1px solid rgba(255,255,255,0.1)" }}>
-                            <img src={url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
-                            <button
-                                type="button"
-                                style={{ position: "absolute", top: 0, right: 0, background: "rgba(0,0,0,0.5)", color: "white", border: "none", borderRadius: "0 0 0 4px", cursor: "pointer", padding: "2px" }}
-                                onClick={() => setEditImages(current => current.filter((_, idx) => idx !== i))}
-                            >
-                                <X size={10} />
-                            </button>
-                        </div>
-                    ))}
-                    {editFiles.map((f, i) => (
-                         <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "rgba(255,255,255,0.1)", padding: "4px 20px 4px 8px", borderRadius: "4px", fontSize: "11px", border: "1px solid rgba(255,255,255,0.2)" }}>
-                            <FileText size={12} style={{ marginRight: "4px" }} />
-                            <span style={{ maxWidth: "80px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
-                            <button
-                                type="button"
-                                style={{ position: "absolute", right: "2px", background: "transparent", color: "inherit", border: "none", cursor: "pointer", display: "flex", alignItems: "center" }}
-                                onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}
-                            >
-                                <X size={12} />
-                            </button>
-                        </div>
-                    ))}
+                {(editImages.length > 0 || editFiles.length > 0) && (
+                    <div style={{ display: "flex", gap: "6px", flexWrap: "wrap", marginBottom: "12px" }}>
+                        {editImages.map((url, i) => (
+                            <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "6px", overflow: "hidden", border: "1px solid rgba(128,128,128,0.2)" }}>
+                                <img src={url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+                                <button type="button" style={{ position: "absolute", top: 2, right: 2, background: "rgba(0,0,0,0.6)", color: "white", border: "none", borderRadius: "50%", cursor: "pointer", width: "14px", height: "14px", display: "flex", alignItems: "center", justifyContent: "center" }} onClick={() => handleRemoveEditImage(i)}>
+                                    <X size={9} strokeWidth={3} />
+                                </button>
+                            </div>
+                        ))}
+                        {editFiles.map((f, i) => (
+                             <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "var(--qa-bg-secondary)", padding: "4px 22px 4px 8px", borderRadius: "6px", fontSize: "11px", border: "1px solid var(--qa-border)", maxWidth: "120px" }}>
+                                <FileText size={13} style={{ marginRight: "4px", minWidth: "13px", opacity: 0.7 }} />
+                                <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
+                                <button type="button" style={{ position: "absolute", right: "4px", background: "transparent", color: "inherit", border: "none", cursor: "pointer", display: "flex", alignItems: "center", opacity: 0.6 }} onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}>
+                                    <X size={12} strokeWidth={2.5}/>
+                                </button>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+            
+            <div className="qa-edit-actions" style={{ justifyContent: "space-between", paddingTop: "8px", borderTop: "1px solid var(--qa-border)", margin: "0 16px 16px 16px", paddingBottom: 0, paddingLeft: 0, paddingRight: 0 }}>
+                <div style={{ position: "relative" }}>
+                    <button type="button" className="qa-circle-btn qa-attach-btn" onClick={() => setEditAttachMenuOpen(!editAttachMenuOpen)} style={{ background: "transparent", border: "1px solid var(--qa-border)", color: "inherit" }}>
+                         <Plus size={16} style={{ transform: editAttachMenuOpen ? 'rotate(45deg)' : 'none', transition: 'transform 0.2s', opacity: 0.7 }} />
+                    </button>
+                    {editAttachMenuOpen && (
+                        <>
+                            <div style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, zIndex: 90 }} onClick={() => setEditAttachMenuOpen(false)} />
+                            <div style={{ position: "absolute", bottom: "100%", left: 0, marginBottom: "8px", background: "var(--qa-bg-elevated)", border: "1px solid var(--qa-border)", borderRadius: "12px", padding: "6px", display: "flex", flexDirection: "column", gap: "2px", zIndex: 100, boxShadow: "0 4px 12px rgba(0,0,0,0.1)", minWidth: "110px" }}>
+                                <button type="button" className="qa-drawer-menu-btn" style={{ justifyContent: "flex-start", padding: "8px 12px" }} onClick={() => { setEditAttachMenuOpen(false); fileInputRef.current?.click(); }}>
+                                    <FileText size={15} style={{ marginRight: "8px", opacity: 0.7 }} /> 上传附件
+                                </button>
+                                {visionEnabled && (
+                                    <button type="button" className="qa-drawer-menu-btn" style={{ justifyContent: "flex-start", padding: "8px 12px" }} onClick={() => {
+                                        setEditAttachMenuOpen(false);
+                                        imageInputRef.current?.setAttribute('data-edit-mode', 'true');
+                                        imageInputRef.current?.click();
+                                    }}>
+                                        <ImageIcon size={15} style={{ marginRight: "8px", opacity: 0.7 }} /> 上传图片
+                                    </button>
+                                )}
+                            </div>
+                        </>
+                    )}
                 </div>
 
                 <div style={{ display: "flex", gap: "8px" }}>
-                    <button type="button" className="qa-devnotice-btn" onClick={() => fileInputRef.current?.click()} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
-                        <Paperclip size={12} /> 添加附件
+                    <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
+                        保存
                     </button>
-                    <button type="button" className="qa-devnotice-btn" onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); }} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
-                        <Plus size={12} /> 添加图片
+                    <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
+                        保存并发送
                     </button>
-                     <input
-                        ref={imageInputRef}
-                        type="file"
-                        accept="image/*"
-                        multiple
-                        style={{ display: "none" }}
-                        onChange={(e) => {
-                            const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
-                            handlePickImages(e.target.files, isEditMode);
-                            e.target.removeAttribute('data-edit-mode');
-                        }}
-                    />
-                    <input
-                        ref={fileInputRef}
-                        type="file"
-                        multiple
-                        accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
-                        style={{ display: "none" }}
-                        onChange={(e) => handlePickFiles(e.target.files, true)}
-                    />
                 </div>
-            </div>
-            
-            <div className="qa-edit-actions">
-              <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
-                取消
-              </button>
-              <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
-                仅保存
-              </button>
-              <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
-                保存并发送
-              </button>
             </div>
           </div>
         </div>
@@ -1469,3 +1482,4 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
     </div>
   );
 }
+```eof

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -1115,8 +1115,8 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                 </div>
               ))}
               {pendingFiles.map((file, i) => (
-                <div key={`file-${i}`} className="qa-attach-thumb" style={{ background: "rgba(128,128,128,0.2)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px" }}>
-                  <FileText size={16} style={{ minWidth: "16px", marginRight: "4px" }}/>
+                <div key={`file-${i}`} className="qa-attach-thumb" style={{ background: "var(--qa-bg-secondary)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px", border: "1px solid var(--qa-border)" }}>
+                  <FileText size={16} style={{ minWidth: "16px", marginRight: "4px", opacity: 0.7 }}/>
                   <span style={{ fontSize: "11px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{file.name}</span>
                   <button
                     type="button"
@@ -1180,13 +1180,13 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                 {attachMenuOpen && (
                     <>
                         <div style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, zIndex: 90 }} onClick={() => setAttachMenuOpen(false)} />
-                        <div style={{ position: "absolute", bottom: "100%", left: 0, marginBottom: "8px", background: "var(--qa-bg-elevated)", border: "1px solid var(--qa-border)", borderRadius: "12px", padding: "6px", display: "flex", flexDirection: "column", gap: "2px", zIndex: 100, boxShadow: "0 4px 12px rgba(0,0,0,0.1)", minWidth: "110px" }}>
-                            <button type="button" className="qa-drawer-menu-btn" style={{ justifyContent: "flex-start", padding: "8px 12px" }} onClick={() => fileInputRef.current?.click()}>
-                                <FileText size={15} style={{ marginRight: "8px", opacity: 0.7 }} /> 上传附件
+                        <div className="qa-dropdown-menu">
+                            <button type="button" className="qa-drawer-menu-btn" onClick={() => fileInputRef.current?.click()}>
+                                <FileText size={15} className="qa-drawer-menu-icon" /> 📄 上传附件
                             </button>
                             {visionEnabled && (
-                                <button type="button" className="qa-drawer-menu-btn" style={{ justifyContent: "flex-start", padding: "8px 12px" }} onClick={() => imageInputRef.current?.click()}>
-                                    <ImageIcon size={15} style={{ marginRight: "8px", opacity: 0.7 }} /> 上传图片
+                                <button type="button" className="qa-drawer-menu-btn" onClick={() => imageInputRef.current?.click()}>
+                                    <ImageIcon size={15} className="qa-drawer-menu-icon" /> 🖼️ 上传图片
                                 </button>
                             )}
                         </div>
@@ -1336,32 +1336,31 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
               </button>
             </div>
             
-            <div style={{ padding: "0 16px 4px 16px" }}>
+            <div className="qa-edit-body">
                 <textarea
                   className="qa-edit-textarea"
                   value={editText}
                   onChange={(e) => setEditText(e.target.value)}
                   spellCheck={false}
                   autoFocus
-                  style={{ minHeight: "100px", marginBottom: "12px", border: "1px solid var(--qa-border)", borderRadius: "8px", padding: "10px", background: "transparent", color: "inherit", width: "100%", boxSizing: "border-box" }}
                 />
                 
                 {(editImages.length > 0 || editFiles.length > 0) && (
-                    <div style={{ display: "flex", gap: "6px", flexWrap: "wrap", marginBottom: "12px" }}>
+                    <div className="qa-attach-strip" style={{ marginTop: "12px", padding: 0, background: "transparent", border: "none" }}>
                         {editImages.map((url, i) => (
-                            <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "6px", overflow: "hidden", border: "1px solid rgba(128,128,128,0.2)" }}>
-                                <img src={url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
-                                <button type="button" style={{ position: "absolute", top: 2, right: 2, background: "rgba(0,0,0,0.6)", color: "white", border: "none", borderRadius: "50%", cursor: "pointer", width: "14px", height: "14px", display: "flex", alignItems: "center", justifyContent: "center" }} onClick={() => handleRemoveEditImage(i)}>
-                                    <X size={9} strokeWidth={3} />
+                            <div key={`edit-img-${i}`} className="qa-attach-thumb">
+                                <img src={url} alt="" />
+                                <button type="button" className="qa-attach-remove" onClick={() => handleRemoveEditImage(i)}>
+                                    <X size={11} strokeWidth={2.4} />
                                 </button>
                             </div>
                         ))}
                         {editFiles.map((f, i) => (
-                             <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "var(--qa-bg-secondary)", padding: "4px 22px 4px 8px", borderRadius: "6px", fontSize: "11px", border: "1px solid var(--qa-border)", maxWidth: "120px" }}>
-                                <FileText size={13} style={{ marginRight: "4px", minWidth: "13px", opacity: 0.7 }} />
-                                <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
-                                <button type="button" style={{ position: "absolute", right: "4px", background: "transparent", color: "inherit", border: "none", cursor: "pointer", display: "flex", alignItems: "center", opacity: 0.6 }} onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}>
-                                    <X size={12} strokeWidth={2.5}/>
+                             <div key={`edit-file-${i}`} className="qa-attach-thumb" style={{ background: "var(--qa-bg-secondary)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px", border: "1px solid var(--qa-border)" }}>
+                                <FileText size={16} style={{ minWidth: "16px", marginRight: "4px", opacity: 0.7 }} />
+                                <span style={{ fontSize: "11px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
+                                <button type="button" className="qa-attach-remove" onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}>
+                                    <X size={11} strokeWidth={2.4} />
                                 </button>
                             </div>
                         ))}
@@ -1369,25 +1368,25 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                 )}
             </div>
             
-            <div className="qa-edit-actions" style={{ justifyContent: "space-between", paddingTop: "8px", borderTop: "1px solid var(--qa-border)", margin: "0 16px 16px 16px", paddingBottom: 0, paddingLeft: 0, paddingRight: 0 }}>
+            <div className="qa-edit-actions is-row">
                 <div style={{ position: "relative" }}>
-                    <button type="button" className="qa-circle-btn qa-attach-btn" onClick={() => setEditAttachMenuOpen(!editAttachMenuOpen)} style={{ background: "transparent", border: "1px solid var(--qa-border)", color: "inherit" }}>
-                         <Plus size={16} style={{ transform: editAttachMenuOpen ? 'rotate(45deg)' : 'none', transition: 'transform 0.2s', opacity: 0.7 }} />
+                    <button type="button" className={`qa-circle-btn qa-attach-btn ${editAttachMenuOpen ? "is-active" : ""}`} onClick={() => setEditAttachMenuOpen(!editAttachMenuOpen)}>
+                         <Plus size={17} strokeWidth={2.2} style={{ transform: editAttachMenuOpen ? 'rotate(45deg)' : 'none', transition: 'transform 0.2s' }} />
                     </button>
                     {editAttachMenuOpen && (
                         <>
                             <div style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, zIndex: 90 }} onClick={() => setEditAttachMenuOpen(false)} />
-                            <div style={{ position: "absolute", bottom: "100%", left: 0, marginBottom: "8px", background: "var(--qa-bg-elevated)", border: "1px solid var(--qa-border)", borderRadius: "12px", padding: "6px", display: "flex", flexDirection: "column", gap: "2px", zIndex: 100, boxShadow: "0 4px 12px rgba(0,0,0,0.1)", minWidth: "110px" }}>
-                                <button type="button" className="qa-drawer-menu-btn" style={{ justifyContent: "flex-start", padding: "8px 12px" }} onClick={() => { setEditAttachMenuOpen(false); fileInputRef.current?.click(); }}>
-                                    <FileText size={15} style={{ marginRight: "8px", opacity: 0.7 }} /> 上传附件
+                            <div className="qa-dropdown-menu">
+                                <button type="button" className="qa-drawer-menu-btn" onClick={() => { setEditAttachMenuOpen(false); fileInputRef.current?.click(); }}>
+                                    <FileText size={15} className="qa-drawer-menu-icon" /> 📄 上传附件
                                 </button>
                                 {visionEnabled && (
-                                    <button type="button" className="qa-drawer-menu-btn" style={{ justifyContent: "flex-start", padding: "8px 12px" }} onClick={() => {
+                                    <button type="button" className="qa-drawer-menu-btn" onClick={() => {
                                         setEditAttachMenuOpen(false);
                                         imageInputRef.current?.setAttribute('data-edit-mode', 'true');
                                         imageInputRef.current?.click();
                                     }}>
-                                        <ImageIcon size={15} style={{ marginRight: "8px", opacity: 0.7 }} /> 上传图片
+                                        <ImageIcon size={15} className="qa-drawer-menu-icon" /> 🖼️ 上传图片
                                     </button>
                                 )}
                             </div>
@@ -1395,7 +1394,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                     )}
                 </div>
 
-                <div style={{ display: "flex", gap: "8px" }}>
+                <div className="qa-edit-buttons">
                     <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
                         保存
                     </button>

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -1184,7 +1184,11 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                 multiple
                 accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
                 style={{ display: "none" }}
-                onChange={(e) => handlePickFiles(e.target.files)}
+                onChange={(e) => {
+                    const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
+                    handlePickFiles(e.target.files, isEditMode);
+                    e.target.removeAttribute('data-edit-mode'); // 读完清理标记
+                }}
             />
             {visionEnabled && (
                 <input
@@ -1193,7 +1197,11 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                   accept="image/*"
                   multiple
                   style={{ display: "none" }}
-                  onChange={(e) => handlePickImages(e.target.files)}
+                  onChange={(e) => {
+                      const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
+                      handlePickImages(e.target.files, isEditMode);
+                      e.target.removeAttribute('data-edit-mode'); // 读完清理标记
+                  }}
                 />
             )}
             
@@ -1387,28 +1395,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                     ))}
                 </div>
 
-                <div style={{ display: "none" }}>
-                     <input
-                        ref={imageInputRef}
-                        type="file"
-                        accept="image/*"
-                        multiple
-                        style={{ display: "none" }}
-                        onChange={(e) => {
-                            const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
-                            handlePickImages(e.target.files, isEditMode);
-                            e.target.removeAttribute('data-edit-mode');
-                        }}
-                    />
-                    <input
-                        ref={fileInputRef}
-                        type="file"
-                        multiple
-                        accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
-                        style={{ display: "none" }}
-                        onChange={(e) => handlePickFiles(e.target.files, true)}
-                    />
-                </div>
+                {/* 修改面板内部的隐藏 input 替身已被删除，统一调用主界面的 input，防止 ref 丢失导致按钮失效 */}
                 
                 {/* 菜单移到这里，取消绝对定位，融入正常排版，自动撑开高度并完美左对齐 */}
                 {editAttachMenuOpen && (

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -1482,4 +1482,3 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
     </div>
   );
 }
-```eof

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -4,7 +4,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExterna
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
-import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, MoreVertical, Pencil, Pin, PinOff, Play, Plus, Square, Trash2, Wrench, X } from "lucide-react";
+import { AppWindow, ArrowUp, BrushCleaning, Check, ChevronLeft, ChevronRight, Copy, Drama, Gamepad2, Github, Loader2, Menu, MoreVertical, Pencil, Pin, PinOff, Play, Plus, Square, Trash2, Wrench, X, Paperclip, FileText } from "lucide-react";
 import { QaFileCard } from "@/components/qa-file-card";
 import { parseQaFileMarker } from "@/lib/qa-computer-tools";
 import { mdiHammerWrench } from "@mdi/js";
@@ -15,1320 +15,1455 @@ import { BlackMarketApp } from "@/components/shopping/black-market-app";
 import { getInstalledCustomApp } from "@/lib/custom-app-storage";
 import type { QaCreatedContent } from "@/lib/qa-agent-tools";
 import {
-  applyQaCommit,
-  cancelQaCommit,
-  clearQaToolHistory,
-  createQaSession,
-  deleteQaSession,
-  getQaActiveContextChars,
-  getQaChatSnapshot,
-  getQaContextBudgetChars,
-  hasQaToolHistory,
-  hydrateQaChat,
-  QA_CONTEXT_BUDGET_MAX,
-  QA_CONTEXT_BUDGET_MIN,
-  QA_DEFAULT_CONTEXT_BUDGET_CHARS,
-  setQaContextBudgetChars,
-  retryQaMessage,
-  renameQaSession,
-  revertQaAppliedCommit,
-  sendQaMessage,
-  stopQaGeneration,
-  subscribeQaChat,
-  switchQaSession,
-  toggleQaSessionPin,
-  updateQaMessageContent,
-  type QaMsg,
-  type QaSession,
-  type QaToolStatus,
+applyQaCommit,
+cancelQaCommit,
+clearQaToolHistory,
+createQaSession,
+deleteQaSession,
+getQaActiveContextChars,
+getQaChatSnapshot,
+getQaContextBudgetChars,
+hasQaToolHistory,
+hydrateQaChat,
+QA_CONTEXT_BUDGET_MAX,
+QA_CONTEXT_BUDGET_MIN,
+QA_DEFAULT_CONTEXT_BUDGET_CHARS,
+setQaContextBudgetChars,
+retryQaMessage,
+renameQaSession,
+revertQaAppliedCommit,
+sendQaMessage,
+stopQaGeneration,
+subscribeQaChat,
+switchQaSession,
+toggleQaSessionPin,
+updateQaMessageContent,
+editAndResendQaMessage,
+type QaMsg,
+type QaSession,
+type QaToolStatus,
 } from "@/lib/qa-chat-store";
 import {
-  getQaPageChars,
-  setQaPageChars,
-  QA_DEFAULT_PAGE_CHARS,
-  QA_PAGE_CHARS_MIN,
-  QA_PAGE_CHARS_MAX,
-  getQaMaxRounds,
-  setQaMaxRounds,
-  QA_DEFAULT_MAX_ROUNDS,
-  QA_MAX_ROUNDS_MIN,
-  QA_MAX_ROUNDS_MAX,
-  getQaMaxOutputTokens,
-  setQaMaxOutputTokens,
-  QA_DEFAULT_MAX_OUTPUT_TOKENS,
-  QA_MAX_OUTPUT_TOKENS_MIN,
-  QA_MAX_OUTPUT_TOKENS_MAX,
+getQaPageChars,
+setQaPageChars,
+QA_DEFAULT_PAGE_CHARS,
+QA_PAGE_CHARS_MIN,
+QA_PAGE_CHARS_MAX,
+getQaMaxRounds,
+setQaMaxRounds,
+QA_DEFAULT_MAX_ROUNDS,
+QA_MAX_ROUNDS_MIN,
+QA_MAX_ROUNDS_MAX,
+getQaMaxOutputTokens,
+setQaMaxOutputTokens,
+QA_DEFAULT_MAX_OUTPUT_TOKENS,
+QA_MAX_OUTPUT_TOKENS_MIN,
+QA_MAX_OUTPUT_TOKENS_MAX,
 } from "@/lib/qa-prefs";
 import { resolveQaApiConfig } from "@/lib/qa-agent-engine";
 import {
-  loadQaGithubConfig,
-  saveQaGithubConfig,
-  clearQaGithubConfig,
-  validateQaGithubConfig,
-  type QaGithubConfig,
-  type QaGithubValidation,
+loadQaGithubConfig,
+saveQaGithubConfig,
+clearQaGithubConfig,
+validateQaGithubConfig,
+type QaGithubConfig,
+type QaGithubValidation,
 } from "@/lib/qa-github";
 import "@/lib/qa-error-log";
 
 type PhoneQaAppProps = {
-  onClose: () => void;
-  onNotice?: (msg: string) => void;
+onClose: () => void;
+onNotice?: (msg: string) => void;
 };
 
 const SUGGESTIONS = [
-  "怎么添加我的 API？",
-  "聊天没有回复怎么排查？",
-  "怎么部署到 Netlify / Vercel？",
-  "数据存在哪里，怎么备份？",
-  "帮我写个小游戏装到本机",
+"怎么添加我的 API？",
+"聊天没有回复怎么排查？",
+"怎么部署到 Netlify / Vercel？",
+"数据存在哪里，怎么备份？",
+"帮我写个小游戏装到本机",
 ];
 
 function formatRelativeTime(ts: number): string {
-  const diff = Date.now() - ts;
-  if (diff < 60_000) return "刚刚";
-  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟前`;
-  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前`;
-  return `${Math.floor(diff / 86_400_000)} 天前`;
+const diff = Date.now() - ts;
+if (diff < 60_000) return "刚刚";
+if (diff < 3_600_000) return ${Math.floor(diff / 60_000)} 分钟前;
+if (diff < 86_400_000) return ${Math.floor(diff / 3_600_000)} 小时前;
+return ${Math.floor(diff / 86_400_000)} 天前;
 }
 
 // ── 代码块（语言标签 + 一键复制）─────────────────────
 
 function QaCodeBlock({ className, children }: { className?: string; children?: React.ReactNode }) {
-  const [copied, setCopied] = useState(false);
-  const language = /language-(\w+)/.exec(className || "")?.[1] ?? "";
-  const code = String(children ?? "").replace(/\n$/, "");
+const [copied, setCopied] = useState(false);
+const language = /language-(\w+)/.exec(className || "")?.[1] ?? "";
+const code = String(children ?? "").replace(/\n$/, "");
 
-  const handleCopy = useCallback(() => {
-    navigator.clipboard
-      ?.writeText(code)
-      .then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      })
-      .catch(() => {});
-  }, [code]);
+const handleCopy = useCallback(() => {
+navigator.clipboard
+?.writeText(code)
+.then(() => {
+setCopied(true);
+setTimeout(() => setCopied(false), 1500);
+})
+.catch(() => {});
+}, [code]);
 
-  return (
-    <div className="qa-codeblock">
-      <div className="qa-codeblock-head">
-        <span className="qa-codeblock-lang">{language || "code"}</span>
-        <button type="button" className="qa-codeblock-copy" onClick={handleCopy} aria-label="复制代码">
-          {copied ? <Check size={13} /> : <Copy size={13} />}
-        </button>
-      </div>
-      <pre>
-        <code>{code}</code>
-      </pre>
-    </div>
-  );
+return (
+
+
+{language || "code"}
+
+{copied ?  : }
+
+
+
+{code}
+
+
+);
 }
 
 const QA_MARKDOWN_COMPONENTS = {
-  pre({ children }: { children?: React.ReactNode }) {
-    return <>{children}</>;
-  },
-  code(props: { className?: string; children?: React.ReactNode }) {
-    const { className, children } = props;
-    const isBlock = /language-/.test(className || "") || String(children ?? "").includes("\n");
-    if (isBlock) return <QaCodeBlock className={className}>{children}</QaCodeBlock>;
-    return <code className="qa-inline-code">{children}</code>;
-  },
-  a({ href, children }: { href?: string; children?: React.ReactNode }) {
-    return (
-      <a href={href} target="_blank" rel="noreferrer noopener">
-        {children}
-      </a>
-    );
-  },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+pre({ children }: { children?: React.ReactNode }) {
+return <>{children}</>;
+},
+code(props: { className?: string; children?: React.ReactNode }) {
+const { className, children } = props;
+const isBlock = /language-/.test(className || "") || String(children ?? "").includes("\n");
+if (isBlock) return {children};
+return {children};
+},
+a({ href, children }: { href?: string; children?: React.ReactNode }) {
+return (
+
+{children}
+
+);
+},
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any;
 
 // ── 提交提案卡片 ─────────────────────────────────────
 
 function QaCommitCard({ msg }: { msg: QaMsg }) {
-  const pending = msg.pendingCommit;
-  const [busy, setBusy] = useState(false);
-  if (!pending) return null;
-  const { proposal, status, result, error } = pending;
-  const files = proposal.files;
+const pending = msg.pendingCommit;
+const [busy, setBusy] = useState(false);
+if (!pending) return null;
+const { proposal, status, result, error } = pending;
+const files = proposal.files;
 
-  const apply = async () => {
-    setBusy(true);
-    await applyQaCommit(msg.id);
-    setBusy(false);
-  };
-  const revert = async () => {
-    setBusy(true);
-    await revertQaAppliedCommit(msg.id);
-    setBusy(false);
-  };
+const apply = async () => {
+setBusy(true);
+await applyQaCommit(msg.id);
+setBusy(false);
+};
+const revert = async () => {
+setBusy(true);
+await revertQaAppliedCommit(msg.id);
+setBusy(false);
+};
 
-  return (
-    <div className={`qa-commit-card status-${status}`}>
-      <div className="qa-commit-head">
-        <span className="qa-commit-title">
-          {status === "applied" ? "已提交" : status === "reverted" ? "已撤销" : status === "canceled" ? "已取消" : "修改提案"}
-        </span>
-        <span className="qa-commit-branch">{proposal.branch || "默认分支"} · {files.length + (proposal.deletes?.length ?? 0)} 个文件</span>
-      </div>
-      <div className="qa-commit-msg">{proposal.message}</div>
-      <ul className="qa-commit-files">
-        {files.map((f) => (
-          <li key={f.path}>{f.path}</li>
-        ))}
-        {(proposal.deletes ?? []).map((path) => (
-          <li key={`del-${path}`} className="qa-commit-file-delete">− {path}（删除）</li>
-        ))}
-      </ul>
-      {error && <div className="qa-commit-error">{error}</div>}
-      {status === "pending" && (
-        <div className="qa-commit-actions">
-          <button type="button" className="qa-commit-btn is-primary" onClick={apply} disabled={busy}>
-            {busy ? <Loader2 size={13} className="qa-spin" /> : "应用"}
-          </button>
-          <button type="button" className="qa-commit-btn" onClick={() => cancelQaCommit(msg.id)} disabled={busy}>
-            取消
-          </button>
-        </div>
-      )}
-      {(status === "applying" || status === "reverting") && (
-        <div className="qa-commit-actions">
-          <span className="qa-commit-progress">
-            <Loader2 size={13} className="qa-spin" /> {status === "applying" ? "提交中…" : "撤销中…"}
-          </span>
-        </div>
-      )}
-      {status === "applied" && result && (
-        <div className="qa-commit-actions">
-          <a className="qa-commit-link" href={result.htmlUrl} target="_blank" rel="noreferrer noopener">
-            查看 commit {result.sha.slice(0, 7)}
-          </a>
-          <button type="button" className="qa-commit-btn is-danger" onClick={revert} disabled={busy}>
-            撤销
-          </button>
-        </div>
-      )}
-    </div>
-  );
+return (
+<div className={qa-commit-card status-${status}}>
+
+
+{status === "applied" ? "已提交" : status === "reverted" ? "已撤销" : status === "canceled" ? "已取消" : "修改提案"}
+
+{proposal.branch || "默认分支"} · {files.length + (proposal.deletes?.length ?? 0)} 个文件
+
+{proposal.message}
+
+{files.map((f) => (
+{f.path}
+))}
+{(proposal.deletes ?? []).map((path) => (
+<li key={del-${path}} className="qa-commit-file-delete">− {path}（删除）
+))}
+
+{error && {error}}
+{status === "pending" && (
+
+
+{busy ?  : "应用"}
+
+<button type="button" className="qa-commit-btn" onClick={() => cancelQaCommit(msg.id)} disabled={busy}>
+取消
+
+
+)}
+{(status === "applying" || status === "reverting") && (
+
+
+ {status === "applying" ? "提交中…" : "撤销中…"}
+
+
+)}
+{status === "applied" && result && (
+
+
+查看 commit {result.sha.slice(0, 7)}
+
+
+撤销
+
+
+)}
+
+);
 }
 
 // ── 消息渲染 ─────────────────────────────────────────
 
 // 工具调用行：折叠的单行摘要，点开展开参数与结果（Claude Code 风格）
 function QaToolRow({ tool }: { tool: QaToolStatus }) {
-  const [open, setOpen] = useState(false);
-  // 「电脑文件 op=send」的结果里带文件卡标记：卡片常显，标记从结果文本中剥离
-  const { text: resultText, file } = parseQaFileMarker(tool.result || "");
-  const hasDetail = Boolean(tool.detail || resultText);
-  const summary = tool.running ? `正在${tool.name}…` : tool.success === false ? `${tool.name}失败` : tool.name;
-  return (
-    <div className={`qa-tool-row ${tool.running ? "is-running" : tool.success === false ? "is-fail" : "is-done"}`}>
-      <button
-        type="button"
-        className="qa-tool-row-head"
-        onClick={() => hasDetail && setOpen((v) => !v)}
-        disabled={!hasDetail}
-      >
-        {tool.running ? <Loader2 size={13} className="qa-spin" /> : <Wrench size={13} />}
-        <span className="qa-tool-row-summary">
-          {summary}
-          {tool.subtitle && <span className="qa-tool-row-sub">{tool.subtitle}</span>}
-        </span>
-        {hasDetail && <ChevronRight size={14} className={`qa-tool-row-chevron ${open ? "is-open" : ""}`} />}
-      </button>
-      {open && hasDetail && (
-        <div className="qa-tool-row-body">
-          {tool.detail && (
-            <>
-              <div className="qa-tool-row-label">参数</div>
-              <pre className="qa-tool-row-pre">{tool.detail}</pre>
-            </>
-          )}
-          {resultText && (
-            <>
-              <div className="qa-tool-row-label">结果</div>
-              <pre className="qa-tool-row-pre">{resultText}</pre>
-            </>
-          )}
-        </div>
-      )}
-      {file && <QaFileCard file={file} />}
-    </div>
-  );
+const [open, setOpen] = useState(false);
+// 「电脑文件 op=send」的结果里带文件卡标记：卡片常显，标记从结果文本中剥离
+const { text: resultText, file } = parseQaFileMarker(tool.result || "");
+const hasDetail = Boolean(tool.detail || resultText);
+const summary = tool.running ? 正在${tool.name}… : tool.success === false ? ${tool.name}失败 : tool.name;
+return (
+<div className={qa-tool-row ${tool.running ? "is-running" : tool.success === false ? "is-fail" : "is-done"}}>
+<button
+type="button"
+className="qa-tool-row-head"
+onClick={() => hasDetail && setOpen((v) => !v)}
+disabled={!hasDetail}
+>
+{tool.running ?  : }
+
+{summary}
+{tool.subtitle && {tool.subtitle}}
+
+{hasDetail && <ChevronRight size={14} className={qa-tool-row-chevron ${open ? "is-open" : ""}} />}
+
+{open && hasDetail && (
+
+{tool.detail && (
+<>
+参数
+{tool.detail}
+</>
+)}
+{resultText && (
+<>
+结果
+{resultText}
+</>
+)}
+
+)}
+{file && }
+
+);
 }
 
 // 已完成文本的 Markdown 渲染：memo 缓存——流式期间每次增量都全文重排 remark 是
 // 低端机 WebView OOM 崩溃的主因（几万字 × 每秒多次解析）。文本不变就不重渲。
 const QaMarkdownBlock = memo(function QaMarkdownBlock({ text }: { text: string }) {
-  return (
-    <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={QA_MARKDOWN_COMPONENTS}>
-      {text}
-    </ReactMarkdown>
-  );
+return (
+<ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={QA_MARKDOWN_COMPONENTS}>
+{text}
+
+);
 });
 
 // 正在生长的活跃段：纯文本渲染（零解析成本），生成结束后换回完整 Markdown
 function QaStreamingText({ text }: { text: string }) {
-  return (
-    <>
-      <div className="qa-stream-text">{text}</div>
-      <span className="qa-cursor" />
-    </>
-  );
+return (
+<>
+{text}
+
+</>
+);
 }
 
 const QaMessageItem = memo(function QaMessageItem({
-  msg,
-  isStreaming,
-  onRetry,
-  onViewImage,
-  onCopy,
-  onEdit,
+msg,
+isStreaming,
+onRetry,
+onViewImage,
+onCopy,
+onEdit,
 }: {
-  msg: QaMsg;
-  isStreaming: boolean;
-  onRetry: (id: string) => void;
-  onViewImage: (url: string) => void;
-  onCopy: (content: string) => void;
-  onEdit: (msg: QaMsg) => void;
+msg: QaMsg;
+isStreaming: boolean;
+onRetry: (id: string) => void;
+onViewImage: (url: string) => void;
+onCopy: (content: string) => void;
+onEdit: (msg: QaMsg) => void;
 }) {
-  const thinkingOnly = isStreaming && !msg.content && (!msg.tools || msg.tools.length === 0);
-  // 消息操作（复制原始内容 / 编辑原始内容——前端渲染会吞掉一些特殊标签，
-  // 沟通时看不到原文）常驻在气泡下方，不用长按触发：长按要跟系统的选词、
-  // 取词、划词搜索抢同一个手势，在移动端几乎必然打架。
-  // 生成中不显示（内容还不完整，复制/编辑都没有意义）。
-  const showActions = !isStreaming && !thinkingOnly;
-  const msgWrap = (node: ReactNode) => (
-    <div className="qa-msg-wrap">
-      {node}
-      {showActions && (
-        <div className="qa-msg-actions" data-role={msg.role}>
-          <button type="button" className="qa-msg-action" aria-label="复制原始内容" title="复制" onClick={() => onCopy(msg.content)}>
-            <Copy size={14} strokeWidth={2} />
-          </button>
-          <button type="button" className="qa-msg-action" aria-label="编辑原始内容" title="编辑" onClick={() => onEdit(msg)}>
-            <Pencil size={14} strokeWidth={2} />
-          </button>
-        </div>
-      )}
-    </div>
-  );
-  // 时序分段渲染：文字与工具行按实际发生顺序交错（连续工具行合并成一组）；
-  // 旧消息没有 segments 时回退「工具在顶、文字在下」布局。
-  // hooks 必须在 user 分支 early-return 之前调用（rules-of-hooks）
-  const segmentBlocks = useMemo(() => {
-    if (!msg.segments?.length) return null;
-    const blocks: Array<{ kind: "text"; text: string } | { kind: "tools"; tools: QaToolStatus[] }> = [];
-    for (const seg of msg.segments) {
-      const last = blocks[blocks.length - 1];
-      if (seg.kind === "tool") {
-        if (last?.kind === "tools") last.tools.push(seg.tool);
-        else blocks.push({ kind: "tools", tools: [seg.tool] });
-      } else if (seg.text.trim()) {
-        if (last?.kind === "text") last.text += seg.text;
-        else blocks.push({ kind: "text", text: seg.text });
-      }
-    }
-    return blocks.length ? blocks : null;
-  }, [msg.segments]);
+const thinkingOnly = isStreaming && !msg.content && (!msg.tools || msg.tools.length === 0);
+const showActions = !isStreaming && !thinkingOnly;
+const msgWrap = (node: ReactNode) => (
 
-  if (msg.role === "user") {
-    return msgWrap(
-      <div className="qa-msg-user-row">
-        <div className="qa-msg-user">
-          {msg.images && msg.images.length > 0 && (
-            <div className="qa-msg-images">
-              {msg.images.map((url, i) => (
-                <button key={i} type="button" className="qa-msg-image" onClick={() => onViewImage(url)} aria-label="查看图片">
-                  <img src={url} alt="" />
-                </button>
-              ))}
-            </div>
-          )}
-          {msg.content}
-        </div>
-      </div>,
-    );
-  }
+{node}
+{showActions && (
 
-  return msgWrap(
-    <div className="qa-msg-assistant">
-      {segmentBlocks ? (
-        segmentBlocks.map((block, i) =>
-          block.kind === "tools" ? (
-            <div className="qa-tools" key={i}>
-              {block.tools.map((tool, j) => (
-                <QaToolRow key={`${tool.name}-${j}`} tool={tool} />
-              ))}
-            </div>
-          ) : isStreaming && i === segmentBlocks.length - 1 ? (
-            <div className="qa-markdown" key={i}>
-              <QaStreamingText text={block.text} />
-            </div>
-          ) : (
-            <div className="qa-markdown" key={i}>
-              <QaMarkdownBlock text={block.text} />
-            </div>
-          ),
-        )
-      ) : (
-        <>
-          {msg.tools && msg.tools.length > 0 && (
-            <div className="qa-tools">
-              {msg.tools.map((tool, i) => (
-                <QaToolRow key={`${tool.name}-${i}`} tool={tool} />
-              ))}
-            </div>
-          )}
-          {thinkingOnly ? (
-            <div className="qa-thinking">{msg.toolDrafting ? "正在编写工具调用…" : msg.reasoning ? "正在思考…" : "正在生成…"}</div>
-          ) : isStreaming ? (
-            <div className="qa-markdown">
-              <QaStreamingText text={msg.content} />
-            </div>
-          ) : (
-            <div className="qa-markdown">
-              <QaMarkdownBlock text={msg.content} />
-            </div>
-          )}
-        </>
-      )}
-      {isStreaming && msg.toolDrafting && !thinkingOnly && (
-        <div className="qa-thinking qa-tool-drafting">正在编写工具调用…</div>
-      )}
-      {msg.streamNote && <div className="qa-msg-note">{msg.streamNote}</div>}
-      {msg.pendingCommit && <QaCommitCard msg={msg} />}
-      {msg.aborted && <div className="qa-msg-note">已停止生成</div>}
-      {msg.error && (
-        <div className="qa-msg-error">
-          <div className="qa-msg-error-text">{msg.error}</div>
-          <button type="button" className="qa-retry-btn" onClick={() => onRetry(msg.id)}>
-            重试
-          </button>
-        </div>
-      )}
-    </div>,
-  );
+<button type="button" className="qa-msg-action" aria-label="复制原始内容" title="复制" onClick={() => onCopy(msg.content)}>
+
+
+<button type="button" className="qa-msg-action" aria-label="修改消息" title="修改" onClick={() => onEdit(msg)}>
+
+
+
+)}
+
+);
+
+const segmentBlocks = useMemo(() => {
+if (!msg.segments?.length) return null;
+const blocks: Array<{ kind: "text"; text: string } | { kind: "tools"; tools: QaToolStatus[] }> = [];
+for (const seg of msg.segments) {
+const last = blocks[blocks.length - 1];
+if (seg.kind === "tool") {
+if (last?.kind === "tools") last.tools.push(seg.tool);
+else blocks.push({ kind: "tools", tools: [seg.tool] });
+} else if (seg.text.trim()) {
+if (last?.kind === "text") last.text += seg.text;
+else blocks.push({ kind: "text", text: seg.text });
+}
+}
+return blocks.length ? blocks : null;
+}, [msg.segments]);
+
+if (msg.role === "user") {
+return msgWrap(
+
+
+{msg.images && msg.images.length > 0 && (
+
+{msg.images.map((url, i) => (
+<button key={i} type="button" className="qa-msg-image" onClick={() => onViewImage(url)} aria-label="查看图片">
+
+
+))}
+
+)}
+{msg.files && msg.files.length > 0 && (
+<div className="qa-msg-files" style={{ display: "flex", flexDirection: "column", gap: "4px", marginBottom: "8px" }}>
+{msg.files.map((f, i) => (
+<div key={i} style={{ display: "flex", alignItems: "center", gap: "6px", background: "rgba(255,255,255,0.1)", padding: "4px 8px", borderRadius: "6px", fontSize: "12px", border: "1px solid rgba(255,255,255,0.2)" }}>
+
+<span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: "150px" }}>{f.name}
+
+))}
+
+)}
+{msg.content}
+
+,
+);
+}
+
+return msgWrap(
+
+{segmentBlocks ? (
+segmentBlocks.map((block, i) =>
+block.kind === "tools" ? (
+
+{block.tools.map((tool, j) => (
+<QaToolRow key={${tool.name}-${j}} tool={tool} />
+))}
+
+) : isStreaming && i === segmentBlocks.length - 1 ? (
+
+
+
+) : (
+
+
+
+),
+)
+) : (
+<>
+{msg.tools && msg.tools.length > 0 && (
+
+{msg.tools.map((tool, i) => (
+<QaToolRow key={${tool.name}-${i}} tool={tool} />
+))}
+
+)}
+{thinkingOnly ? (
+{msg.toolDrafting ? "正在编写工具调用…" : msg.reasoning ? "正在思考…" : "正在生成…"}
+) : isStreaming ? (
+
+
+
+) : (
+
+
+
+)}
+</>
+)}
+{isStreaming && msg.toolDrafting && !thinkingOnly && (
+正在编写工具调用…
+)}
+{msg.streamNote && {msg.streamNote}}
+{msg.pendingCommit && }
+{msg.aborted && 已停止生成}
+{msg.error && (
+
+{msg.error}
+<button type="button" className="qa-retry-btn" onClick={() => onRetry(msg.id)}>
+重试
+
+
+)}
+,
+);
 });
 
 // ── 会话抽屉 ─────────────────────────────────────────
 
 function QaSessionDrawer({
-  sessions,
-  activeId,
-  onSelect,
-  onDelete,
-  onCreate,
-  onOpenSettings,
-  onRenameRequest,
+sessions,
+activeId,
+onSelect,
+onDelete,
+onCreate,
+onOpenSettings,
+onRenameRequest,
 }: {
-  sessions: QaSession[];
-  activeId: string | null;
-  onSelect: (id: string) => void;
-  onDelete: (id: string) => void;
-  onCreate: () => void;
-  onOpenSettings: () => void;
-  onRenameRequest: (id: string, title: string) => void;
+sessions: QaSession[];
+activeId: string | null;
+onSelect: (id: string) => void;
+onDelete: (id: string) => void;
+onCreate: () => void;
+onOpenSettings: () => void;
+onRenameRequest: (id: string, title: string) => void;
 }) {
-  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 
-  // 置顶的排最前，其余保持时间序。只在渲染层排，存储顺序不动
-  const sortedSessions = useMemo(() => {
-    return [...sessions].sort((a, b) => {
-      if (Boolean(a.isPinned) !== Boolean(b.isPinned)) return a.isPinned ? -1 : 1;
-      return b.updatedAt - a.updatedAt;
-    });
-  }, [sessions]);
+// 置顶的排最前，其余保持时间序。只在渲染层排，存储顺序不动
+const sortedSessions = useMemo(() => {
+return [...sessions].sort((a, b) => {
+if (Boolean(a.isPinned) !== Boolean(b.isPinned)) return a.isPinned ? -1 : 1;
+return b.updatedAt - a.updatedAt;
+});
+}, [sessions]);
 
-  return (
-    <aside className="qa-drawer">
-      <div className="qa-drawer-head">
-        <span className="qa-drawer-title">对话记录</span>
-      </div>
-      <div
-        className="qa-drawer-list hide-scrollbar"
-        onClick={() => { if (menuOpenId) setMenuOpenId(null); }}
-      >
-        {sortedSessions.length === 0 && <div className="qa-drawer-empty">还没有对话</div>}
-        {sortedSessions.map((session) => (
-          <div
-            key={session.id}
-            className={`qa-drawer-item ${session.id === activeId ? "is-active" : ""}`}
-            onClick={() => onSelect(session.id)}
-          >
-            <div className="qa-drawer-item-main">
-              <span className="qa-drawer-item-title">
-                {session.isPinned && <Pin size={12} className="qa-drawer-pin-mark" aria-label="已置顶" />}
-                {session.title}
-              </span>
-              <span className="qa-drawer-item-time">{formatRelativeTime(session.updatedAt)}</span>
-            </div>
+return (
+
+
+对话记录
+
+<div
+className="qa-drawer-list hide-scrollbar"
+onClick={() => { if (menuOpenId) setMenuOpenId(null); }}
+>
+{sortedSessions.length === 0 && 还没有对话}
+{sortedSessions.map((session) => (
+<div
+key={session.id}
+className={qa-drawer-item ${session.id === activeId ? "is-active" : ""}}
+onClick={() => onSelect(session.id)}
+>
+
+
+{session.isPinned && }
+{session.title}
+
+{formatRelativeTime(session.updatedAt)}
+
+<button
+type="button"
+className="qa-icon-btn qa-drawer-item-more"
+aria-label="更多操作"
+aria-expanded={menuOpenId === session.id}
+onClick={(e) => {
+e.stopPropagation();
+setMenuOpenId(menuOpenId === session.id ? null : session.id);
+}}
+>
+
+
+
+        {menuOpenId === session.id && (
+          <div className="qa-drawer-item-menu" role="menu">
             <button
               type="button"
-              className="qa-icon-btn qa-drawer-item-more"
-              aria-label="更多操作"
-              aria-expanded={menuOpenId === session.id}
+              role="menuitem"
+              className="qa-drawer-menu-btn"
               onClick={(e) => {
                 e.stopPropagation();
-                setMenuOpenId(menuOpenId === session.id ? null : session.id);
+                toggleQaSessionPin(session.id);
+                setMenuOpenId(null);
               }}
             >
-              <MoreVertical size={14} />
+              {session.isPinned ? <PinOff size={14} /> : <Pin size={14} />}
+              {session.isPinned ? "取消置顶" : "置顶"}
             </button>
-
-            {menuOpenId === session.id && (
-              <div className="qa-drawer-item-menu" role="menu">
-                <button
-                  type="button"
-                  role="menuitem"
-                  className="qa-drawer-menu-btn"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    toggleQaSessionPin(session.id);
-                    setMenuOpenId(null);
-                  }}
-                >
-                  {session.isPinned ? <PinOff size={14} /> : <Pin size={14} />}
-                  {session.isPinned ? "取消置顶" : "置顶"}
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className="qa-drawer-menu-btn"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onRenameRequest(session.id, session.title);
-                    setMenuOpenId(null);
-                  }}
-                >
-                  <Pencil size={14} /> 重命名
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className="qa-drawer-menu-btn is-danger"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDelete(session.id);
-                    setMenuOpenId(null);
-                  }}
-                >
-                  <Trash2 size={14} /> 删除
-                </button>
-              </div>
-            )}
+            <button
+              type="button"
+              role="menuitem"
+              className="qa-drawer-menu-btn"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRenameRequest(session.id, session.title);
+                setMenuOpenId(null);
+              }}
+            >
+              <Pencil size={14} /> 重命名
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className="qa-drawer-menu-btn is-danger"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(session.id);
+                setMenuOpenId(null);
+              }}
+            >
+              <Trash2 size={14} /> 删除
+            </button>
           </div>
-        ))}
+        )}
       </div>
-      <div className="qa-drawer-foot">
-        <button type="button" className="qa-drawer-new qa-drawer-settings" onClick={onOpenSettings}>
-          <Wrench size={15} strokeWidth={2} />
-          <span>工坊配置</span>
-        </button>
-        <button type="button" className="qa-drawer-new" onClick={onCreate}>
-          <Plus size={16} strokeWidth={2} />
-          <span>新对话</span>
-        </button>
-      </div>
-    </aside>
-  );
+    ))}
+  </div>
+  <div className="qa-drawer-foot">
+    <button type="button" className="qa-drawer-new qa-drawer-settings" onClick={onOpenSettings}>
+      <Wrench size={15} strokeWidth={2} />
+      <span>工坊配置</span>
+    </button>
+    <button type="button" className="qa-drawer-new" onClick={onCreate}>
+      <Plus size={16} strokeWidth={2} />
+      <span>新对话</span>
+    </button>
+  </div>
+</aside>
+
+
+);
 }
 
 // ── 工坊配置面板 ─────────────────────────────────────
 
 function QaSettingsSheet({ onClose, onNotice }: { onClose: () => void; onNotice?: (msg: string) => void }) {
-  const [budget, setBudget] = useState(() => String(getQaContextBudgetChars()));
-  const [pageChars, setPageChars] = useState(() => String(getQaPageChars()));
-  const [maxRounds, setMaxRounds] = useState(() => String(getQaMaxRounds()));
-  const [maxOutTokens, setMaxOutTokens] = useState(() => {
-    const v = getQaMaxOutputTokens();
-    return v == null ? "" : String(v);
-  });
-  const usedChars = getQaActiveContextChars();
-  const pct = Math.round((usedChars / getQaContextBudgetChars()) * 100);
+const [budget, setBudget] = useState(() => String(getQaContextBudgetChars()));
+const [pageChars, setPageChars] = useState(() => String(getQaPageChars()));
+const [maxRounds, setMaxRounds] = useState(() => String(getQaMaxRounds()));
+const [maxOutTokens, setMaxOutTokens] = useState(() => {
+const v = getQaMaxOutputTokens();
+return v == null ? "" : String(v);
+});
+const usedChars = getQaActiveContextChars();
+const pct = Math.round((usedChars / getQaContextBudgetChars()) * 100);
 
-  const save = () => {
-    const parsed = Number(budget);
-    if (!Number.isFinite(parsed) || parsed < QA_CONTEXT_BUDGET_MIN || parsed > QA_CONTEXT_BUDGET_MAX) {
-      onNotice?.(`预算需为 ${QA_CONTEXT_BUDGET_MIN.toLocaleString()} - ${QA_CONTEXT_BUDGET_MAX.toLocaleString()} 之间的数字。`);
-      return;
-    }
-    const parsedPage = Number(pageChars);
-    if (!Number.isFinite(parsedPage) || parsedPage < QA_PAGE_CHARS_MIN || parsedPage > QA_PAGE_CHARS_MAX) {
-      onNotice?.(`单页字符数需为 ${QA_PAGE_CHARS_MIN.toLocaleString()} - ${QA_PAGE_CHARS_MAX.toLocaleString()} 之间的数字。`);
-      return;
-    }
-    const parsedRounds = Number(maxRounds);
-    if (!Number.isFinite(parsedRounds) || parsedRounds < QA_MAX_ROUNDS_MIN || parsedRounds > QA_MAX_ROUNDS_MAX) {
-      onNotice?.(`工具调用上限需为 ${QA_MAX_ROUNDS_MIN} - ${QA_MAX_ROUNDS_MAX} 之间的数字。`);
-      return;
-    }
-    const trimmedTokens = maxOutTokens.trim();
-    const parsedTokens = trimmedTokens ? Number(trimmedTokens) : null;
-    if (parsedTokens != null && (!Number.isFinite(parsedTokens) || parsedTokens < QA_MAX_OUTPUT_TOKENS_MIN || parsedTokens > QA_MAX_OUTPUT_TOKENS_MAX)) {
-      onNotice?.(`单次最大输出 token 需留空或为 ${QA_MAX_OUTPUT_TOKENS_MIN.toLocaleString()} - ${QA_MAX_OUTPUT_TOKENS_MAX.toLocaleString()} 之间的数字。`);
-      return;
-    }
-    setQaContextBudgetChars(parsed);
-    setQaPageChars(parsedPage);
-    setQaMaxRounds(parsedRounds);
-    // 留空 = 显式不传 max_tokens（0 哨兵），与"没设置用默认值"区分开
-    setQaMaxOutputTokens(trimmedTokens ? parsedTokens : 0);
-    onNotice?.("已保存工坊配置。");
-    onClose();
-  };
+const save = () => {
+const parsed = Number(budget);
+if (!Number.isFinite(parsed) || parsed < QA_CONTEXT_BUDGET_MIN || parsed > QA_CONTEXT_BUDGET_MAX) {
+onNotice?.(预算需为 ${QA_CONTEXT_BUDGET_MIN.toLocaleString()} - ${QA_CONTEXT_BUDGET_MAX.toLocaleString()} 之间的数字。);
+return;
+}
+const parsedPage = Number(pageChars);
+if (!Number.isFinite(parsedPage) || parsedPage < QA_PAGE_CHARS_MIN || parsedPage > QA_PAGE_CHARS_MAX) {
+onNotice?.(单页字符数需为 ${QA_PAGE_CHARS_MIN.toLocaleString()} - ${QA_PAGE_CHARS_MAX.toLocaleString()} 之间的数字。);
+return;
+}
+const parsedRounds = Number(maxRounds);
+if (!Number.isFinite(parsedRounds) || parsedRounds < QA_MAX_ROUNDS_MIN || parsedRounds > QA_MAX_ROUNDS_MAX) {
+onNotice?.(工具调用上限需为 ${QA_MAX_ROUNDS_MIN} - ${QA_MAX_ROUNDS_MAX} 之间的数字。);
+return;
+}
+const trimmedTokens = maxOutTokens.trim();
+const parsedTokens = trimmedTokens ? Number(trimmedTokens) : null;
+if (parsedTokens != null && (!Number.isFinite(parsedTokens) || parsedTokens < QA_MAX_OUTPUT_TOKENS_MIN || parsedTokens > QA_MAX_OUTPUT_TOKENS_MAX)) {
+onNotice?.(单次最大输出 token 需留空或为 ${QA_MAX_OUTPUT_TOKENS_MIN.toLocaleString()} - ${QA_MAX_OUTPUT_TOKENS_MAX.toLocaleString()} 之间的数字。);
+return;
+}
+setQaContextBudgetChars(parsed);
+setQaPageChars(parsedPage);
+setQaMaxRounds(parsedRounds);
+setQaMaxOutputTokens(trimmedTokens ? parsedTokens : 0);
+onNotice?.("已保存工坊配置。");
+onClose();
+};
 
-  const reset = () => {
-    setQaContextBudgetChars(null);
-    setQaPageChars(null);
-    setQaMaxRounds(null);
-    setQaMaxOutputTokens(null);
-    setBudget(String(QA_DEFAULT_CONTEXT_BUDGET_CHARS));
-    setPageChars(String(QA_DEFAULT_PAGE_CHARS));
-    setMaxRounds(String(QA_DEFAULT_MAX_ROUNDS));
-    setMaxOutTokens(String(QA_DEFAULT_MAX_OUTPUT_TOKENS));
-    onNotice?.("已恢复默认配置。");
-  };
+const reset = () => {
+setQaContextBudgetChars(null);
+setQaPageChars(null);
+setQaMaxRounds(null);
+setQaMaxOutputTokens(null);
+setBudget(String(QA_DEFAULT_CONTEXT_BUDGET_CHARS));
+setPageChars(String(QA_DEFAULT_PAGE_CHARS));
+setMaxRounds(String(QA_DEFAULT_MAX_ROUNDS));
+setMaxOutTokens(String(QA_DEFAULT_MAX_OUTPUT_TOKENS));
+onNotice?.("已恢复默认配置。");
+};
 
-  return (
-    <div className="qa-devnotice-backdrop" onClick={onClose}>
-      <div className="qa-devnotice" role="dialog" aria-label="工坊配置" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-devnotice-title">工坊配置</div>
-        <label className="qa-settings-field">
-          <span>上下文预算（字符）</span>
-          <input
-            type="number"
-            inputMode="numeric"
-            min={QA_CONTEXT_BUDGET_MIN}
-            max={QA_CONTEXT_BUDGET_MAX}
-            step={1000}
-            value={budget}
-            onChange={(e) => setBudget(e.target.value)}
-          />
-        </label>
-        <div className="qa-settings-hint">
-          上下文满 100% 时自动压缩成摘要并重新累计。中文约 1 字符 ≈ 1 token；默认 {QA_DEFAULT_CONTEXT_BUDGET_CHARS.toLocaleString()}，小上下文（32k）模型建议 30000–50000。
-        </div>
-        <div className="qa-settings-hint">当前会话已用 {usedChars.toLocaleString()} 字符（约 {pct}%）。</div>
-        <label className="qa-settings-field">
-          <span>单页读取字符数</span>
-          <input
-            type="number"
-            inputMode="numeric"
-            min={QA_PAGE_CHARS_MIN}
-            max={QA_PAGE_CHARS_MAX}
-            step={1000}
-            value={pageChars}
-            onChange={(e) => setPageChars(e.target.value)}
-          />
-        </label>
-        <div className="qa-settings-hint">
-          小坊翻页读答疑文档 / 本机内容 / 仓库源码时，每页返回的字符数。默认 {QA_DEFAULT_PAGE_CHARS.toLocaleString()}；调大读得快但更占上下文，小上下文模型建议调小。
-        </div>
-        <label className="qa-settings-field">
-          <span>单轮工具调用上限（次）</span>
-          <input
-            type="number"
-            inputMode="numeric"
-            min={QA_MAX_ROUNDS_MIN}
-            max={QA_MAX_ROUNDS_MAX}
-            step={1}
-            value={maxRounds}
-            onChange={(e) => setMaxRounds(e.target.value)}
-          />
-        </label>
-        <div className="qa-settings-hint">
-          一次提问里小坊最多连续执行多少轮工具，用完会提示「回复继续」。默认 {QA_DEFAULT_MAX_ROUNDS}；复杂任务（写游戏、改代码）可调大，想控制 token 消耗可调小。
-        </div>
-        <label className="qa-settings-field">
-          <span>单次最大输出 token</span>
-          <input
-            type="number"
-            inputMode="numeric"
-            min={QA_MAX_OUTPUT_TOKENS_MIN}
-            max={QA_MAX_OUTPUT_TOKENS_MAX}
-            step={1000}
-            placeholder="留空 = 不传"
-            value={maxOutTokens}
-            onChange={(e) => setMaxOutTokens(e.target.value)}
-          />
-        </label>
-        <div className="qa-settings-hint">
-          输出长度护栏：每次请求带 max_tokens，小坊会按该预算分段写大文件，写超被安全截断后自动续接，不再整轮报废。默认 {QA_DEFAULT_MAX_OUTPUT_TOKENS.toLocaleString()}；留空 = 不传该参数（部分模型/中转不支持 max_tokens 时请留空）。
-        </div>
-        <div className="qa-devnotice-actions is-row">
-          <button type="button" className="qa-devnotice-btn" onClick={reset}>恢复默认</button>
-          <button type="button" className="qa-devnotice-btn is-primary" onClick={save}>保存</button>
-        </div>
-      </div>
-    </div>
-  );
+return (
+
+<div className="qa-devnotice" role="dialog" aria-label="工坊配置" onClick={(e) => e.stopPropagation()}>
+工坊配置
+
+上下文预算（字符）
+<input
+type="number"
+inputMode="numeric"
+min={QA_CONTEXT_BUDGET_MIN}
+max={QA_CONTEXT_BUDGET_MAX}
+step={1000}
+value={budget}
+onChange={(e) => setBudget(e.target.value)}
+/>
+
+
+上下文满 100% 时自动压缩成摘要并重新累计。中文约 1 字符 ≈ 1 token；默认 {QA_DEFAULT_CONTEXT_BUDGET_CHARS.toLocaleString()}，小上下文（32k）模型建议 30000–50000。
+
+当前会话已用 {usedChars.toLocaleString()} 字符（约 {pct}%）。
+
+单页读取字符数
+<input
+type="number"
+inputMode="numeric"
+min={QA_PAGE_CHARS_MIN}
+max={QA_PAGE_CHARS_MAX}
+step={1000}
+value={pageChars}
+onChange={(e) => setPageChars(e.target.value)}
+/>
+
+
+小坊翻页读答疑文档 / 本机内容 / 仓库源码时，每页返回的字符数。默认 {QA_DEFAULT_PAGE_CHARS.toLocaleString()}；调大读得快但更占上下文，小上下文模型建议调小。
+
+
+单轮工具调用上限（次）
+<input
+type="number"
+inputMode="numeric"
+min={QA_MAX_ROUNDS_MIN}
+max={QA_MAX_ROUNDS_MAX}
+step={1}
+value={maxRounds}
+onChange={(e) => setMaxRounds(e.target.value)}
+/>
+
+
+一次提问里小坊最多连续执行多少轮工具，用完会提示「回复继续」。默认 {QA_DEFAULT_MAX_ROUNDS}；复杂任务（写游戏、改代码）可调大，想控制 token 消耗可调小。
+
+
+单次最大输出 token
+<input
+type="number"
+inputMode="numeric"
+min={QA_MAX_OUTPUT_TOKENS_MIN}
+max={QA_MAX_OUTPUT_TOKENS_MAX}
+step={1000}
+placeholder="留空 = 不传"
+value={maxOutTokens}
+onChange={(e) => setMaxOutTokens(e.target.value)}
+/>
+
+
+输出长度护栏：每次请求带 max_tokens，小坊会按该预算分段写大文件，写超被安全截断后自动续接，不再整轮报废。默认 {QA_DEFAULT_MAX_OUTPUT_TOKENS.toLocaleString()}；留空 = 不传该参数（部分模型/中转不支持 max_tokens 时请留空）。
+
+
+恢复默认
+保存
+
+
+
+);
 }
 
 // ── GitHub 仓库配置面板 ──────────────────────────────
 
 function QaRepoSheet({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
-  const existing = useMemo(() => loadQaGithubConfig(), []);
-  const [owner, setOwner] = useState(existing?.owner ?? "");
-  const [repo, setRepo] = useState(existing?.repo ?? "");
-  const [branch, setBranch] = useState(existing?.branch ?? "");
-  const [token, setToken] = useState(existing?.token ?? "");
-  const [writeMode, setWriteMode] = useState<"confirm" | "auto">(existing?.writeMode ?? "confirm");
-  const [checking, setChecking] = useState(false);
-  const [result, setResult] = useState<QaGithubValidation | null>(null);
+const existing = useMemo(() => loadQaGithubConfig(), []);
+const [owner, setOwner] = useState(existing?.owner ?? "");
+const [repo, setRepo] = useState(existing?.repo ?? "");
+const [branch, setBranch] = useState(existing?.branch ?? "");
+const [token, setToken] = useState(existing?.token ?? "");
+const [writeMode, setWriteMode] = useState<"confirm" | "auto">(existing?.writeMode ?? "confirm");
+const [checking, setChecking] = useState(false);
+const [result, setResult] = useState<QaGithubValidation | null>(null);
 
-  const buildConfig = useCallback((): QaGithubConfig => {
-    const cfg: QaGithubConfig = { owner: owner.trim(), repo: repo.trim(), writeMode };
-    if (branch.trim()) cfg.branch = branch.trim();
-    if (token.trim()) cfg.token = token.trim();
-    if (existing?.apiBase) cfg.apiBase = existing.apiBase;
-    return cfg;
-  }, [owner, repo, branch, token, writeMode, existing]);
+const buildConfig = useCallback((): QaGithubConfig => {
+const cfg: QaGithubConfig = { owner: owner.trim(), repo: repo.trim(), writeMode };
+if (branch.trim()) cfg.branch = branch.trim();
+if (token.trim()) cfg.token = token.trim();
+if (existing?.apiBase) cfg.apiBase = existing.apiBase;
+return cfg;
+}, [owner, repo, branch, token, writeMode, existing]);
 
-  const handleVerify = useCallback(async () => {
-    if (!owner.trim() || !repo.trim()) {
-      setResult({ ok: false, error: "请填写 owner 和 repo。" });
-      return;
-    }
-    setChecking(true);
-    setResult(null);
-    const validation = await validateQaGithubConfig(buildConfig());
-    setResult(validation);
-    setChecking(false);
-  }, [owner, repo, buildConfig]);
+const handleVerify = useCallback(async () => {
+if (!owner.trim() || !repo.trim()) {
+setResult({ ok: false, error: "请填写 owner 和 repo。" });
+return;
+}
+setChecking(true);
+setResult(null);
+const validation = await validateQaGithubConfig(buildConfig());
+setResult(validation);
+setChecking(false);
+}, [owner, repo, buildConfig]);
 
-  const handleSave = useCallback(() => {
-    if (!owner.trim() || !repo.trim()) return;
-    saveQaGithubConfig(buildConfig());
-    onSaved();
-    onClose();
-  }, [owner, repo, buildConfig, onSaved, onClose]);
+const handleSave = useCallback(() => {
+if (!owner.trim() || !repo.trim()) return;
+saveQaGithubConfig(buildConfig());
+onSaved();
+onClose();
+}, [owner, repo, buildConfig, onSaved, onClose]);
 
-  const handleDisconnect = useCallback(() => {
-    clearQaGithubConfig();
-    onSaved();
-    onClose();
-  }, [onSaved, onClose]);
+const handleDisconnect = useCallback(() => {
+clearQaGithubConfig();
+onSaved();
+onClose();
+}, [onSaved, onClose]);
 
-  return (
-    <div className="qa-sheet-backdrop" onClick={onClose}>
-      <div className="qa-sheet" onClick={(e) => e.stopPropagation()}>
-        <div className="qa-sheet-head">
-          <span className="qa-sheet-title">
-            <Github size={16} /> 连接 GitHub 仓库
-          </span>
-          <button type="button" className="qa-icon-btn" onClick={onClose} aria-label="关闭">
-            <X size={16} />
-          </button>
-        </div>
-        <div className="qa-sheet-body hide-scrollbar">
-          <p className="qa-sheet-note">
-            连接后可以让工坊查阅这个仓库的代码来回答问题。配置只保存在你的浏览器本地，不会上传。公开仓库可不填 PAT。
-          </p>
-          <label className="qa-field">
-            <span className="qa-field-label">Owner（用户名 / 组织）</span>
-            <input className="qa-input" value={owner} onChange={(e) => setOwner(e.target.value)} placeholder="例：octocat" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-          </label>
-          <label className="qa-field">
-            <span className="qa-field-label">Repo（仓库名）</span>
-            <input className="qa-input" value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="例：hello-world" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-          </label>
-          <label className="qa-field">
-            <span className="qa-field-label">分支（可选，默认仓库默认分支）</span>
-            <input className="qa-input" value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="main" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-          </label>
-          <label className="qa-field">
-            <span className="qa-field-label">Fine-grained PAT（私有仓库或搜索代码需要）</span>
-            <input className="qa-input" type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="github_pat_…" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
-            <span className="qa-field-hint">
-              GitHub → Settings → Menu 按钮 → Developer settings → Personal access tokens → Fine-grained tokens。创建时 Repository access 记得勾选目标仓库；Permissions 里：Contents——只查代码选 Read-only，要让工坊改代码选 Read and write；要用「创建PR」再加 Pull requests 的 Read and write（Metadata 会自动带上，其余权限都不用勾）。
-            </span>
-          </label>
-          <div className="qa-field">
-            <span className="qa-field-label">改代码时的模式</span>
-            <div className="qa-segment">
-              <button type="button" className={`qa-segment-btn ${writeMode === "confirm" ? "is-active" : ""}`} onClick={() => setWriteMode("confirm")}>
-                确认后提交
-              </button>
-              <button type="button" className={`qa-segment-btn ${writeMode === "auto" ? "is-active" : ""}`} onClick={() => setWriteMode("auto")}>
-                全自动
-              </button>
-            </div>
-            <span className="qa-field-hint">
-              {writeMode === "confirm"
-                ? "工坊改代码前会先展示改动，你点「应用」才真正提交。推荐。"
-                : "工坊说完直接提交推送，不再逐次确认。仍可事后一键撤销。仅在信任后开启。"}
-            </span>
-          </div>
-          {result && (
-            <div className={`qa-verify ${result.ok ? "is-ok" : "is-fail"}`}>
-              {result.ok
-                ? `✓ 已连接 ${result.fullName}（${result.private ? "私有" : "公开"}，默认分支 ${result.defaultBranch}）`
-                : `✗ ${result.error}`}
-            </div>
-          )}
-        </div>
-        <div className="qa-sheet-actions">
-          {existing && (
-            <button type="button" className="qa-sheet-btn is-danger" onClick={handleDisconnect}>
-              断开
-            </button>
-          )}
-          <button type="button" className="qa-sheet-btn" onClick={handleVerify} disabled={checking}>
-            {checking ? <Loader2 size={14} className="qa-spin" /> : "验证"}
-          </button>
-          <button type="button" className="qa-sheet-btn is-primary" onClick={handleSave} disabled={!owner.trim() || !repo.trim()}>
-            保存
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+return (
+
+<div className="qa-sheet" onClick={(e) => e.stopPropagation()}>
+
+
+ 连接 GitHub 仓库
+
+
+
+
+
+
+
+连接后可以让工坊查阅这个仓库的代码来回答问题。配置只保存在你的浏览器本地，不会上传。公开仓库可不填 PAT。
+
+
+Owner（用户名 / 组织）
+<input className="qa-input" value={owner} onChange={(e) => setOwner(e.target.value)} placeholder="例：octocat" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+
+
+Repo（仓库名）
+<input className="qa-input" value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="例：hello-world" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+
+
+分支（可选，默认仓库默认分支）
+<input className="qa-input" value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="main" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+
+
+Fine-grained PAT（私有仓库或搜索代码需要）
+<input className="qa-input" type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="github_pat_…" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+
+GitHub → Settings → Menu 按钮 → Developer settings → Personal access tokens → Fine-grained tokens。创建时 Repository access 记得勾选目标仓库；Permissions 里：Contents——只查代码选 Read-only，要让工坊改代码选 Read and write；要用「创建PR」再加 Pull requests 的 Read and write（Metadata 会自动带上，其余权限都不用勾）。
+
+
+
+改代码时的模式
+
+<button type="button" className={qa-segment-btn ${writeMode === "confirm" ? "is-active" : ""}} onClick={() => setWriteMode("confirm")}>
+确认后提交
+
+<button type="button" className={qa-segment-btn ${writeMode === "auto" ? "is-active" : ""}} onClick={() => setWriteMode("auto")}>
+全自动
+
+
+
+{writeMode === "confirm"
+? "工坊改代码前会先展示改动，你点「应用」才真正提交。推荐。"
+: "工坊说完直接提交推送，不再逐次确认。仍可事后一键撤销。仅在信任后开启。"}
+
+
+{result && (
+<div className={qa-verify ${result.ok ? "is-ok" : "is-fail"}}>
+{result.ok
+? ✓ 已连接 ${result.fullName}（${result.private ? "私有" : "公开"}，默认分支 ${result.defaultBranch}）
+: ✗ ${result.error}}
+
+)}
+
+
+{existing && (
+
+断开
+
+)}
+
+{checking ?  : "验证"}
+
+<button type="button" className="qa-sheet-btn is-primary" onClick={handleSave} disabled={!owner.trim() || !repo.trim()}>
+保存
+
+
+
+
+);
 }
 
 // ── App 本体 ─────────────────────────────────────────
 
 export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
-  const snapshot = useSyncExternalStore(subscribeQaChat, getQaChatSnapshot, getQaChatSnapshot);
-  const [input, setInput] = useState("");
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const [repoSheetOpen, setRepoSheetOpen] = useState(false);
-  const [repoConnected, setRepoConnected] = useState(false);
-  const [clearToolsOpen, setClearToolsOpen] = useState(false);
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  /** 会话重命名弹窗：抽屉菜单里点「重命名」打开 */
-  const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
-  const [renameTitle, setRenameTitle] = useState("");
-  const [pendingImages, setPendingImages] = useState<string[]>([]);
-  const [viewerImage, setViewerImage] = useState<string | null>(null);
-  const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
-  const [editText, setEditText] = useState("");
-  const [visionEnabled, setVisionEnabled] = useState(false);
-  const imageInputRef = useRef<HTMLInputElement | null>(null);
-  const [apiReady, setApiReady] = useState(true);
-  const [modelName, setModelName] = useState("");
-  const [repoWritable, setRepoWritable] = useState(false);
-  const [writeMode, setWriteMode] = useState<"confirm" | "auto">("confirm");
-  const bodyRef = useRef<HTMLDivElement | null>(null);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const stickToBottomRef = useRef(true);
+const snapshot = useSyncExternalStore(subscribeQaChat, getQaChatSnapshot, getQaChatSnapshot);
+const [input, setInput] = useState("");
+const [drawerOpen, setDrawerOpen] = useState(false);
+const [repoSheetOpen, setRepoSheetOpen] = useState(false);
+const [repoConnected, setRepoConnected] = useState(false);
+const [clearToolsOpen, setClearToolsOpen] = useState(false);
+const [settingsOpen, setSettingsOpen] = useState(false);
+/ 会话重命名弹窗：抽屉菜单里点「重命名」打开 */
+const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
+const [renameTitle, setRenameTitle] = useState("");
+const [pendingImages, setPendingImages] = useState<string[]>([]);
+const [pendingFiles, setPendingFiles] = useState<{name: string, content: string}[]>([]);
 
-  const refreshComposerMeta = useCallback(() => {
-    setApiReady(resolveQaApiConfig() != null);
-    setModelName(resolveQaApiConfig()?.defaultModel ?? "");
-    setVisionEnabled(resolveQaApiConfig()?.enableImageRecognition === true);
-    const gh = loadQaGithubConfig();
-    setRepoConnected(gh != null);
-    setRepoWritable(Boolean(gh?.token));
-    setWriteMode(gh?.writeMode ?? "confirm");
-  }, []);
+const [viewerImage, setViewerImage] = useState<string | null>(null);
+const [editingMsg, setEditingMsg] = useState<QaMsg | null>(null);
+const [editText, setEditText] = useState("");
+const [editImages, setEditImages] = useState<string[]>([]);
+const [editFiles, setEditFiles] = useState<{name: string, content: string}[]>([]);
 
-  useEffect(() => {
-    void hydrateQaChat();
-    refreshComposerMeta();
-  }, [refreshComposerMeta]);
+const [visionEnabled, setVisionEnabled] = useState(false);
+const imageInputRef = useRef<HTMLInputElement | null>(null);
+const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-  // 清理原生 tool 调用历史（防报错）：与小卷同款——移除上下文里的工具记录与原生元数据
-  const handleClearToolHistory = useCallback(() => {
-    if (snapshot.isGenerating) {
-      onNotice?.("小坊正在执行，完成后再清理。");
-      return;
-    }
-    if (!hasQaToolHistory()) {
-      onNotice?.("没有可清理的工具调用历史。");
-      return;
-    }
-    setClearToolsOpen(true);
-  }, [snapshot.isGenerating, onNotice]);
+const [apiReady, setApiReady] = useState(true);
+const [modelName, setModelName] = useState("");
+const [repoWritable, setRepoWritable] = useState(false);
+const [writeMode, setWriteMode] = useState<"confirm" | "auto">("confirm");
+const bodyRef = useRef<HTMLDivElement | null>(null);
+const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+const stickToBottomRef = useRef(true);
 
-  const confirmClearToolHistory = useCallback(() => {
-    setClearToolsOpen(false);
-    const result = clearQaToolHistory();
-    onNotice?.(result && result.removed + result.cleaned > 0
-      ? `已清理 ${result.removed} 条工具记录，整理 ${result.cleaned} 条消息。`
-      : "没有可清理的工具调用历史。");
-  }, [onNotice]);
+const refreshComposerMeta = useCallback(() => {
+setApiReady(resolveQaApiConfig() != null);
+setModelName(resolveQaApiConfig()?.defaultModel ?? "");
+setVisionEnabled(resolveQaApiConfig()?.enableImageRecognition === true);
+const gh = loadQaGithubConfig();
+setRepoConnected(gh != null);
+setRepoWritable(Boolean(gh?.token));
+setWriteMode(gh?.writeMode ?? "confirm");
+}, []);
 
-  const toggleWriteMode = useCallback(() => {
-    const gh = loadQaGithubConfig();
-    if (!gh) return;
-    const next = gh.writeMode === "auto" ? "confirm" : "auto";
-    saveQaGithubConfig({ ...gh, writeMode: next });
-    setWriteMode(next);
-  }, []);
+useEffect(() => {
+void hydrateQaChat();
+refreshComposerMeta();
+}, [refreshComposerMeta]);
 
-  const activeSession = useMemo(
-    () => snapshot.sessions.find((s) => s.id === snapshot.activeSessionId) ?? null,
-    [snapshot.sessions, snapshot.activeSessionId],
-  );
-  const messages = useMemo(() => activeSession?.messages ?? [], [activeSession]);
-  const createdContent = useMemo(() => activeSession?.createdContent ?? [], [activeSession]);
-  const [previewOpen, setPreviewOpen] = useState(false);
-  const [previewItem, setPreviewItem] = useState<QaCreatedContent | null>(null);
-  const previewApp = useMemo(
-    () => (previewItem?.type === "app" ? getInstalledCustomApp(previewItem.refId) : null),
-    [previewItem],
-  );
+// 清理原生 tool 调用历史（防报错）：与小卷同款——移除上下文里的工具记录与原生元数据
+const handleClearToolHistory = useCallback(() => {
+if (snapshot.isGenerating) {
+onNotice?.("小坊正在执行，完成后再清理。");
+return;
+}
+if (!hasQaToolHistory()) {
+onNotice?.("没有可清理的工具调用历史。");
+return;
+}
+setClearToolsOpen(true);
+}, [snapshot.isGenerating, onNotice]);
 
-  // 自动滚动：用户上滚阅读时不拉回底部
-  const handleScroll = useCallback(() => {
-    const el = bodyRef.current;
-    if (!el) return;
-    stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
-  }, []);
+const confirmClearToolHistory = useCallback(() => {
+setClearToolsOpen(false);
+const result = clearQaToolHistory();
+onNotice?.(result && result.removed + result.cleaned > 0
+? 已清理 ${result.removed} 条工具记录，整理 ${result.cleaned} 条消息。
+: "没有可清理的工具调用历史。");
+}, [onNotice]);
 
-  useEffect(() => {
-    const el = bodyRef.current;
-    if (el && stickToBottomRef.current) {
-      el.scrollTop = el.scrollHeight;
-    }
-  }, [messages]);
+const toggleWriteMode = useCallback(() => {
+const gh = loadQaGithubConfig();
+if (!gh) return;
+const next = gh.writeMode === "auto" ? "confirm" : "auto";
+saveQaGithubConfig({ ...gh, writeMode: next });
+setWriteMode(next);
+}, []);
 
-  const autoGrow = useCallback(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
-  }, []);
+const activeSession = useMemo(
+() => snapshot.sessions.find((s) => s.id === snapshot.activeSessionId) ?? null,
+[snapshot.sessions, snapshot.activeSessionId],
+);
+const messages = useMemo(() => activeSession?.messages ?? [], [activeSession]);
+const createdContent = useMemo(() => activeSession?.createdContent ?? [], [activeSession]);
+const [previewOpen, setPreviewOpen] = useState(false);
+const [previewItem, setPreviewItem] = useState<QaCreatedContent | null>(null);
+const previewApp = useMemo(
+() => (previewItem?.type === "app" ? getInstalledCustomApp(previewItem.refId) : null),
+[previewItem],
+);
 
-  const handleSend = useCallback(() => {
-    const text = input.trim();
-    if ((!text && pendingImages.length === 0) || snapshot.isGenerating) return;
-    setInput("");
-    const images = pendingImages;
-    setPendingImages([]);
-    stickToBottomRef.current = true;
-    requestAnimationFrame(autoGrow);
-    void sendQaMessage(text, images.length ? images : undefined);
-  }, [input, pendingImages, snapshot.isGenerating, autoGrow]);
+// 自动滚动：用户上滚阅读时不拉回底部
+const handleScroll = useCallback(() => {
+const el = bodyRef.current;
+if (!el) return;
+stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+}, []);
 
-  // 附加图片：仅识图已开启的 API 显示入口；读为 dataURL，单张限 4MB
-  const handlePickImages = useCallback((files: FileList | null) => {
-    if (!files?.length) return;
-    for (const file of Array.from(files).slice(0, 6)) {
-      if (file.size > 4 * 1024 * 1024) {
-        onNotice?.(`「${file.name}」超过 4MB，已跳过。`);
-        continue;
-      }
-      const reader = new FileReader();
-      reader.onload = () => {
-        const url = typeof reader.result === "string" ? reader.result : "";
-        if (url) setPendingImages((current) => (current.length >= 6 ? current : [...current, url]));
-      };
-      reader.readAsDataURL(file);
-    }
-    if (imageInputRef.current) imageInputRef.current.value = "";
-  }, [onNotice]);
+useEffect(() => {
+const el = bodyRef.current;
+if (el && stickToBottomRef.current) {
+el.scrollTop = el.scrollHeight;
+}
+}, [messages]);
 
-  const handleRetry = useCallback((assistantMsgId: string) => {
-    stickToBottomRef.current = true;
-    void retryQaMessage(assistantMsgId);
-  }, []);
+const autoGrow = useCallback(() => {
+const el = textareaRef.current;
+if (!el) return;
+el.style.height = "auto";
+el.style.height = ${Math.min(el.scrollHeight, 120)}px;
+}, []);
 
-  const handleCopyMessage = useCallback((content: string) => {
-    void navigator.clipboard?.writeText(content).then(
-      () => onNotice?.("已复制原始内容"),
-      () => onNotice?.("复制失败"),
-    );
-  }, [onNotice]);
+const handleSend = useCallback(() => {
+const text = input.trim();
+if ((!text && pendingImages.length === 0 && pendingFiles.length === 0) || snapshot.isGenerating) return;
+setInput("");
+const images = pendingImages;
+const files = pendingFiles;
+setPendingImages([]);
+setPendingFiles([]);
+stickToBottomRef.current = true;
+requestAnimationFrame(autoGrow);
+void sendQaMessage(text, images.length ? images : undefined, files.length ? files : undefined);
+}, [input, pendingImages, pendingFiles, snapshot.isGenerating, autoGrow]);
 
-  const handleEditMessage = useCallback((msg: QaMsg) => {
-    setEditingMsg(msg);
-    setEditText(msg.content);
-  }, []);
+// 附加图片：仅识图已开启的 API 显示入口；读为 dataURL，单张限 4MB
+const handlePickImages = useCallback((files: FileList | null, isEditMode = false) => {
+if (!files?.length) return;
+const setter = isEditMode ? setEditImages : setPendingImages;
+for (const file of Array.from(files).slice(0, 6)) {
+if (file.size > 4 * 1024 * 1024) {
+onNotice?.(「${file.name}」超过 4MB，已跳过。);
+continue;
+}
+const reader = new FileReader();
+reader.onload = () => {
+const url = typeof reader.result === "string" ? reader.result : "";
+if (url) setter((current) => (current.length >= 6 ? current : [...current, url]));
+};
+reader.readAsDataURL(file);
+}
+if (imageInputRef.current) imageInputRef.current.value = "";
+}, [onNotice]);
 
-  const handleSaveEdit = useCallback(() => {
-    if (!editingMsg || !snapshot.activeSessionId) return;
-    updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText);
-    setEditingMsg(null);
-    onNotice?.("已保存消息内容");
-  }, [editingMsg, editText, snapshot.activeSessionId, onNotice]);
+// 附加文本文件
+const handlePickFiles = useCallback((files: FileList | null, isEditMode = false) => {
+if (!files?.length) return;
+const setter = isEditMode ? setEditFiles : setPendingFiles;
+for (const file of Array.from(files).slice(0, 6)) {
+if (file.size > 1024 * 1024) { // 纯文本文件限 1MB
+onNotice?.(「${file.name}」太大（超过 1MB），请直接粘贴内容。);
+continue;
+}
+const reader = new FileReader();
+reader.onload = () => {
+const content = typeof reader.result === "string" ? reader.result : "";
+if (content) setter((current) => {
+if (current.length >= 6 || current.some(f => f.name === file.name)) return current;
+return [...current, { name: file.name, content }];
+});
+};
+reader.readAsText(file);
+}
+if (fileInputRef.current) fileInputRef.current.value = "";
+}, [onNotice]);
 
-  const streamingMsgId =
-    snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
-      ? messages[messages.length - 1].id
-      : null;
+const handleRetry = useCallback((assistantMsgId: string) => {
+stickToBottomRef.current = true;
+void retryQaMessage(assistantMsgId);
+}, []);
 
-  return (
-    <div className="qa-app-shell">
-      <QaSessionDrawer
-        sessions={snapshot.sessions}
-        activeId={snapshot.activeSessionId}
-        onSelect={(id) => {
-          switchQaSession(id);
-          setDrawerOpen(false);
-        }}
-        onDelete={deleteQaSession}
-        onCreate={() => {
-          createQaSession();
-          setDrawerOpen(false);
-        }}
-        onOpenSettings={() => {
-          setSettingsOpen(true);
-          setDrawerOpen(false);
-        }}
-        onRenameRequest={(id, title) => {
-          setRenameTarget({ id, title });
-          setRenameTitle(title);
+const handleCopyMessage = useCallback((content: string) => {
+void navigator.clipboard?.writeText(content).then(
+() => onNotice?.("已复制原始内容"),
+() => onNotice?.("复制失败"),
+);
+}, [onNotice]);
+
+const handleEditMessage = useCallback((msg: QaMsg) => {
+setEditingMsg(msg);
+setEditText(msg.content);
+setEditImages(msg.images || []);
+setEditFiles(msg.files || []);
+}, []);
+
+const handleSaveEdit = useCallback((andResend: boolean) => {
+if (!editingMsg || !snapshot.activeSessionId) return;
+if (andResend) {
+editAndResendQaMessage(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
+} else {
+updateQaMessageContent(snapshot.activeSessionId, editingMsg.id, editText, editImages.length ? editImages : undefined, editFiles.length ? editFiles : undefined);
+}
+setEditingMsg(null);
+onNotice?.(andResend ? "已提交修改" : "已保存消息内容");
+}, [editingMsg, editText, editImages, editFiles, snapshot.activeSessionId, onNotice]);
+
+const streamingMsgId =
+snapshot.isGenerating && messages.length > 0 && messages[messages.length - 1].role === "assistant"
+? messages[messages.length - 1].id
+: null;
+
+return (
+
+<QaSessionDrawer
+sessions={snapshot.sessions}
+activeId={snapshot.activeSessionId}
+onSelect={(id) => {
+switchQaSession(id);
+setDrawerOpen(false);
+}}
+onDelete={deleteQaSession}
+onCreate={() => {
+createQaSession();
+setDrawerOpen(false);
+}}
+onOpenSettings={() => {
+setSettingsOpen(true);
+setDrawerOpen(false);
+}}
+onRenameRequest={(id, title) => {
+setRenameTarget({ id, title });
+setRenameTitle(title);
+}}
+/>
+<div className={qa-stage ${drawerOpen ? "is-pushed" : ""}}>
+
+
+
+
+
+
+
+
+工坊
+{repoConnected && 已连接仓库}
+
+
+
+
+
+<button type="button" className="qa-icon-btn" onClick={() => setDrawerOpen((v) => !v)} aria-label="对话记录">
+
+
+
+
+
+  <div className="qa-body hide-scrollbar" ref={bodyRef} onScroll={handleScroll}>
+    {messages.length === 0 ? (
+      <div className="qa-welcome">
+        <div className="qa-welcome-badge" aria-hidden>
+          <svg viewBox="0 0 24 24" width="26" height="26">
+            <path d={mdiHammerWrench} fill="currentColor" />
+          </svg>
+        </div>
+        <div className="qa-welcome-title">有什么问题？</div>
+        <div className="qa-welcome-sub">
+          我是小坊，工坊的驻场工程师。使用问题、报错排查、部署配置，都可以问我。
+          <br />
+          我还能动手：写小游戏 / APP / 剧场直接装进本机试玩；连接仓库后我会查源码答疑，填了有写权限的 PAT 还能帮你改代码。
+          <br />
+          想创作角色、世界书或美化桌面，找桌面上的小卷更合适。
+        </div>
+        {!apiReady && (
+          <div className="qa-welcome-warn">还没有可用的 API：请先到「设置 → API 设置」添加 LLM API。</div>
+        )}
+        <div className="qa-suggestions">
+          {SUGGESTIONS.map((text) => (
+            <button
+              key={text}
+              type="button"
+              className="qa-suggestion"
+              onClick={() => {
+                stickToBottomRef.current = true;
+                void sendQaMessage(text);
+              }}
+            >
+              {text}
+            </button>
+          ))}
+        </div>
+      </div>
+    ) : (
+      <div className="qa-messages">
+        {messages.map((msg) => (
+          <QaMessageItem key={msg.id} msg={msg} isStreaming={msg.id === streamingMsgId} onRetry={handleRetry} onViewImage={setViewerImage} onCopy={handleCopyMessage} onEdit={handleEditMessage} />
+        ))}
+      </div>
+    )}
+  </div>
+
+  <footer className="qa-composer-wrap">
+    <div className={`qa-composer ${snapshot.isGenerating ? "is-generating" : ""}`}>
+      {(pendingImages.length > 0 || pendingFiles.length > 0) && (
+        <div className="qa-attach-strip">
+          {pendingImages.map((url, i) => (
+            <div key={`img-${i}`} className="qa-attach-thumb">
+              <button type="button" className="qa-attach-view" onClick={() => setViewerImage(url)} aria-label="查看图片">
+                <img src={url} alt="" />
+              </button>
+              <button
+                type="button"
+                className="qa-attach-remove"
+                onClick={() => setPendingImages((current) => current.filter((_, idx) => idx !== i))}
+                aria-label="移除图片"
+              >
+                <X size={11} strokeWidth={2.4} />
+              </button>
+            </div>
+          ))}
+          {pendingFiles.map((file, i) => (
+            <div key={`file-${i}`} className="qa-attach-thumb" style={{ background: "rgba(128,128,128,0.2)", display: "flex", alignItems: "center", justifyContent: "center", padding: "0 8px", minWidth: "60px", maxWidth: "120px" }}>
+              <FileText size={16} style={{ minWidth: "16px", marginRight: "4px" }}/>
+              <span style={{ fontSize: "11px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{file.name}</span>
+              <button
+                type="button"
+                className="qa-attach-remove"
+                onClick={() => setPendingFiles((current) => current.filter((_, idx) => idx !== i))}
+                aria-label="移除附件"
+              >
+                <X size={11} strokeWidth={2.4} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <textarea
+        ref={textareaRef}
+        className="qa-composer-input hide-scrollbar"
+        placeholder="输入你的问题…"
+        rows={1}
+        value={input}
+        onChange={(e) => {
+          setInput(e.target.value);
+          autoGrow();
         }}
       />
-      <div className={`qa-stage ${drawerOpen ? "is-pushed" : ""}`}>
-      <div className="qa-ambient" aria-hidden />
-      <header className="qa-header">
-        <div className="qa-header-left">
-          <button type="button" className="qa-icon-btn" onClick={onClose} aria-label="返回">
-            <ChevronLeft size={22} strokeWidth={1.75} />
-          </button>
-        </div>
-        <div className="qa-header-center">
-          <span className="qa-header-title">工坊</span>
-          {repoConnected && <span className="qa-header-sub">已连接仓库</span>}
-        </div>
-        <div className="qa-header-right">
-          <button
+      <div className="qa-composer-toolbar">
+        <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
+            style={{ display: "none" }}
+            onChange={(e) => handlePickFiles(e.target.files)}
+        />
+        <button
             type="button"
-            className="qa-icon-btn"
-            onClick={handleClearToolHistory}
-            aria-label="清理原生tool调用历史（防报错）"
-            title="清理原生tool调用历史——防报错"
-          >
-            <BrushCleaning size={17} strokeWidth={1.75} />
-          </button>
-          <button type="button" className="qa-icon-btn" onClick={() => setDrawerOpen((v) => !v)} aria-label="对话记录">
-            <Menu size={18} strokeWidth={1.75} />
-          </button>
-        </div>
-      </header>
+            className="qa-circle-btn qa-attach-btn"
+            onClick={() => fileInputRef.current?.click()}
+            aria-label="添加附件"
+        >
+            <Paperclip size={17} strokeWidth={2.2} />
+        </button>
 
-      <div className="qa-body hide-scrollbar" ref={bodyRef} onScroll={handleScroll}>
-        {messages.length === 0 ? (
-          <div className="qa-welcome">
-            <div className="qa-welcome-badge" aria-hidden>
-              <svg viewBox="0 0 24 24" width="26" height="26">
-                <path d={mdiHammerWrench} fill="currentColor" />
-              </svg>
-            </div>
-            <div className="qa-welcome-title">有什么问题？</div>
-            <div className="qa-welcome-sub">
-              我是小坊，工坊的驻场工程师。使用问题、报错排查、部署配置，都可以问我。
-              <br />
-              我还能动手：写小游戏 / APP / 剧场直接装进本机试玩；连接仓库后我会查源码答疑，填了有写权限的 PAT 还能帮你改代码。
-              <br />
-              想创作角色、世界书或美化桌面，找桌面上的小卷更合适。
-            </div>
-            {!apiReady && (
-              <div className="qa-welcome-warn">还没有可用的 API：请先到「设置 → API 设置」添加 LLM API。</div>
-            )}
-            <div className="qa-suggestions">
-              {SUGGESTIONS.map((text) => (
-                <button
-                  key={text}
-                  type="button"
-                  className="qa-suggestion"
-                  onClick={() => {
-                    stickToBottomRef.current = true;
-                    void sendQaMessage(text);
-                  }}
-                >
-                  {text}
-                </button>
-              ))}
-            </div>
-          </div>
-        ) : (
-          <div className="qa-messages">
-            {messages.map((msg) => (
-              <QaMessageItem key={msg.id} msg={msg} isStreaming={msg.id === streamingMsgId} onRetry={handleRetry} onViewImage={setViewerImage} onCopy={handleCopyMessage} onEdit={handleEditMessage} />
-            ))}
-          </div>
-        )}
-      </div>
-
-      <footer className="qa-composer-wrap">
-        <div className={`qa-composer ${snapshot.isGenerating ? "is-generating" : ""}`}>
-          {pendingImages.length > 0 && (
-            <div className="qa-attach-strip">
-              {pendingImages.map((url, i) => (
-                <div key={i} className="qa-attach-thumb">
-                  <button type="button" className="qa-attach-view" onClick={() => setViewerImage(url)} aria-label="查看图片">
-                    <img src={url} alt="" />
-                  </button>
-                  <button
-                    type="button"
-                    className="qa-attach-remove"
-                    onClick={() => setPendingImages((current) => current.filter((_, idx) => idx !== i))}
-                    aria-label="移除图片"
-                  >
-                    <X size={11} strokeWidth={2.4} />
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-          <textarea
-            ref={textareaRef}
-            className="qa-composer-input hide-scrollbar"
-            placeholder="输入你的问题…"
-            rows={1}
-            value={input}
-            onChange={(e) => {
-              setInput(e.target.value);
-              autoGrow();
-            }}
-          />
-          <div className="qa-composer-toolbar">
-            {visionEnabled && (
-              <>
-                <input
-                  ref={imageInputRef}
-                  type="file"
-                  accept="image/*"
-                  multiple
-                  style={{ display: "none" }}
-                  onChange={(e) => handlePickImages(e.target.files)}
-                />
-                <button
-                  type="button"
-                  className="qa-circle-btn qa-attach-btn"
-                  onClick={() => imageInputRef.current?.click()}
-                  aria-label="发送图片"
-                >
-                  <Plus size={17} strokeWidth={2.2} />
-                </button>
-              </>
-            )}
-            {modelName && <span className="qa-model-pill">{modelName}</span>}
-
-            {repoWritable && (
-              <button type="button" className="qa-mode-pill" onClick={toggleWriteMode}>
-                {writeMode === "auto" ? "全自动" : "确认后提交"}
-              </button>
-            )}
-
-            <div className="qa-composer-spacer" />
-
-            {createdContent.length > 0 && (
-              <button
-                type="button"
-                className="qa-circle-btn qa-preview-btn"
-                onClick={() => setPreviewOpen(true)}
-                aria-label="预览本轮创建的内容"
-              >
-                <Play size={16} />
-              </button>
-            )}
-
+        {visionEnabled && (
+          <>
+            <input
+              ref={imageInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              style={{ display: "none" }}
+              onChange={(e) => handlePickImages(e.target.files)}
+            />
             <button
               type="button"
-              className={`qa-circle-btn qa-github-btn ${repoConnected ? "is-active" : ""}`}
-              onClick={() => setRepoSheetOpen(true)}
-              aria-label="连接仓库"
+              className="qa-circle-btn qa-attach-btn"
+              onClick={() => imageInputRef.current?.click()}
+              aria-label="发送图片"
             >
-              <Github size={16} strokeWidth={1.75} />
+              <Plus size={17} strokeWidth={2.2} />
             </button>
+          </>
+        )}
+        {modelName && <span className="qa-model-pill">{modelName}</span>}
 
-            {snapshot.isGenerating ? (
-              <button type="button" className="qa-circle-btn qa-send-btn is-stop" onClick={stopQaGeneration} aria-label="停止生成">
-                <Square size={14} fill="currentColor" />
-              </button>
-            ) : (
-              <button
-                type="button"
-                className="qa-circle-btn qa-send-btn"
-                onClick={handleSend}
-                disabled={!input.trim()}
-                aria-label="发送"
-              >
-                <ArrowUp size={20} strokeWidth={2.4} />
-              </button>
-            )}
-          </div>
-          <div
-            className={`qa-context-meter ${snapshot.isCompacting ? "is-compacting" : ""}`}
-            title="上下文用量：满 100% 时自动压缩成摘要并从头累计"
+        {repoWritable && (
+          <button type="button" className="qa-mode-pill" onClick={toggleWriteMode}>
+            {writeMode === "auto" ? "全自动" : "确认后提交"}
+          </button>
+        )}
+
+        <div className="qa-composer-spacer" />
+
+        {createdContent.length > 0 && (
+          <button
+            type="button"
+            className="qa-circle-btn qa-preview-btn"
+            onClick={() => setPreviewOpen(true)}
+            aria-label="预览本轮创建的内容"
           >
-            <div className="qa-context-meter-track" aria-hidden>
-              <i style={{ width: `${Math.min(100, Math.round(snapshot.contextUsage * 100))}%` }} />
-            </div>
-            <span className="qa-context-meter-label">
-              {snapshot.isCompacting ? "压缩中" : `${Math.min(999, Math.round(snapshot.contextUsage * 100))}%`}
-            </span>
-          </div>
-        </div>
-      </footer>
+            <Play size={16} />
+          </button>
+        )}
 
-      {drawerOpen && (
         <button
           type="button"
-          className="qa-stage-scrim"
-          aria-label="关闭对话列表"
-          onClick={() => setDrawerOpen(false)}
-        />
-      )}
-      </div>
+          className={`qa-circle-btn qa-github-btn ${repoConnected ? "is-active" : ""}`}
+          onClick={() => setRepoSheetOpen(true)}
+          aria-label="连接仓库"
+        >
+          <Github size={16} strokeWidth={1.75} />
+        </button>
 
-      {renameTarget && (
-        <div className="qa-rename-backdrop" role="presentation" onClick={() => setRenameTarget(null)}>
-          <form
-            className="qa-rename-dialog"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="qa-rename-dialog-title"
-            onClick={(e) => e.stopPropagation()}
-            onSubmit={(e) => {
-              e.preventDefault();
-              const title = renameTitle.trim();
-              if (!title) return;
-              renameQaSession(renameTarget.id, title);
-              setRenameTarget(null);
-            }}
+        {snapshot.isGenerating ? (
+          <button type="button" className="qa-circle-btn qa-send-btn is-stop" onClick={stopQaGeneration} aria-label="停止生成">
+            <Square size={14} fill="currentColor" />
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="qa-circle-btn qa-send-btn"
+            onClick={handleSend}
+            disabled={!input.trim() && pendingImages.length === 0 && pendingFiles.length === 0}
+            aria-label="发送"
           >
-            <div id="qa-rename-dialog-title" className="qa-rename-title">重命名对话</div>
-            <input
-              className="qa-rename-input"
-              autoFocus
-              value={renameTitle}
-              maxLength={80}
-              aria-label="新对话名称"
-              onChange={(e) => setRenameTitle(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Escape") setRenameTarget(null); }}
-            />
-            <div className="qa-rename-actions">
-              <button type="button" className="qa-rename-cancel" onClick={() => setRenameTarget(null)}>取消</button>
-              <button type="submit" className="qa-drawer-new qa-rename-confirm" disabled={!renameTitle.trim()}>确认</button>
-            </div>
-          </form>
+            <ArrowUp size={20} strokeWidth={2.4} />
+          </button>
+        )}
+      </div>
+      <div
+        className={`qa-context-meter ${snapshot.isCompacting ? "is-compacting" : ""}`}
+        title="上下文用量：满 100% 时自动压缩成摘要并从头累计"
+      >
+        <div className="qa-context-meter-track" aria-hidden>
+          <i style={{ width: `${Math.min(100, Math.round(snapshot.contextUsage * 100))}%` }} />
         </div>
-      )}
+        <span className="qa-context-meter-label">
+          {snapshot.isCompacting ? "压缩中" : `${Math.min(999, Math.round(snapshot.contextUsage * 100))}%`}
+        </span>
+      </div>
+    </div>
+  </footer>
 
-      {clearToolsOpen && (
-        <div className="qa-devnotice-backdrop" onClick={() => setClearToolsOpen(false)}>
-          <div className="qa-devnotice" role="alertdialog" aria-label="清理工具历史确认" onClick={(e) => e.stopPropagation()}>
-            <div className="qa-devnotice-title">清理工具调用历史？</div>
-            <div className="qa-devnotice-text">
-              将移除本会话上下文中的工具调用与工具结果记录，用于修复原生工具协议的报错。普通对话内容不会删除，之前的工具结论仍保留在小坊的回复文字里。
-            </div>
-            <div className="qa-devnotice-actions is-row">
-              <button type="button" className="qa-devnotice-btn" onClick={() => setClearToolsOpen(false)}>
-                取消
-              </button>
-              <button type="button" className="qa-devnotice-btn is-primary" onClick={confirmClearToolHistory}>
-                清理
-              </button>
-            </div>
-          </div>
+  {drawerOpen && (
+    <button
+      type="button"
+      className="qa-stage-scrim"
+      aria-label="关闭对话列表"
+      onClick={() => setDrawerOpen(false)}
+    />
+  )}
+  </div>
+
+  {renameTarget && (
+    <div className="qa-rename-backdrop" role="presentation" onClick={() => setRenameTarget(null)}>
+      <form
+        className="qa-rename-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="qa-rename-dialog-title"
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={(e) => {
+          e.preventDefault();
+          const title = renameTitle.trim();
+          if (!title) return;
+          renameQaSession(renameTarget.id, title);
+          setRenameTarget(null);
+        }}
+      >
+        <div id="qa-rename-dialog-title" className="qa-rename-title">重命名对话</div>
+        <input
+          className="qa-rename-input"
+          autoFocus
+          value={renameTitle}
+          maxLength={80}
+          aria-label="新对话名称"
+          onChange={(e) => setRenameTitle(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Escape") setRenameTarget(null); }}
+        />
+        <div className="qa-rename-actions">
+          <button type="button" className="qa-rename-cancel" onClick={() => setRenameTarget(null)}>取消</button>
+          <button type="submit" className="qa-drawer-new qa-rename-confirm" disabled={!renameTitle.trim()}>确认</button>
         </div>
-      )}
+      </form>
+    </div>
+  )}
 
-      {viewerImage && (
-        <div className="qa-image-viewer" role="presentation" onClick={() => setViewerImage(null)}>
-          <img src={viewerImage} alt="" />
-          <button type="button" className="qa-image-viewer-close" aria-label="关闭" onClick={() => setViewerImage(null)}>
-            <X size={20} />
+  {clearToolsOpen && (
+    <div className="qa-devnotice-backdrop" onClick={() => setClearToolsOpen(false)}>
+      <div className="qa-devnotice" role="alertdialog" aria-label="清理工具历史确认" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-devnotice-title">清理工具调用历史？</div>
+        <div className="qa-devnotice-text">
+          将移除本会话上下文中的工具调用与工具结果记录，用于修复原生工具协议的报错。普通对话内容不会删除，之前的工具结论仍保留在小坊的回复文字里。
+        </div>
+        <div className="qa-devnotice-actions is-row">
+          <button type="button" className="qa-devnotice-btn" onClick={() => setClearToolsOpen(false)}>
+            取消
+          </button>
+          <button type="button" className="qa-devnotice-btn is-primary" onClick={confirmClearToolHistory}>
+            清理
           </button>
         </div>
-      )}
+      </div>
+    </div>
+  )}
 
-      {editingMsg && (
-        <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
-          <div className="qa-edit-dialog" role="dialog" aria-label="编辑消息" onClick={(e) => e.stopPropagation()}>
-            <div className="qa-edit-head">
-              <span className="qa-edit-title">编辑消息（未渲染原始内容）</span>
-              <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
-                <X size={16} />
-              </button>
-            </div>
+  {viewerImage && (
+    <div className="qa-image-viewer" role="presentation" onClick={() => setViewerImage(null)}>
+      <img src={viewerImage} alt="" />
+      <button type="button" className="qa-image-viewer-close" aria-label="关闭" onClick={() => setViewerImage(null)}>
+        <X size={20} />
+      </button>
+    </div>
+  )}
+
+  {editingMsg && (
+    <div className="qa-edit-backdrop" onClick={() => setEditingMsg(null)}>
+      <div className="qa-edit-dialog" role="dialog" aria-label="修改消息" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-edit-head">
+          <span className="qa-edit-title">修改消息</span>
+          <button type="button" className="qa-icon-btn" onClick={() => setEditingMsg(null)} aria-label="关闭">
+            <X size={16} />
+          </button>
+        </div>
+        
+        <div style={{ padding: "0 16px 8px 16px" }}>
             <textarea
               className="qa-edit-textarea"
               value={editText}
               onChange={(e) => setEditText(e.target.value)}
               spellCheck={false}
               autoFocus
-              placeholder="这里显示的是消息的原始内容，不会被前端渲染，可放心查看特殊标签。"
+              style={{ minHeight: "120px", marginBottom: "8px" }}
             />
-            <div className="qa-edit-actions">
-              <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
-                取消
-              </button>
-              <button type="button" className="qa-devnotice-btn is-primary" onClick={handleSaveEdit}>
-                保存
-              </button>
+            
+            <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "8px" }}>
+                {editImages.map((url, i) => (
+                    <div key={`edit-img-${i}`} style={{ position: "relative", width: "40px", height: "40px", borderRadius: "4px", overflow: "hidden", border: "1px solid rgba(255,255,255,0.1)" }}>
+                        <img src={url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+                        <button
+                            type="button"
+                            style={{ position: "absolute", top: 0, right: 0, background: "rgba(0,0,0,0.5)", color: "white", border: "none", borderRadius: "0 0 0 4px", cursor: "pointer", padding: "2px" }}
+                            onClick={() => setEditImages(current => current.filter((_, idx) => idx !== i))}
+                        >
+                            <X size={10} />
+                        </button>
+                    </div>
+                ))}
+                {editFiles.map((f, i) => (
+                     <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "rgba(255,255,255,0.1)", padding: "4px 20px 4px 8px", borderRadius: "4px", fontSize: "11px", border: "1px solid rgba(255,255,255,0.2)" }}>
+                        <FileText size={12} style={{ marginRight: "4px" }} />
+                        <span style={{ maxWidth: "80px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
+                        <button
+                            type="button"
+                            style={{ position: "absolute", right: "2px", background: "transparent", color: "inherit", border: "none", cursor: "pointer", display: "flex", alignItems: "center" }}
+                            onClick={() => setEditFiles(current => current.filter((_, idx) => idx !== i))}
+                        >
+                            <X size={12} />
+                        </button>
+                    </div>
+                ))}
             </div>
-          </div>
+
+            <div style={{ display: "flex", gap: "8px" }}>
+                <button type="button" className="qa-devnotice-btn" onClick={() => fileInputRef.current?.click()} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
+                    <Paperclip size={12} /> 添加附件
+                </button>
+                <button type="button" className="qa-devnotice-btn" onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); }} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
+                    <Plus size={12} /> 添加图片
+                </button>
+                 <input
+                    ref={imageInputRef}
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    style={{ display: "none" }}
+                    onChange={(e) => {
+                        const isEditMode = e.target.getAttribute('data-edit-mode') === 'true';
+                        handlePickImages(e.target.files, isEditMode);
+                        e.target.removeAttribute('data-edit-mode');
+                    }}
+                />
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    multiple
+                    accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.html,.css,.csv"
+                    style={{ display: "none" }}
+                    onChange={(e) => handlePickFiles(e.target.files, true)}
+                />
+            </div>
         </div>
-      )}
+        
+        <div className="qa-edit-actions">
+          <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
+            取消
+          </button>
+          <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
+            仅保存
+          </button>
+          <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
+            保存并发送
+          </button>
+        </div>
+      </div>
+    </div>
+  )}
 
-      {settingsOpen && (
-        <QaSettingsSheet onClose={() => setSettingsOpen(false)} onNotice={onNotice} />
-      )}
+  {settingsOpen && (
+    <QaSettingsSheet onClose={() => setSettingsOpen(false)} onNotice={onNotice} />
+  )}
 
-      {repoSheetOpen && (
-        <QaRepoSheet onClose={() => setRepoSheetOpen(false)} onSaved={refreshComposerMeta} />
-      )}
+  {repoSheetOpen && (
+    <QaRepoSheet onClose={() => setRepoSheetOpen(false)} onSaved={refreshComposerMeta} />
+  )}
 
-      {previewOpen && !previewItem && (
-        <div className="qa-sheet-backdrop" onClick={() => setPreviewOpen(false)}>
-          <div className="qa-sheet qa-preview-sheet" onClick={(e) => e.stopPropagation()}>
-            <div className="qa-sheet-head">
-              <span className="qa-sheet-title">
-                <Play size={16} /> 预览本轮创建
+  {previewOpen && !previewItem && (
+    <div className="qa-sheet-backdrop" onClick={() => setPreviewOpen(false)}>
+      <div className="qa-sheet qa-preview-sheet" onClick={(e) => e.stopPropagation()}>
+        <div className="qa-sheet-head">
+          <span className="qa-sheet-title">
+            <Play size={16} /> 预览本轮创建
+          </span>
+          <button type="button" className="qa-icon-btn" onClick={() => setPreviewOpen(false)} aria-label="关闭">
+            <X size={16} />
+          </button>
+        </div>
+        <div className="qa-sheet-body">
+          <p className="qa-sheet-note">本次对话里创建/更新的内容，点开直接测试，返回后回到聊天。</p>
+          {createdContent.map((item) => (
+            <button
+              key={`${item.type}-${item.refId}`}
+              type="button"
+              className="qa-preview-item"
+              onClick={() => setPreviewItem(item)}
+            >
+              {item.type === "app" ? <AppWindow size={17} /> : item.type === "game" ? <Gamepad2 size={17} /> : <Drama size={17} />}
+              <span className="qa-preview-item-title">{item.title}</span>
+              <span className="qa-preview-item-type">
+                {item.type === "app" ? "应用" : item.type === "game" ? "游戏" : "剧场"}
               </span>
-              <button type="button" className="qa-icon-btn" onClick={() => setPreviewOpen(false)} aria-label="关闭">
-                <X size={16} />
-              </button>
-            </div>
-            <div className="qa-sheet-body">
-              <p className="qa-sheet-note">本次对话里创建/更新的内容，点开直接测试，返回后回到聊天。</p>
-              {createdContent.map((item) => (
-                <button
-                  key={`${item.type}-${item.refId}`}
-                  type="button"
-                  className="qa-preview-item"
-                  onClick={() => setPreviewItem(item)}
-                >
-                  {item.type === "app" ? <AppWindow size={17} /> : item.type === "game" ? <Gamepad2 size={17} /> : <Drama size={17} />}
-                  <span className="qa-preview-item-title">{item.title}</span>
-                  <span className="qa-preview-item-type">
-                    {item.type === "app" ? "应用" : item.type === "game" ? "游戏" : "剧场"}
-                  </span>
-                  <ChevronRight size={15} />
-                </button>
-              ))}
-            </div>
-          </div>
+              <ChevronRight size={15} />
+            </button>
+          ))}
         </div>
-      )}
+      </div>
+    </div>
+  )}
 
-      {previewItem && (
-        <div className="qa-preview-runtime">
-          {previewItem.type === "app" ? (
-            previewApp ? (
-              <CustomAppForegroundBoundary
-                key={previewApp.id}
-                appName={previewApp.name}
-                appId={previewApp.id}
-                appVersion={previewApp.version}
-                manifestId={previewApp.manifest?.id}
-                closeLabel="返回"
-                onClose={() => setPreviewItem(null)}
-              >
-                <CustomAppRunner app={previewApp} onClose={() => setPreviewItem(null)} />
-              </CustomAppForegroundBoundary>
-            ) : (
-              <div className="qa-preview-missing">
-                <p>这个应用已被卸载或找不到了。</p>
-                <button type="button" className="qa-sheet-btn is-primary" onClick={() => setPreviewItem(null)}>
-                  返回
-                </button>
-              </div>
-            )
-          ) : previewItem.type === "game" ? (
-            <GameHubApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
-          ) : (
-            <BlackMarketApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
-          )}
-        </div>
+  {previewItem && (
+    <div className="qa-preview-runtime">
+      {previewItem.type === "app" ? (
+        previewApp ? (
+          <CustomAppForegroundBoundary
+            key={previewApp.id}
+            appName={previewApp.name}
+            appId={previewApp.id}
+            appVersion={previewApp.version}
+            manifestId={previewApp.manifest?.id}
+            closeLabel="返回"
+            onClose={() => setPreviewItem(null)}
+          >
+            <CustomAppRunner app={previewApp} onClose={() => setPreviewItem(null)} />
+          </CustomAppForegroundBoundary>
+        ) : (
+          <div className="qa-preview-missing">
+            <p>这个应用已被卸载或找不到了。</p>
+            <button type="button" className="qa-sheet-btn is-primary" onClick={() => setPreviewItem(null)}>
+              返回
+            </button>
+          </div>
+        )
+      ) : previewItem.type === "game" ? (
+        <GameHubApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
+      ) : (
+        <BlackMarketApp onClose={() => setPreviewItem(null)} autoOpenLocalId={previewItem.refId} />
       )}
     </div>
-  );
+  )}
+</div>
+
+
+);
 }

--- a/components/phone-qa-app.tsx
+++ b/components/phone-qa-app.tsx
@@ -802,6 +802,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
   const [clearToolsOpen, setClearToolsOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [attachMenuOpen, setAttachMenuOpen] = useState(false); // 控制上方悬浮菜单状态
+  const [editAttachMenuOpen, setEditAttachMenuOpen] = useState(false); // 控制编辑消息内的悬浮菜单状态
   
   /** 会话重命名弹窗：抽屉菜单里点「重命名」打开 */
   const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
@@ -1359,7 +1360,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                         </div>
                     ))}
                     {editFiles.map((f, i) => (
-                         <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "rgba(255,255,255,0.1)", padding: "4px 20px 4px 8px", borderRadius: "12px", fontSize: "11px", border: "1px solid rgba(255,255,255,0.2)" }}>
+                         <div key={`edit-file-${i}`} style={{ position: "relative", display: "flex", alignItems: "center", background: "rgba(128,128,128,0.15)", padding: "4px 24px 4px 10px", borderRadius: "12px", fontSize: "11px", border: "1px solid rgba(128,128,128,0.2)", color: "inherit" }}>
                             <FileText size={12} style={{ marginRight: "4px" }} />
                             <span style={{ maxWidth: "80px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.name}</span>
                             <button
@@ -1373,13 +1374,7 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                     ))}
                 </div>
 
-                <div style={{ display: "flex", gap: "8px" }}>
-                    <button type="button" className="qa-devnotice-btn" onClick={() => fileInputRef.current?.click()} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
-                        <Paperclip size={12} /> 添加附件
-                    </button>
-                    <button type="button" className="qa-devnotice-btn" onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); }} style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "12px", padding: "4px 8px" }}>
-                        <Plus size={12} /> 添加图片
-                    </button>
+                <div style={{ display: "none" }}>
                      <input
                         ref={imageInputRef}
                         type="file"
@@ -1403,16 +1398,46 @@ export function PhoneQaApp({ onClose, onNotice }: PhoneQaAppProps) {
                 </div>
             </div>
             
-            <div className="qa-edit-actions">
-              <button type="button" className="qa-devnotice-btn" onClick={() => setEditingMsg(null)}>
-                取消
-              </button>
-              <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
-                仅保存
-              </button>
-              <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
-                保存并发送
-              </button>
+            <div className="qa-edit-actions" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', marginTop: '8px' }}>
+                <div style={{ position: 'relative' }}>
+                    {editAttachMenuOpen && (
+                        <div style={{ position: "absolute", bottom: "100%", left: "-8px", marginBottom: "4px", display: "flex", gap: "8px", padding: "8px", animation: "fadeIn 0.2s", whiteSpace: "nowrap" }}>
+                            <button
+                                type="button"
+                                onClick={() => { fileInputRef.current?.click(); setEditAttachMenuOpen(false); }}
+                                style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
+                            >
+                                <Paperclip size={15} strokeWidth={2} /> 上传附件
+                            </button>
+                            {visionEnabled && (
+                                <button
+                                    type="button"
+                                    onClick={() => { imageInputRef.current?.setAttribute('data-edit-mode', 'true'); imageInputRef.current?.click(); setEditAttachMenuOpen(false); }}
+                                    style={{ display: "flex", alignItems: "center", gap: "4px", padding: "6px 12px", borderRadius: "14px", fontSize: "13px", cursor: "pointer", background: "rgba(128, 128, 128, 0.15)", border: "none", color: "inherit", fontWeight: 500 }}
+                                >
+                                    <Image size={15} strokeWidth={2} /> 添加图片
+                                </button>
+                            )}
+                        </div>
+                    )}
+                    <button
+                        type="button"
+                        onClick={() => setEditAttachMenuOpen(prev => !prev)}
+                        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '32px', height: '32px', borderRadius: '50%', background: 'transparent', border: 'none', cursor: 'pointer', color: 'inherit' }}
+                        aria-label="添加附件或图片"
+                    >
+                        <Plus size={22} strokeWidth={2.2} style={{ transform: editAttachMenuOpen ? 'rotate(45deg)' : 'none', transition: 'transform 0.2s ease-in-out' }} />
+                    </button>
+                </div>
+                
+                <div style={{ display: 'flex', gap: '8px' }}>
+                    <button type="button" className="qa-devnotice-btn" onClick={() => handleSaveEdit(false)}>
+                        保存
+                    </button>
+                    <button type="button" className="qa-devnotice-btn is-primary" onClick={() => handleSaveEdit(true)}>
+                        保存并发送
+                    </button>
+                </div>
             </div>
           </div>
         </div>

--- a/lib/qa-agent-engine.ts
+++ b/lib/qa-agent-engine.ts
@@ -458,6 +458,8 @@ export type QaContextEntry = {
     content: string;
     /** user：随消息附带的图片（dataURL）；识图未开启时适配层会自动降级为占位文本 */
     images?: string[];
+    /** user：随消息发送的文本附件 */
+    files?: { name: string; content: string }[];
     /** assistant：原生协议的工具调用（文本协议轮次不填，指令已在 content 里） */
     toolCalls?: LlmToolCall[];
     /** tool：来源调用 id（原生轮次才有）与工具名 */
@@ -467,11 +469,19 @@ export type QaContextEntry = {
     turn?: string;
 };
 
-/** user 条目内容：带图片时转多模态 parts（识图未开启由适配层降级为占位） */
+/** user 条目内容：带附件时拼接文本，带图片时转多模态 parts */
 function userEntryContent(entry: QaContextEntry): string | LLMContentPart[] {
-    if (!entry.images?.length) return entry.content;
+    let textContent = entry.content;
+    // 如果存在附件，就把附件名称和内容拼接到文字的末尾发给 AI
+    if (entry.files && entry.files.length > 0) {
+        const filesText = entry.files.map(f => `\n\n[附件：${f.name}]\n${f.content}`).join("");
+        textContent += filesText;
+    }
+    
+    if (!entry.images?.length) return textContent;
+    
     return [
-        { type: "text", text: entry.content },
+        { type: "text", text: textContent },
         ...entry.images.map((url) => ({ type: "image_url" as const, image_url: { url } })),
     ];
 }

--- a/lib/qa-chat-store.ts
+++ b/lib/qa-chat-store.ts
@@ -35,8 +35,10 @@ export type QaMsg = {
     id: string;
     role: "user" | "assistant";
     content: string;
-    /** user：随消息发送的图片（dataURL），点击可查看 */
+   /** user：随消息发送的图片（dataURL），点击可查看 */
     images?: string[];
+    /** user：随消息发送的文本附件 */
+    files?: { name: string; content: string }[];
     reasoning?: string;
     error?: string;
     aborted?: boolean;
@@ -374,13 +376,36 @@ export function deleteQaSession(sessionId: string) {
 
 /** 编辑一条已发送消息的内容（小坊助手界面"编辑"）。
  *  只覆盖 content 并清掉时序分段缓存（保证渲染用新内容），工具行/提交卡等历史保留。 */
-export function updateQaMessageContent(sessionId: string, msgId: string, content: string): void {
+export function updateQaMessageContent(sessionId: string, msgId: string, content: string, images?: string[], files?: { name: string; content: string }[]): void {
     sessions = sessions.map((s) =>
         s.id !== sessionId
             ? s
-            : { ...s, messages: s.messages.map((m) => (m.id === msgId ? { ...m, content, segments: undefined } : m)) }
+            : { ...s, messages: s.messages.map((m) => (m.id === msgId ? { ...m, content, images, files, segments: undefined } : m)) }
     );
     publish();
+}
+
+/** 保存并重新发送：截断此消息之后的所有回复，并以新内容重新触发 AI */
+export async function editAndResendQaMessage(
+    sessionId: string,
+    msgId: string,
+    newContent: string,
+    newImages?: string[],
+    newFiles?: { name: string; content: string }[]
+): Promise<void> {
+    if (isGenerating) return;
+    const session = sessions.find((s) => s.id === sessionId);
+    if (!session) return;
+    const msgIndex = session.messages.findIndex((m) => m.id === msgId);
+    if (msgIndex === -1) return;
+
+    updateSession(sessionId, (s) => ({
+        ...s,
+        messages: s.messages.slice(0, msgIndex),
+        context: undefined,
+    }));
+
+    await sendQaMessage(newContent, newImages, newFiles);
 }
 
 function updateSession(sessionId: string, updater: (session: QaSession) => QaSession, options?: { persist?: boolean }) {
@@ -402,10 +427,11 @@ function autoTitle(text: string): string {
 export async function sendQaMessage(
     text: string,
     images?: string[],
+    files?: { name: string; content: string }[],
     options?: { /** true=不显示用户气泡，只把指令写入上下文（重试续接等内部续发用） */ silentUser?: boolean },
 ): Promise<void> {
     const trimmed = text.trim();
-    if ((!trimmed && !images?.length) || isGenerating) return;
+    if ((!trimmed && !images?.length && !files?.length) || isGenerating) return;
 
     let session = getActiveSession();
     if (!session) {
@@ -415,20 +441,19 @@ export async function sendQaMessage(
     }
     const sessionId = session.id;
 
-    // 触顶先压缩再开新轮（Claude Code 同款时机）
     if (contextUsageOf(session) >= 1) {
         await compactSessionContext(sessionId);
     }
 
-    const userMsg: QaMsg = { id: makeId(), role: "user", content: trimmed, images: images?.length ? images : undefined, ts: Date.now() };
+    const userMsg: QaMsg = { id: makeId(), role: "user", content: trimmed, images: images?.length ? images : undefined, files: files?.length ? files : undefined, ts: Date.now() };
     const assistantMsg: QaMsg = { id: makeId(), role: "assistant", content: "", ts: Date.now() };
 
     updateSession(sessionId, (s) => ({
         ...s,
-        title: s.messages.length === 0 ? autoTitle(trimmed || "（图片）") : s.title,
+        title: s.messages.length === 0 ? autoTitle(trimmed || "（图片/附件）") : s.title,
         updatedAt: Date.now(),
         messages: [...s.messages, ...(options?.silentUser ? [] : [userMsg]), assistantMsg].slice(-MAX_MESSAGES_PER_SESSION),
-        context: [...sessionContext(s), { role: "user", content: trimmed || "（用户发来图片）", images: images?.length ? images : undefined, turn: assistantMsg.id }],
+        context: [...sessionContext(s), { role: "user", content: trimmed || "（用户发来内容）", images: images?.length ? images : undefined, files: files?.length ? files : undefined, turn: assistantMsg.id }],
     }));
 
     isGenerating = true;
@@ -697,6 +722,7 @@ export async function retryQaMessage(assistantMsgId: string): Promise<void> {
     }));
     await sendQaMessage(
         "上一轮执行中途失败。请从中断的地方继续完成剩余部分，已经完成的操作和说过的内容不要重复。",
+        undefined,
         undefined,
         { silentUser: true },
     );


### PR DESCRIPTION
贡献者：什锦杂货铺

（二编：由于我的分支是在官方更新前创建的，如今26年8月29日，显示贡献无法自动合并，且去同步官方main时，也显示冲突。我不知该如何处理该情况，请问是否方便由维护者协助处理与最新 main 的冲突？）
<img width="1233" height="577" alt="mmexport1787979777818" src="https://github.com/user-attachments/assets/cc33122e-fee7-4ecf-bf5e-4daf22125bf2" />


以下为一编内容：
改了components/phone-qa-app.tsx和lib/qa-chat-store.ts，和lib/qa-agent-engine.ts
1.新增工坊附件上传功能
入口：工坊app——点击输入框的+，+会旋转45°，呈现为×，并且显现上传附件+原有的添加图片的功能。
其中附件上传，仅支持.txt, .md, .json, .csv, .js, .ts, .tsx, .jsx, .html, .css
其余无法上传的附件，例如.pdf,.docx,都会在用户上传时，有对应弹窗提示，表示不支持该文件，无法上传。
同时附件上传只支持1mb以内。超过也会有弹窗表示无法上传。
（经过数次测试，以上内容属实）
2.优化工坊编辑消息为修改消息
以前的编辑消息，仅为单纯保存，不能让小坊根据新的消息重新生成新的内容。
而经过我的优化，新增“保存并发送”按钮，点击即可让小坊根据新内容重新生成。
并将修改消息页面增加了上传附件和图片，或删除已经上传过的附件和图片。
在逻辑上，如果用户修改了倒数第二轮的指令，系统会丢弃该消息之后的所有对话，让 AI 根据修改后的新内容重新接续话题。
同理，如果用户重新修改了正数第一轮对话，那么原本的第二轮、第三轮、第四轮对话……都会被丢弃。
（类似于deepseek修改消息的逻辑。但我暂没有做自由切换分支的功能）
另外，我保留了原有的“保存”按钮。按下即可单纯保存，不触发小坊重新生成。
但是，我删掉了原有的“取消”按钮，因为按钮多了不好看，且该功能可以通过右上角的×来实现。
（我没有做修改消息后“自动保存”的功能，所以用户点击右上角×，就可以直接恢复成修改前的指令，符合“取消”的逻辑）
经过数次测试，以上内容属实
希望作者采纳！
如果作者觉得排版或ui不好看也可以改
<img width="1280" height="1280" alt="8ffb8003b59ad329091ab702d4046a8c" src="https://github.com/user-attachments/assets/7c3f67c7-6c47-4eec-8737-39ad9f11f5a2" />
<img width="1280" height="1280" alt="4d7d45faa5004b3916c98e170d9c43d5" src="https://github.com/user-attachments/assets/73e5761e-c6db-45a4-80aa-cf7756154972" />