### PR TITLE
feat(preset): 预设多选(右滑进入/点行切换选中) + 按App高亮/仅显示/折叠；SwipeActionRow 支持右滑回调；优化预设条目渲染拖拽

### DIFF
--- a/components/settings/preset-manager.tsx
+++ b/components/settings/preset-manager.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useContext, useCallback, useMemo } from "react";
-import { Plus, Upload, Download, Trash2, RotateCcw, ChevronLeft, ChevronDown, GripVertical, MessageSquare, AlertCircle, Maximize2, Copy, Replace } from "lucide-react";
+import { Plus, Upload, Download, Trash2, RotateCcw, ChevronLeft, ChevronDown, GripVertical, MessageSquare, AlertCircle, Maximize2, Copy, Replace, CheckSquare, Check, Filter } from "lucide-react";
 import {
     loadPresets,
     savePresets,
@@ -30,6 +30,18 @@ import { useTouchSort } from "@/lib/use-touch-sort";
 // ── Tag helpers for backward compat (tags[] > featureTag + followUpOnly) ──
 function getPromptTags(p: Prompt): string[] {
     return getScopedPromptTags(p);
+}
+
+/** 条目是否命中选中的 App 大类集合（多选；空集合视为未筛选，全部命中）。 */
+function matchesSelectedAppTags(p: Prompt, tags: Set<string>): boolean {
+    if (!tags || tags.size === 0) return true;
+    const pt = getPromptTags(p);
+    if (tags.has("__universal__") && pt.length === 0) return true;
+    for (const t of tags) {
+        if (t === "__universal__") continue;
+        if (pt.includes(t)) return true;
+    }
+    return false;
 }
 
 function getPromptTagGroup(p: Prompt, tagGroups = CONTENT_SCOPE_TAG_GROUPS) {
@@ -84,6 +96,27 @@ function matchMarkerByName(name: string): string | null {
     return MARKER_NAMES_NORMALIZED[normalizeMarkerName(name)] ?? null;
 }
 
+// 构建「有序 + 孤儿」的条目列表，并按 identifier 去重。
+// 若 prompt_order 含重复 entry 或 prompts 含重复 identifier，会导致同一条目渲染多次、
+// reorder 索引错位、touch 拖拽拖到错误的条目；这里统一保首个出现，保证渲染与重排视图唯一。
+function buildDisplayedPrompts(preset: PresetConfig): Prompt[] {
+    const seen = new Set<string>();
+    const out: Prompt[] = [];
+    const push = (p?: Prompt) => {
+        if (p && !seen.has(p.identifier)) {
+            seen.add(p.identifier);
+            out.push(p);
+        }
+    };
+    if (preset.prompt_order && preset.prompt_order.length > 0) {
+        for (const e of preset.prompt_order) {
+            push(preset.prompts.find(x => x.identifier === e.identifier));
+        }
+    }
+    for (const p of preset.prompts || []) push(p);
+    return out;
+}
+
 const MASCOT_PRESET_STORAGE_TOOL_NAMES = new Set([
     "创建剧情预设",
     "克隆内置预设",
@@ -130,6 +163,25 @@ export function PresetManager({ isActive = true }: { isActive?: boolean } = {}) 
     const [expandTarget, setExpandTarget] = useState<{ identifier: string; field: string } | null>(null);
     const [importError, setImportError] = useState<string | null>(null);
     const [customApps, setCustomApps] = useState<InstalledCustomApp[]>([]);
+    // ── 多选模式（右滑选中 / 批量操作 / 多选拖拽） ──
+    const [selectMode, setSelectMode] = useState(false);
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+    const [confirmDeleteSelected, setConfirmDeleteSelected] = useState(false);
+
+    // ── 按 App 筛选（高亮/仅显示/仅折叠/同类折叠） ──
+    const [appFilterOpen, setAppFilterOpen] = useState(false);
+    const [appFilterMode, setAppFilterMode] = useState<"highlight" | "only-show" | "collapse" | "group-collapse">("highlight");
+    const [appFilterTags, setAppFilterTags] = useState<Set<string>>(new Set()); // 选中的大类 tag 集合（可多选）
+    const [expandedCollapseGroups, setExpandedCollapseGroups] = useState<Set<string>>(new Set()); // 已展开的折叠组 key
+
+    const toggleFilterTag = useCallback((tag: string) => {
+        setAppFilterTags(prev => {
+            const next = new Set(prev);
+            if (next.has(tag)) next.delete(tag);
+            else next.add(tag);
+            return next;
+        });
+    }, []);
 
     const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -452,33 +504,122 @@ export function PresetManager({ isActive = true }: { isActive?: boolean } = {}) 
     };
 
     // ── Prompt reorder (shared by HTML5 drag & touch sort) ──
+    // 多选模式下拖动选中的条目 → 整组批量移动；否则单条目移动。
     const handlePromptReorder = useCallback((fromIndex: number, toIndex: number) => {
         if (!editingId) return;
         const preset = presets.find(p => p.id === editingId);
         if (!preset) return;
-        // Build full display list (same logic as render: ordered + orphans)
-        const ordered = preset.prompt_order && preset.prompt_order.length > 0
-            ? preset.prompt_order.map(e => preset.prompts.find(p => p.identifier === e.identifier)).filter((p): p is Prompt => !!p)
-            : [...preset.prompts];
-        const orderedIds = new Set(ordered.map(p => p.identifier));
-        const orphans = preset.prompts.filter(p => !orderedIds.has(p.identifier));
-        const displayed = [...ordered, ...orphans];
-        // Reorder
-        const [item] = displayed.splice(fromIndex, 1);
-        displayed.splice(toIndex, 0, item);
-        const newOrder = displayed.map(p => ({
+        // Build full display list (same logic as render: ordered + orphans, deduped by identifier)
+        const displayed = buildDisplayedPrompts(preset);
+        const dragged = displayed[fromIndex];
+        if (!dragged) return;
+
+        let newDisplayed: Prompt[];
+        const isBulk = selectMode && selectedIds.size > 1 && dragged.identifier && selectedIds.has(dragged.identifier);
+        if (isBulk) {
+            // 整组选中条目一起移动（选中集内部相对顺序保持不变）
+            const selected = displayed.filter(p => selectedIds.has(p.identifier));
+            if (selected.length === displayed.length) return; // 全选时移动无意义
+            const rest = displayed.filter(p => !selectedIds.has(p.identifier));
+            // 锚点：向下拖时插到「原位置 > to 的第一个未选中条目」之前；向上拖同理用 >= to
+            const anchor = rest.find(p => {
+                const idx = displayed.indexOf(p);
+                return toIndex > fromIndex ? idx > toIndex : idx >= toIndex;
+            });
+            const insertPos = anchor ? rest.indexOf(anchor) : rest.length;
+            newDisplayed = [...rest.slice(0, insertPos), ...selected, ...rest.slice(insertPos)];
+        } else {
+            // 单条目移动（未选中条目 / 单选）
+            const [item] = displayed.splice(fromIndex, 1);
+            displayed.splice(toIndex, 0, item);
+            newDisplayed = displayed;
+        }
+        const newOrder = newDisplayed.map(p => ({
             identifier: p.identifier,
             enabled: preset.prompt_order
                 ? (preset.prompt_order.find(o => o.identifier === p.identifier)?.enabled ?? p.enabled)
                 : p.enabled,
         }));
-        updatePreset(preset.id, { prompts: displayed, prompt_order: newOrder });
-    }, [editingId, presets]);
+        updatePreset(preset.id, { prompts: newDisplayed, prompt_order: newOrder });
+    }, [editingId, presets, selectMode, selectedIds]);
 
     const { containerRef: promptListRef, onTouchStart: onPromptTouchStart, onTouchMove: onPromptTouchMove, onTouchEnd: onPromptTouchEnd } = useTouchSort(handlePromptReorder);
 
     // ── 条目左滑操作（微信式：左滑露出「新增/删除」） ──
     const swipe = useSwipeActions();
+
+    // ── 多选模式：右滑选中 / 批量操作 / 多选拖拽 ──
+    const enterSelectMode = useCallback(() => {
+        setSelectMode(true);
+        setEditingPromptId(null); // 收起展开的编辑，避免手势冲突
+        swipe.close();
+    }, [swipe]);
+
+    const exitSelectMode = useCallback(() => {
+        setSelectMode(false);
+        setSelectedIds(new Set());
+        swipe.close();
+    }, [swipe]);
+
+    const toggleSelect = useCallback((identifier: string) => {
+        setSelectedIds(prev => {
+            const next = new Set(prev);
+            if (next.has(identifier)) next.delete(identifier);
+            else next.add(identifier);
+            return next;
+        });
+    }, []);
+
+    // 右滑条目 → 选中并进入多选模式；已处于多选模式时追加选中
+    const handleSwipeRightSelect = useCallback((identifier: string) => {
+        setSelectMode(true);
+        setEditingPromptId(null);
+        setSelectedIds(prev => {
+            const next = new Set(prev);
+            next.add(identifier);
+            return next;
+        });
+        swipe.close();
+    }, [swipe]);
+
+    const selectAllPrompts = useCallback(() => {
+        const preset = presets.find(p => p.id === editingId);
+        if (!preset) return;
+        setSelectedIds(new Set(preset.prompts.map(p => p.identifier)));
+    }, [presets, editingId]);
+
+    const bulkSetEnabled = useCallback((enabled: boolean) => {
+        const preset = presets.find(p => p.id === editingId);
+        if (!preset || selectedIds.size === 0) return;
+        const newPrompts = preset.prompts.map(p =>
+            selectedIds.has(p.identifier) ? { ...p, enabled } : p,
+        );
+        const newOrder = preset.prompt_order?.map(o =>
+            selectedIds.has(o.identifier) ? { ...o, enabled } : o,
+        );
+        updatePreset(preset.id, { prompts: newPrompts, ...(newOrder ? { prompt_order: newOrder } : {}) });
+    }, [presets, editingId, selectedIds]);
+
+    const bulkExportSelected = useCallback(async () => {
+        const preset = presets.find(p => p.id === editingId);
+        if (!preset || selectedIds.size === 0) return;
+        const selected = preset.prompts.filter(p => selectedIds.has(p.identifier));
+        const { downloadFile } = await import("@/lib/download-utils");
+        const blob = new Blob([JSON.stringify(selected, null, 2)], { type: "application/json" });
+        await downloadFile(blob, `${preset.name || "preset"}-entries.json`);
+    }, [presets, editingId, selectedIds]);
+
+    const deleteSelectedPrompts = useCallback(() => {
+        const preset = presets.find(p => p.id === editingId);
+        if (!preset || selectedIds.size === 0) return;
+        const newPrompts = preset.prompts.filter(p => !selectedIds.has(p.identifier));
+        const newOrder = (preset.prompt_order || []).filter(o => !selectedIds.has(o.identifier));
+        updatePreset(preset.id, { prompts: newPrompts, prompt_order: newOrder });
+        if (editingPromptId && selectedIds.has(editingPromptId)) setEditingPromptId(null);
+        setSelectedIds(new Set());
+        setConfirmDeleteSelected(false);
+        setSelectMode(false);
+    }, [presets, editingId, selectedIds, editingPromptId]);
 
     const insertPromptAfter = (preset: PresetConfig, afterIdentifier: string) => {
         const newPrompt = {
@@ -489,13 +630,8 @@ export function PresetManager({ isActive = true }: { isActive?: boolean } = {}) 
             injection_depth: 0,
             enabled: true,
         };
-        // 与渲染一致的显示顺序（prompt_order + 孤儿条目）
-        const ordered = preset.prompt_order && preset.prompt_order.length > 0
-            ? preset.prompt_order.map(entry => preset.prompts.find(p => p.identifier === entry.identifier)).filter((p): p is Prompt => !!p)
-            : [...(preset.prompts || [])];
-        const orderedIds = new Set(ordered.map(p => p.identifier));
-        const orphans = (preset.prompts || []).filter(p => !orderedIds.has(p.identifier));
-        const displayed = [...ordered, ...orphans];
+        // 与渲染一致的显示顺序（去重后的 prompt_order + 孤儿条目）
+        const displayed = buildDisplayedPrompts(preset);
         const idx = displayed.findIndex(p => p.identifier === afterIdentifier);
         if (idx >= 0) displayed.splice(idx + 1, 0, newPrompt);
         else displayed.push(newPrompt);
@@ -784,14 +920,16 @@ export function PresetManager({ isActive = true }: { isActive?: boolean } = {}) 
                                             <span>重置默认</span>
                                         </button>
                                     ) : (
-                                        <button
-                                            type="button"
-                                            onClick={() => setConfirmDeleteId(preset.id)}
-                                            className="inline-flex h-10 items-center justify-center gap-1.5 rounded-[20px] border border-black/10 bg-white px-4 text-xs font-bold text-[var(--c-danger)] shadow-sm transition-all hover:bg-gray-50 hover:shadow-md active:scale-95"
-                                        >
-                                            <Trash2 size={15} strokeWidth={1.8} />
-                                            <span>删除预设</span>
-                                        </button>
+                                        <>
+                                            <button
+                                                type="button"
+                                                onClick={() => setConfirmDeleteId(preset.id)}
+                                                className="inline-flex h-10 items-center justify-center gap-1.5 rounded-[20px] border border-black/10 bg-white px-4 text-xs font-bold text-[var(--c-danger)] shadow-sm transition-all hover:bg-gray-50 hover:shadow-md active:scale-95"
+                                            >
+                                                <Trash2 size={15} strokeWidth={1.8} />
+                                                <span>删除预设</span>
+                                            </button>
+                                        </>
                                     )}
                                 </div>
                                 <h2 className="mx-2 mb-0 mt-2 ts-20 font-bold leading-none text-black">Preset Info</h2>
@@ -1029,7 +1167,63 @@ export function PresetManager({ isActive = true }: { isActive?: boolean } = {}) 
 
                                 {/* Prompts Section */}
                                 <div className="flex flex-col gap-4 mt-3">
-                                    <h2 className="mx-2 mb-0 mt-2 ts-20 font-bold leading-none text-black">Prompt Entries ({preset.prompts?.length || 0})</h2>
+                                    <div className="mx-2 mb-0 mt-2 flex items-center justify-between">
+                                        <div className="flex items-center gap-2">
+                                            <h2 className="ts-20 font-bold leading-none text-black">Prompt Entries ({preset.prompts?.length || 0})</h2>
+                                            <button
+                                                type="button"
+                                                onClick={() => setAppFilterOpen(true)}
+                                                className={`inline-flex h-8 items-center justify-center gap-1 rounded-full border px-3 text-xs font-bold shadow-sm transition-all active:scale-95 ${appFilterTags.size > 0 || appFilterMode !== "highlight" ? "border-[var(--c-icon-active)] bg-[var(--c-icon-active)] text-white" : "border-black/10 bg-white text-gray-800 hover:bg-gray-50"}`}
+                                            >
+                                                <Filter size={14} strokeWidth={1.8} />
+                                                <span>按 App{appFilterTags.size > 0 ? ` · ${appFilterTags.size} 个` : ""}</span>
+                                            </button>
+                                        </div>
+                                        {!selectMode && (
+                                            <button
+                                                type="button"
+                                                onClick={enterSelectMode}
+                                                className="inline-flex h-8 items-center justify-center gap-1 rounded-full border border-black/10 bg-white px-3 text-xs font-bold text-gray-800 shadow-sm transition-all hover:bg-gray-50 active:scale-95"
+                                            >
+                                                <CheckSquare size={14} strokeWidth={1.8} />
+                                                <span>多选</span>
+                                            </button>
+                                        )}
+                                    </div>
+
+                                    {selectMode && (
+                                        <div className="multi-select-float-bar">
+                                            <div className="msfb-main">
+                                                <span className="msfb-count">已选 {selectedIds.size} 项</span>
+                                                <button type="button" className="msfb-btn" onClick={selectAllPrompts}>
+                                                    <CheckSquare size={15} strokeWidth={1.8} />
+                                                    <span>全选</span>
+                                                </button>
+                                                <button type="button" className="msfb-btn" onClick={() => bulkSetEnabled(true)} disabled={selectedIds.size === 0}>
+                                                    <Check size={15} strokeWidth={2} />
+                                                    <span>启用</span>
+                                                </button>
+                                                <button type="button" className="msfb-btn" onClick={() => bulkSetEnabled(false)} disabled={selectedIds.size === 0}>
+                                                    <RotateCcw size={15} strokeWidth={1.8} />
+                                                    <span>禁用</span>
+                                                </button>
+                                                <button type="button" className="msfb-btn" onClick={() => bulkExportSelected()} disabled={selectedIds.size === 0}>
+                                                    <Download size={15} strokeWidth={1.8} />
+                                                    <span>导出</span>
+                                                </button>
+                                                <button type="button" className="msfb-btn msfb-danger" onClick={() => setConfirmDeleteSelected(true)} disabled={selectedIds.size === 0}>
+                                                    <Trash2 size={15} strokeWidth={1.8} />
+                                                    <span>删除</span>
+                                                </button>
+                                            </div>
+                                            <div className="msfb-actions">
+                                                <button type="button" className="msfb-btn msfb-done" onClick={exitSelectMode}>
+                                                    <Check size={15} strokeWidth={2} />
+                                                    <span>完成</span>
+                                                </button>
+                                            </div>
+                                        </div>
+                                    )}
 
                                     <div ref={promptListRef} className="flex flex-col gap-2"
                                         onTouchMove={onPromptTouchMove}
@@ -1037,17 +1231,165 @@ export function PresetManager({ isActive = true }: { isActive?: boolean } = {}) 
                                         onTouchCancel={onPromptTouchEnd}
                                     >
                                         {(() => {
-                                            // Display prompts in prompt_order sequence
-                                            const orderedPrompts = preset.prompt_order && preset.prompt_order.length > 0
-                                                ? preset.prompt_order
-                                                    .map(entry => preset.prompts.find(p => p.identifier === entry.identifier))
-                                                    .filter((p): p is Prompt => !!p)
-                                                : preset.prompts || [];
-                                            // Append any prompts not in prompt_order (orphans)
-                                            const orderedIds = new Set(orderedPrompts.map(p => p.identifier));
-                                            const orphans = (preset.prompts || []).filter(p => !orderedIds.has(p.identifier));
-                                            return [...orderedPrompts, ...orphans];
-                                        })().map((prompt, index) => {
+                                            // 按 prompt_order + 孤儿构建唯一列表（identifier 去重，避免重复条目/索引错位/拖错条目）
+                                            const allPrompts = buildDisplayedPrompts(preset);
+
+                                            // ── 按 App 大类筛选（可多选） ──
+                                            const filterTags = appFilterTags;
+                                            const matchesFilter = (p: Prompt) => matchesSelectedAppTags(p, filterTags);
+                                            const hasFilter = filterTags.size > 0;
+
+                                            if (appFilterMode === "only-show" && hasFilter) {
+                                                return allPrompts.filter(matchesFilter).map(p => ({ type: "item" as const, prompt: p }));
+                                            }
+
+                                            // 获取条目所属大类 key：取第一个命中的 group tag；无匹配 → "__universal__"
+                                            const getGroupKeyOf = (p: Prompt): string => {
+                                                const pt = getPromptTags(p);
+                                                if (pt.length === 0) return "__universal__";
+                                                const group = findTagGroupForTags(tagGroups, pt);
+                                                if (group && group.tags.length > 0) return group.tags[0];
+                                                // 无已知 group：用第一个 tag 作为兜底大类
+                                                return pt[0];
+                                            };
+                                            const getGroupLabelOf = (tag: string): string => {
+                                                if (tag === "__universal__") return "通用";
+                                                return tagGroups.find(g => g.tags[0] === tag)?.label || tag;
+                                            };
+
+                                            // collapse / group-collapse 独立于 App 选择：
+                                            // 未选 App → 对所有 App 的条目按大类折叠；选了 App → 只折叠该 App 条目 + 高亮
+                                            if (appFilterMode === "collapse" || appFilterMode === "group-collapse") {
+                                                type RenderItem =
+                                                    | { type: "item"; prompt: Prompt }
+                                                    | { type: "collapsed"; prompts: Prompt[]; groupKey: string; label: string }
+                                                    | { type: "collapse-header"; groupKey: string; label: string; count: number };
+                                                const result: RenderItem[] = [];
+
+                                                const makeCollapsedOrExpanded = (prompts: Prompt[], key: string, label: string): RenderItem[] => {
+                                                    if (expandedCollapseGroups.has(key)) {
+                                                        return [{ type: "collapse-header", groupKey: key, label, count: prompts.length },
+                                                            ...prompts.map(p => ({ type: "item" as const, prompt: p }))];
+                                                    }
+                                                    return [{ type: "collapsed", prompts, groupKey: key, label }];
+                                                };
+
+                                                // 是否参与本次折叠：选了 App 只看该 App；未选 App 全部参与（按各自大类）
+                                                const participates = (p: Prompt): boolean => !hasFilter || matchesFilter(p);
+
+                                                if (appFilterMode === "group-collapse") {
+                                                    // 整组折叠：按大类把所有参与条目收进各自的折叠组
+                                                    const byGroup = new Map<string, Prompt[]>();
+                                                    for (const p of allPrompts) {
+                                                        if (!participates(p)) {
+                                                            // 非参与条目原样保留
+                                                            result.push({ type: "item", prompt: p });
+                                                            continue;
+                                                        }
+                                                        const gk = getGroupKeyOf(p);
+                                                        const arr = byGroup.get(gk) || [];
+                                                        arr.push(p);
+                                                        byGroup.set(gk, arr);
+                                                    }
+                                                    // 把每个折叠组插回正确位置：按该类第一条出现的位置
+                                                    // 而非参与条目已在上面按原位 push，这里原位塞折叠组会乱序；
+                                                    // 简化：按大类在第一处匹配前插入组（保序做法见 collapse，此处用稳定插入）
+                                                    // 采用与 collapse 一致的稳序：重排，组放到该类第一项处。
+                                                    // 这里改用「按原始顺序遍历，遇某大类第一项时插组，非参与项原样」：
+                                                    const ordered: RenderItem[] = [];
+                                                    const seenGroups = new Set<string>();
+                                                    const matchedCount = new Map<string, number>();
+                                                    for (const p of allPrompts) {
+                                                        if (!participates(p)) { ordered.push({ type: "item", prompt: p }); continue; }
+                                                        const gk = getGroupKeyOf(p);
+                                                        const arr = byGroup.get(gk)!;
+                                                        if (!seenGroups.has(gk)) {
+                                                            seenGroups.add(gk);
+                                                            if (arr.length >= 2) {
+                                                                ordered.push(...makeCollapsedOrExpanded(arr, `g-${gk}`, getGroupLabelOf(gk)));
+                                                            } else {
+                                                                arr.forEach(x => ordered.push({ type: "item", prompt: x }));
+                                                            }
+                                                        }
+                                                        matchedCount.set(gk, (matchedCount.get(gk) || 0) + 1);
+                                                        // 属于该组的后续条目已被组收纳，跳过（不再单独 push）
+                                                    }
+                                                    return ordered;
+                                                }
+
+                                                // collapse：相邻折叠 —— 连续同类（同一大类 key）条目折叠成段
+                                                let i = 0;
+                                                let segIdx = 0;
+                                                while (i < allPrompts.length) {
+                                                    const p = allPrompts[i];
+                                                    const gk = getGroupKeyOf(p);
+                                                    if (participates(p)) {
+                                                        // 收集连续同类段
+                                                        const group: Prompt[] = [];
+                                                        let j = i;
+                                                        while (j < allPrompts.length && participates(allPrompts[j]) && getGroupKeyOf(allPrompts[j]) === gk) {
+                                                            group.push(allPrompts[j]);
+                                                            j++;
+                                                        }
+                                                        if (group.length >= 2) {
+                                                            result.push(...makeCollapsedOrExpanded(group, `g-${gk}-seg${segIdx++}`, getGroupLabelOf(gk)));
+                                                        } else {
+                                                            result.push({ type: "item", prompt: p });
+                                                        }
+                                                        i = j;
+                                                    } else {
+                                                        result.push({ type: "item", prompt: p });
+                                                        i++;
+                                                    }
+                                                }
+                                                return result;
+                                            }
+
+                                            return allPrompts.map(p => ({ type: "item" as const, prompt: p }));
+                                        })().flatMap((renderItem, _flatIndex) => {
+                                            const toggleExpand = (gKey: string) => {
+                                                setExpandedCollapseGroups(prev => {
+                                                    const next = new Set(prev);
+                                                    if (next.has(gKey)) next.delete(gKey);
+                                                    else next.add(gKey);
+                                                    return next;
+                                                });
+                                            };
+
+                                            if (renderItem.type === "collapse-header") {
+                                                return [
+                                                    <div key={`collapse-header-${_flatIndex}`} className="ui-entry-card ui-entry-collapsed-group" data-app-match="1" onClick={() => toggleExpand(renderItem.groupKey)}>
+                                                        <div className="flex items-center justify-between cursor-pointer">
+                                                            <div className="flex items-center gap-2">
+                                                                <ChevronDown size={16} />
+                                                                <span className="text-xs font-bold text-gray-800">{renderItem.label}</span>
+                                                                <span className="menu-desc ts-11">· {renderItem.count} 个条目</span>
+                                                            </div>
+                                                            <span className="menu-desc ts-11">点击收起</span>
+                                                        </div>
+                                                    </div>,
+                                                ];
+                                            }
+
+                                            if (renderItem.type === "collapsed") {
+                                                return [
+                                                    <div key={`collapsed-${_flatIndex}`} className="ui-entry-card ui-entry-collapsed-group" data-app-match="1" onClick={() => toggleExpand(renderItem.groupKey)}>
+                                                        <div className="flex items-center justify-between cursor-pointer">
+                                                            <div className="flex items-center gap-2">
+                                                                <ChevronDown size={16} style={{ transform: "rotate(-90deg)" }} />
+                                                                <span className="text-xs font-bold text-gray-800">{renderItem.label}</span>
+                                                                <span className="menu-desc ts-11">· {renderItem.prompts.length} 个条目已折叠</span>
+                                                            </div>
+                                                            <span className="menu-desc ts-11">点击展开</span>
+                                                        </div>
+                                                    </div>,
+                                                ];
+                                            }
+                                            const prompt = renderItem.prompt;
+                                            const index = (() => {
+                                                const allPrompts = buildDisplayedPrompts(preset);
+                                                return allPrompts.findIndex(p => p.identifier === prompt.identifier);
+                                            })();
                                             const isEditing = editingPromptId === prompt.identifier;
                                             // Effective enabled: prompt_order overrides prompt.enabled
                                             const effectiveEnabled = preset.prompt_order
@@ -1065,8 +1407,11 @@ export function PresetManager({ isActive = true }: { isActive?: boolean } = {}) 
                                                     controller={swipe}
                                                     id={prompt.identifier}
                                                     disabled={isEditing}
+                                                    leftSwipeDisabled={selectMode}
+                                                    rightSwipeEnabled
+                                                    onSwipeRight={() => handleSwipeRightSelect(prompt.identifier)}
                                                     onTouchStart={isEditing ? undefined : (e) => onPromptTouchStart(index, e)}
-                                                    actions={
+                                                    actions={selectMode ? null : (
                                                         <>
                                                             <button
                                                                 type="button"
@@ -1114,13 +1459,19 @@ export function PresetManager({ isActive = true }: { isActive?: boolean } = {}) 
                                                                 <Trash2 size={18} strokeWidth={2} />
                                                                 <span>删除</span>
                                                             </button>
-                                                        </>
+                                                        </>)
                                                     }
                                                 >
                                                     <div
                                                     className="ui-entry-card"
                                                     data-active={isEditing}
+                                                    data-selected={selectMode && selectedIds.has(prompt.identifier) ? "true" : undefined}
                                                     data-disabled={!effectiveEnabled}
+                                                    data-app-match={(() => {
+                                                        if (appFilterTags.size === 0) return undefined;
+                                                        if (appFilterMode === "only-show") return undefined;
+                                                        return matchesSelectedAppTags(prompt, appFilterTags) ? "1" : "0";
+                                                    })()}
                                                     style={{
                                                         gap: isEditing ? "12px" : "0px",
                                                         userSelect: isEditing ? undefined : "none",
@@ -1135,14 +1486,31 @@ export function PresetManager({ isActive = true }: { isActive?: boolean } = {}) 
                                                                 swipe.close();
                                                                 return;
                                                             }
+                                                            if (selectMode) {
+                                                                toggleSelect(prompt.identifier);
+                                                                return;
+                                                            }
                                                             setEditingPromptId(isEditing ? null : prompt.identifier);
                                                         }}
                                                         className="flex justify-between items-start gap-2 cursor-pointer"
                                                     >
                                                         <div className="flex gap-3 flex-1 min-w-0 items-start" style={{ cursor: isEditing ? "default" : "grab" }}>
-                                                            <div className="ui-entry-icon mt-[2px]">
-                                                                <MessageSquare size={20} />
-                                                            </div>
+                                                            {selectMode ? (
+                                                                <div
+                                                                    className="mt-[2px] flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2"
+                                                                    style={{
+                                                                        borderColor: selectedIds.has(prompt.identifier) ? "var(--c-icon-active)" : "rgba(0,0,0,0.25)",
+                                                                        background: selectedIds.has(prompt.identifier) ? "var(--c-icon-active)" : "transparent",
+                                                                        color: "#fff",
+                                                                    }}
+                                                                >
+                                                                    {selectedIds.has(prompt.identifier) && <Check size={13} strokeWidth={3} />}
+                                                                </div>
+                                                            ) : (
+                                                                <div className="ui-entry-icon mt-[2px]">
+                                                                    <MessageSquare size={20} />
+                                                                </div>
+                                                            )}
                                                             <div className="flex flex-col gap-1 flex-1">
                                                                 <div className="flex items-center gap-[6px]">
                                                                     {/* Drag Handle shown subtly */}
@@ -1495,6 +1863,18 @@ export function PresetManager({ isActive = true }: { isActive?: boolean } = {}) 
                     onCancel={() => setConfirmDeleteEntry(null)}
                 />
             )}
+            {/* Confirm bulk delete selected entries */}
+            {confirmDeleteSelected && editingId && (
+                <ConfirmDialog
+                    title="确认批量删除？"
+                    message={`将删除已选的 ${selectedIds.size} 个条目，删除后无法恢复。是否继续？`}
+                    icon={AlertCircle}
+                    variant="danger"
+                    confirmLabel="确认删除"
+                    onConfirm={() => deleteSelectedPrompts()}
+                    onCancel={() => setConfirmDeleteSelected(false)}
+                />
+            )}
 
             {importError && (
                 <ConfirmDialog
@@ -1558,6 +1938,84 @@ export function PresetManager({ isActive = true }: { isActive?: boolean } = {}) 
                         placeholder="在此输入提示词内容..."
                         onClose={() => setExpandTarget(null)}
                     />
+                );
+            })()}
+
+            {/* ── 按 App 筛选弹窗 ── */}
+            {appFilterOpen && editingId && (() => {
+                return (
+                    <BottomSheet title="按 App 筛选条目" onClose={() => setAppFilterOpen(false)}>
+                        <div className="flex flex-col gap-4">
+                            {/* 选择 App 大类（可多选，不细分 minor / 起效范围） */}
+                            <div>
+                                <div className="menu-label ts-12 mb-2">选择 App{appFilterTags.size > 0 ? `（已选 ${appFilterTags.size} 个）` : "（可多选）"}</div>
+                                <div className="flex flex-wrap gap-2">
+                                    {tagGroups.map(g => {
+                                        const tag = g.tags.length > 0 ? g.tags[0] : "__universal__";
+                                        const selected = appFilterTags.has(tag);
+                                        return (
+                                            <button
+                                                key={g.id}
+                                                type="button"
+                                                onClick={() => toggleFilterTag(tag)}
+                                                className={`inline-flex items-center justify-center gap-1 rounded-full border px-3 py-1.5 text-xs font-bold transition-all active:scale-95 ${selected ? "border-[var(--c-icon-active)] bg-[var(--c-icon-active)] text-white" : "border-black/10 bg-white text-gray-800 hover:bg-gray-50"}`}
+                                            >
+                                                {g.label}
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+
+                            {/* 选择模式（再次点击折叠模式可退出） */}
+                            <div>
+                                <div className="menu-label ts-12 mb-2">操作模式</div>
+                                <div className="flex flex-col gap-2">
+                                    {([
+                                        { id: "highlight", label: "高亮显示", desc: "匹配条目高亮，其它变暗" },
+                                        { id: "only-show", label: "仅显示", desc: "只显示匹配条目，隐藏其它" },
+                                        { id: "collapse", label: "仅折叠", desc: "相邻同类条目折叠为摘要，可点击展开/收起；再次点击退出折叠" },
+                                        { id: "group-collapse", label: "同类折叠", desc: "所有同类条目折叠成一组（不管分散在哪）；再次点击退出折叠" },
+                                    ] as const).map(opt => {
+                                        const isActive = appFilterMode === opt.id;
+                                        return (
+                                            <button
+                                                key={opt.id}
+                                                type="button"
+                                                onClick={() => {
+                                                    if (isActive && (opt.id === "collapse" || opt.id === "group-collapse")) {
+                                                        // 再次点击折叠模式 → 退出折叠（回到高亮，保留 App 选中用于高亮/仅显示）
+                                                        setAppFilterMode("highlight");
+                                                        setExpandedCollapseGroups(new Set());
+                                                    } else {
+                                                        setAppFilterMode(opt.id);
+                                                    }
+                                                }}
+                                                className={`flex items-center justify-between rounded-xl border px-4 py-3 text-left transition-all active:scale-[0.98] ${isActive ? "border-[var(--c-icon-active)] bg-[var(--c-icon-active)]/5" : "border-black/10 bg-white hover:bg-gray-50"}`}
+                                            >
+                                                <div className="flex flex-col gap-0.5">
+                                                    <span className="text-xs font-bold text-gray-800">{opt.label}</span>
+                                                    <span className="menu-desc ts-11">{opt.desc}</span>
+                                                </div>
+                                                <div className={`h-4 w-4 rounded-full border-2 ${isActive ? "border-[var(--c-icon-active)] bg-[var(--c-icon-active)]" : "border-gray-300"}`} />
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+
+                            {/* 清除按钮 */}
+                            {(appFilterTags.size > 0 || appFilterMode !== "highlight") && (
+                                <button
+                                    type="button"
+                                    onClick={() => { setAppFilterTags(new Set()); setAppFilterMode("highlight"); setExpandedCollapseGroups(new Set()); }}
+                                    className="ui-btn w-full"
+                                >
+                                    清除筛选
+                                </button>
+                            )}
+                        </div>
+                    </BottomSheet>
                 );
             })()}
         </div>

--- a/components/ui/swipe-actions.tsx
+++ b/components/ui/swipe-actions.tsx
@@ -16,6 +16,10 @@ interface SwipeGesture {
     base: number;
     locked: boolean;
     offset: number;
+    direction: "left" | "right" | null;
+    left: boolean;
+    right: boolean;
+    onSwipeRight: (() => void) | null;
 }
 
 export function useSwipeActions(width = DEFAULT_ACTIONS_WIDTH) {
@@ -32,11 +36,17 @@ export function useSwipeActions(width = DEFAULT_ACTIONS_WIDTH) {
     const getContent = (wrapper: HTMLElement) =>
         wrapper.querySelector(":scope > .ui-swipe-content") as HTMLElement | null;
 
-    const onPointerDown = (e: React.PointerEvent<HTMLDivElement>, id: string) => {
+    const onPointerDown = (e: React.PointerEvent<HTMLDivElement>, id: string, opts?: { left?: boolean; right?: boolean; onSwipeRight?: () => void }) => {
         suppressClickRef.current = false;
         if (openId && openId !== id) close();
         const base = openId === id ? -width : 0;
-        gestureRef.current = { id, pointerId: e.pointerId, startX: e.clientX, startY: e.clientY, base, locked: false, offset: base };
+        gestureRef.current = {
+            id, pointerId: e.pointerId, startX: e.clientX, startY: e.clientY, base,
+            locked: false, offset: base, direction: null,
+            left: opts?.left !== false,
+            right: opts?.right === true,
+            onSwipeRight: opts?.onSwipeRight ?? null,
+        };
     };
 
     const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -45,20 +55,27 @@ export function useSwipeActions(width = DEFAULT_ACTIONS_WIDTH) {
         const dx = e.clientX - g.startX;
         const dy = e.clientY - g.startY;
         if (!g.locked) {
-            // 竖向意图（滚动/长按排序）时放弃左滑；横向超过阈值才锁定
+            // 竖向意图（滚动/长按排序）时放弃手势；横向超过阈值才锁定
             if (Math.abs(dy) > 12 && Math.abs(dy) > Math.abs(dx)) {
                 gestureRef.current = null;
                 return;
             }
             if (Math.abs(dx) < 8 || Math.abs(dx) <= Math.abs(dy)) return;
+            // 方向约束：左滑需该行允许左滑，右滑需该行允许右滑
+            if (dx < 0 && !g.left) return;
+            if (dx > 0 && !g.right) return;
             g.locked = true;
+            g.direction = dx < 0 ? "left" : "right";
             setSwipingId(g.id);
             try { e.currentTarget.setPointerCapture(e.pointerId); } catch { /* ignore */ }
         }
         if (e.cancelable) e.preventDefault();
         const content = getContent(e.currentTarget);
         if (!content) return;
-        g.offset = Math.min(0, Math.max(-width, g.base + dx));
+        // 左滑露右侧操作；右滑向右位移（多选选中手势）
+        g.offset = g.direction === "right"
+            ? Math.min(width, Math.max(0, g.base + dx))
+            : Math.min(0, Math.max(-width, g.base + dx));
         content.style.transition = "none";
         content.style.transform = `translateX(${g.offset}px)`;
     };
@@ -69,8 +86,21 @@ export function useSwipeActions(width = DEFAULT_ACTIONS_WIDTH) {
         gestureRef.current = null;
         if (!g.locked) return;
         suppressClickRef.current = true;
-        const open = g.offset < -width / 2;
         const content = getContent(e.currentTarget);
+        // 右滑超过阈值 → 触发右滑回调（多选选中），随后回弹
+        if (g.direction === "right" && g.offset > width / 2) {
+            const onRight = g.onSwipeRight;
+            if (content) {
+                content.style.transition = "transform 0.2s ease";
+                content.style.transform = "translateX(0px)";
+            }
+            const id = g.id;
+            setOpenId(null);
+            window.setTimeout(() => setSwipingId(cur => (cur === id ? null : cur)), 220);
+            onRight?.();
+            return;
+        }
+        const open = g.offset < -width / 2;
         if (content) {
             content.style.transition = "transform 0.2s ease";
             content.style.transform = `translateX(${open ? -width : 0}px)`;
@@ -108,12 +138,15 @@ export function useSwipeActions(width = DEFAULT_ACTIONS_WIDTH) {
 
 export type SwipeActionsController = ReturnType<typeof useSwipeActions>;
 
-export function SwipeActionRow({ controller, id, disabled, actions, onTouchStart, children }: {
+export function SwipeActionRow({ controller, id, disabled, actions, onTouchStart, onSwipeRight, rightSwipeEnabled = false, leftSwipeDisabled = false, children }: {
     controller: SwipeActionsController;
     id: string;
     disabled?: boolean;
     actions: ReactNode;
     onTouchStart?: (e: React.TouchEvent<HTMLDivElement>) => void;
+    onSwipeRight?: () => void;
+    rightSwipeEnabled?: boolean;
+    leftSwipeDisabled?: boolean;
     children: ReactNode;
 }) {
     return (
@@ -121,7 +154,7 @@ export function SwipeActionRow({ controller, id, disabled, actions, onTouchStart
             className="ui-swipe-wrap"
             data-swipe-id={id}
             onTouchStart={onTouchStart}
-            onPointerDown={disabled ? undefined : (e) => controller.onPointerDown(e, id)}
+            onPointerDown={disabled ? undefined : (e) => controller.onPointerDown(e, id, { left: !leftSwipeDisabled, right: rightSwipeEnabled, onSwipeRight })}
             onPointerMove={disabled ? undefined : controller.onPointerMove}
             onPointerUp={disabled ? undefined : controller.onPointerEnd}
             onPointerCancel={disabled ? undefined : controller.onPointerEnd}

--- a/styles/components.css
+++ b/styles/components.css
@@ -3964,6 +3964,85 @@
 .ui-entry-card[data-active="true"] { border-color: var(--c-icon-active); }
 .ui-entry-card[data-disabled="true"] { opacity: 0.5; }
 
+/* ── 预设条目按 App 筛选：高亮/变暗 ── */
+.ui-entry-card[data-app-match="1"] {
+  border-color: var(--c-icon-active);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--c-icon-active) 30%, transparent);
+  background: color-mix(in srgb, var(--c-icon-active) 6%, var(--c-card, #fff));
+}
+.ui-entry-card[data-app-match="0"] {
+  opacity: 0.3;
+  filter: grayscale(0.5);
+}
+
+/* ── 折叠组：轻量摘要卡 ── */
+.ui-entry-collapsed-group {
+  padding: 10px 16px !important;
+  gap: 0 !important;
+  border-style: dashed !important;
+  border-width: 1.5px !important;
+}
+
+/* ── 多选悬浮条：跟随列表滚动（sticky），不固定顶部/底部 ── */
+.multi-select-float-bar {
+  position: sticky;
+  top: 8px;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--c-card, #fff) 92%, transparent);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  backdrop-filter: blur(14px) saturate(140%);
+  border: 1px solid color-mix(in srgb, var(--c-icon-active) 28%, transparent);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.12), inset 0 1px 2px rgba(255, 255, 255, 0.4);
+}
+.multi-select-float-bar .msfb-main {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.multi-select-float-bar .msfb-count {
+  font-size: calc(12px*var(--app-text-scale,1));
+  font-weight: 600;
+  color: var(--c-text-title, #111);
+  white-space: nowrap;
+  margin-right: 2px;
+}
+.multi-select-float-bar .msfb-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.multi-select-float-bar .msfb-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  height: 32px;
+  padding: 0 10px;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: #fff;
+  color: #4b4b4b;
+  font-size: calc(12px*var(--app-text-scale,1));
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.12s ease, background 0.2s, opacity 0.2s;
+  white-space: nowrap;
+}
+.multi-select-float-bar .msfb-btn:active { transform: scale(0.92); }
+.multi-select-float-bar .msfb-btn:disabled { opacity: 0.4; pointer-events: none; }
+.multi-select-float-bar .msfb-btn:hover { background: #f6f6f6; }
+.multi-select-float-bar .msfb-danger { color: var(--c-danger, #e5484d); border-color: color-mix(in srgb, var(--c-danger, #e5484d) 30%, transparent); }
+.multi-select-float-bar .msfb-done { background: var(--c-icon-active, #111); color: #fff; border-color: transparent; }
+.multi-select-float-bar .msfb-done:hover { background: color-mix(in srgb, var(--c-icon-active, #111) 88%, white); }
+
 /* ── Entry card 左滑操作（新增/删除） ── */
 .ui-swipe-wrap {
   position: relative;


### PR DESCRIPTION
贡献者：温铎（@yechen1844）

1. 预设管理器新增多选能力：右滑条目进入多选、点行切换选中、底部 sticky 悬浮条批量 启用/禁用/导出/删除；
2. 按 App 大类 高亮/仅显示/折叠，折叠组可再点展开/收起，属纯渲染，不影响真实顺序；
3. 优化预设条目渲染与拖拽：新增 buildDisplayedPrompts，统一渲染与拖拽排序，按 identifier 去重并补齐孤儿条目，修复「货不对板」与「重复出现」问题；
4. SwipeActionRow 增加可选右滑回调（rightSwipeEnabled/onSwipeRight/leftSwipeDisabled），向后兼容，不传新 props 时行为不变。

验证：改动仅涉及预设管理器的渲染与交互层，未改动预设数据模型与存储结构；SwipeActionRow 新 props 均有默认值，未传入时保持原有左滑行为。贡献文件：components/ui/swipe-actions.tsx、components/settings/preset-manager.tsx、styles/components.css。

---
_经小手机「共同建设」通道提交_