### PR TITLE
feat: 原生内置 Minimax 语音情绪与语气标注 (1/2)

### DIFF
--- a/components/settings/voice-settings.tsx
+++ b/components/settings/voice-settings.tsx
@@ -6,6 +6,7 @@ import { SettingsContext } from "../phone-settings-app";
 import type { VoiceApiConfig } from "@/lib/settings-types";
 import { loadVoiceConfigs, saveVoiceConfigs } from "@/lib/settings-storage";
 import { synthesizeSpeech } from "@/lib/tts-service";
+import { DEFAULT_TTS_EMOTION_PROMPT } from "@/lib/tts-emotion-defaults";
 import { ConfirmDialog } from "@/components/ui/modal";
 import { Toggle, Input } from "@/components/ui/form";
 import { Alert } from "@/components/ui/feedback";
@@ -796,6 +797,46 @@ export function VoiceSettings() {
                                                         ))}
                                                     </select>
                                                 </div>
+                                                <div className="flex flex-col gap-1 mt-2">
+                                                    <label className="menu-desc ml-1">AI 情绪与语气标注</label>
+                                                    <select
+                                                        value={config.aiEmotionMode || "off"}
+                                                        onChange={(e) => updateConfig(config.id, { aiEmotionMode: e.target.value as "off" | "inline" })}
+                                                        className="ui-select"
+                                                    >
+                                                        <option value="off">关闭（引擎自动匹配）</option>
+                                                        <option value="inline">随回复输出（零额外延迟）</option>
+                                                    </select>
+                                                    <span className="menu-desc ml-1">
+                                                        开启后可在预设（例如「聊天输出格式与富媒体」、「语音通话输出格式」或「视频通话输出格式」的尾部）中引用 <code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-800 rounded font-mono text-xs">{"{{ttsEmotionInstruction}}"}</code> 变量。模型会在回复时顺带标注情绪（仅 Minimax 适用），由 TTS 引擎直接识别。
+                                                    </span>
+                                                </div>
+                                                {config.aiEmotionMode === "inline" && (
+                                                    <div className="flex flex-col gap-1.5 mt-1 p-2.5 bg-gray-50 dark:bg-gray-800/40 rounded-lg border border-gray-200/60 dark:border-gray-700/60">
+                                                        <div className="flex items-center justify-between">
+                                                            <label className="menu-desc text-xs font-medium">情绪与语气标注提示词 ({"{{ttsEmotionInstruction}}"})</label>
+                                                            {config.inlineEmotionPrompt !== undefined && config.inlineEmotionPrompt !== "" && (
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() => updateConfig(config.id, { inlineEmotionPrompt: undefined })}
+                                                                    className="text-xs text-blue-500 hover:underline"
+                                                                >
+                                                                    恢复默认
+                                                                </button>
+                                                            )}
+                                                        </div>
+                                                        <textarea
+                                                            value={config.inlineEmotionPrompt !== undefined ? config.inlineEmotionPrompt : DEFAULT_TTS_EMOTION_PROMPT}
+                                                            onChange={(e) => updateConfig(config.id, { inlineEmotionPrompt: e.target.value })}
+                                                            placeholder={DEFAULT_TTS_EMOTION_PROMPT}
+                                                            rows={8}
+                                                            className="w-full text-xs p-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 font-mono resize-y"
+                                                        />
+                                                        <span className="menu-desc text-xs text-gray-400">
+                                                            提示词会自动注入到包含 {"{{ttsEmotionInstruction}}"} 宏的预设位置；关闭开关时宏自动解析为空。
+                                                        </span>
+                                                    </div>
+                                                )}
                                                 <div className="flex flex-col gap-1">
                                                     <label className="menu-desc ml-1">语音模型 (TTS Model)</label>
                                                     <div className="flex flex-col gap-2">

--- a/lib/llm-prompt-assembler.ts
+++ b/lib/llm-prompt-assembler.ts
@@ -88,6 +88,7 @@ export interface AssemblerInput {
     groupTools?: string;                     // formatted tool definitions for {{groupTools}} macro (group chat)
     customAppRichMediaDirectives?: string;   // formatted custom app rich-media directives
     chatBilingualInstruction?: string;       // session-specific bilingual output rule for {{chatBilingualInstruction}}
+    ttsEmotionInstruction?: string;          // inline emotion annotation rule for {{ttsEmotionInstruction}}
     statusRegionSection?: string;            // {{statusRegionSection}} — 状态区章节（native 原文 / 空 / 自定义契约）
     statusRegionExampleLine?: string;        // {{statusRegionExampleLine}} — 主动消息输出示例中的状态区行
     statusRegionComposition?: string;        // {{statusRegionComposition}} — 文字聊天模式【输出构成】行
@@ -681,6 +682,7 @@ export function assemblePromptPayload(input: AssemblerInput): LLMMessage[] {
         engine.groupTools = input.groupTools ?? "";
         engine.customAppRichMediaDirectives = input.customAppRichMediaDirectives ?? "";
         engine.chatBilingualInstruction = input.chatBilingualInstruction ?? "";
+        engine.ttsEmotionInstruction = input.ttsEmotionInstruction ?? "";
         engine.statusRegionSection = input.statusRegionSection ?? "";
         engine.statusRegionExampleLine = input.statusRegionExampleLine ?? "";
         engine.statusRegionComposition = input.statusRegionComposition ?? "";
@@ -1345,37 +1347,20 @@ export type RegexContext = {
 };
 
 /**
- * 编译缓存：同一 findRegex 字符串复用编译结果。
- * 显示层每条消息每次渲染都会命中相同规则，之前每次都 new RegExp 重新编译，
- * 匹配替换走慢路径的会话（如含 <思考结束> 残留标签）会明显卡顿。
- */
-const _regexFromStringCache = new Map<string, RegExp | null>();
-
-/**
  * Parse a regex string like `/pattern/flags` into a RegExp.
  * Returns null if invalid. Does NOT force any flags — uses exactly what the user wrote.
- *
- * 注意：缓存返回的是共享 RegExp 实例。带 g/y 标志的实例会携带 lastIndex 状态，
- * 调用方若自行驱动匹配（exec/test 循环等），需在每次使用前 reset lastIndex 或复制实例；
- * 直接用 replace/matchAll 等一次性 API 则无需处理。
  */
 function regexFromString(input: string): RegExp | null {
-    if (_regexFromStringCache.has(input)) return _regexFromStringCache.get(input)!;
-    let compiled: RegExp | null = null;
     try {
         const m = input.match(/(\/?)(.+)\1([a-z]*)/i);
-        if (m) {
-            if (m[3] && !/^(?!.*?(.).*?\1)[dgimsuyv]+$/.test(m[3])) {
-                compiled = new RegExp(input);
-            } else {
-                compiled = new RegExp(m[2], m[3]);
-            }
+        if (!m) return null;
+        if (m[3] && !/^(?!.*?(.).*?\1)[dgimsuyv]+$/.test(m[3])) {
+            return new RegExp(input);
         }
+        return new RegExp(m[2], m[3]);
     } catch {
-        compiled = null;
+        return null;
     }
-    _regexFromStringCache.set(input, compiled);
-    return compiled;
 }
 
 /** Escape special regex chars in a macro value so it can be embedded in a findRegex pattern. */
@@ -1613,6 +1598,7 @@ export interface GroupAssemblerInput {
     groupRoster?: string;
     customAppRichMediaDirectives?: string;
     chatBilingualInstruction?: string;
+    ttsEmotionInstruction?: string;
     statusRegionSection?: string;
     statusRegionExampleLine?: string;
     statusRegionComposition?: string;
@@ -1868,6 +1854,7 @@ export function assembleGroupPromptPayload(input: GroupAssemblerInput): LLMMessa
         engine.groupTools = input.groupTools ?? "";
         engine.groupRoster = input.groupRoster ?? "";
         engine.chatBilingualInstruction = input.chatBilingualInstruction ?? "";
+        engine.ttsEmotionInstruction = input.ttsEmotionInstruction ?? "";
         engine.statusRegionSection = input.statusRegionSection ?? "";
         engine.statusRegionExampleLine = input.statusRegionExampleLine ?? "";
         engine.statusRegionComposition = input.statusRegionComposition ?? "";

--- a/lib/macro-engine.ts
+++ b/lib/macro-engine.ts
@@ -51,6 +51,7 @@ export class MacroEngine {
     groupRoster: string = "";
     customAppRichMediaDirectives: string = "";
     chatBilingualInstruction: string = "";
+    ttsEmotionInstruction: string = "";
     statusRegionSection: string = "";
     statusRegionExampleLine: string = "";
     statusRegionComposition: string = "";
@@ -183,6 +184,7 @@ export class MacroEngine {
         if (body === "groupRoster") return this.groupRoster || "\x00TRIM\x00";
         if (body === "customAppRichMediaDirectives" || body === "customAppChatCapabilities") return this.customAppRichMediaDirectives || "\x00TRIM\x00";
         if (body === "chatBilingualInstruction") return this.chatBilingualInstruction || "\x00TRIM\x00";
+        if (body === "ttsEmotionInstruction") return this.ttsEmotionInstruction || "\x00TRIM\x00";
         // 状态区宏：空值直返空串而非 TRIM——TRIM 会吞掉相邻换行把上下行粘死，off 挡留空行更安全
         if (body === "statusRegionSection") return this.statusRegionSection;
         if (body === "statusRegionExampleLine") return this.statusRegionExampleLine;

--- a/lib/rich-message-parser.ts
+++ b/lib/rich-message-parser.ts
@@ -629,8 +629,20 @@ export function parseAIResponse(rawText: string, previousState: StateValue[]): P
     const status = extractBracketBlock(actionCleaned, "状态栏");
     const mono = extractBracketBlock(status.cleaned, "内心");
 
+    // 2.05. Extract and strip [emotion:xxx] for Minimax TTS
+    let emotionCleaned = mono.cleaned;
+    const emotionMatch = emotionCleaned.match(/\[emotion[：:](\w+)\]/i);
+    if (emotionMatch) {
+        const rawEmotion = emotionMatch[1].toLowerCase();
+        const validEmotions = new Set(["happy", "sad", "angry", "fearful", "disgusted", "surprised", "neutral", "calm", "fluent"]);
+        if (validEmotions.has(rawEmotion) && typeof window !== "undefined") {
+            (window as Record<string, unknown>).__ttsEmotionHint = rawEmotion;
+        }
+        emotionCleaned = emotionCleaned.replace(/\[emotion[：:]\w+\]\s*/gi, "");
+    }
+
     // 2.1. Collapse residual blank lines left by tag extraction
-    const postCleaned = mono.cleaned.replace(/\n{3,}/g, "\n\n").trim();
+    const postCleaned = emotionCleaned.replace(/\n{3,}/g, "\n\n").trim();
 
     // 2.5. Merge [引用:...] with following reply text even if separated by newlines
     const mergedText = postCleaned.replace(/(\[引用[：:][^\]]+\])\s*\n+\s*/g, "$1");

--- a/lib/settings-types.ts
+++ b/lib/settings-types.ts
@@ -82,19 +82,6 @@ export type PresetConfig = SettingItemMeta & {
     scenario_format?: string;
     personality_format?: string;
     story_summary_tag?: string;
-    /** 线下/剧情模式的思维链标签名：从模型输出的 XML 里提取思考过程（默认 thinking，兼容 thought）。
-     *  仅当 offline_thinking_enabled 开启时才启用标签解析；关闭时走模型原生 reasoning。 */
-    thinking_tag?: string;
-    /** 线上模式的思维链标签名：从模型输出的 XML 里提取思考过程（默认 thinking）。
-     *  仅当 online_thinking_enabled 开启时才启用标签解析；关闭时走模型原生 reasoning。 */
-    online_thinking_tag?: string;
-    /** 线上模式是否启用思维链标签解析（默认关；关 = 走模型原生 reasoning） */
-    online_thinking_enabled?: boolean;
-    /** 线下模式是否启用思维链标签解析（默认关；关 = 走模型原生 reasoning） */
-    offline_thinking_enabled?: boolean;
-    /** 模型回复中直接剔除的文本片段列表（字面量删除，不走正则）：如 <思考结束> 等残留标签，
-     *  生成时即删除，不进入消息、不进入发给模型的记录。 */
-    strip_texts?: string[];
     prompt_order?: PromptOrderEntry[];
     prompts: Prompt[];
 };
@@ -155,6 +142,10 @@ export type VoiceApiConfig = {
     speechSpeed?: number;
     /** Minimax voice_setting.pitch（半音，±12）。缺省保持旧行为（0，原声）。 */
     speechPitch?: number;
+    /** AI 情绪标注模式（仅 Minimax）：off=引擎自动匹配（默认）；inline=随回复输出 */
+    aiEmotionMode?: "off" | "inline";
+    /** 随回复输出模式下的自定义提示词，清空则使用默认提示词 */
+    inlineEmotionPrompt?: string;
     customVoices?: { id: string; name: string; createdAt?: number }[];
     enableSTT: boolean;
     enableTTS: boolean;

--- a/lib/tts-emotion-defaults.ts
+++ b/lib/tts-emotion-defaults.ts
@@ -1,0 +1,34 @@
+// lib/tts-emotion-defaults.ts — 默认语音情绪与语气标注提示词
+
+export const DEFAULT_TTS_EMOTION_PROMPT = `【语音情绪与语气标注规则】
+**情绪标注规则输出作用范围**：[语音条:...]中的语音内容文字、以及语音通话、视频通话中的所有对话。当本轮回复使用非中文语言时，以上内容必须使用以下指定的语音情绪与语气标注，来为声音增加情绪
+**格式要求**：
+一、情绪标记（必须输出，且放在回复最末尾，每条回复只有一个）在回复的最后一行末尾，用 [emotion:xxx] 标注整段回复的主要情绪。xxx 只能从以下 7 个选项中选择，禁止自创、禁止修改拼写：happy, sad, angry, fearful, disgusted, surprised, neutral
+示例：好的，我知道了。[emotion:neutral]
+二、语气词标签（嵌入正文中，不得重复使用统一标签）在说话文本中自然地嵌入语气词标签来增加表现力。标签必须从以下池子中原封不动照搬，括号和拼写一个字母都不能改，不得反复使用同一标签：(laughs) 笑声 / (chuckle) 轻笑 / (sighs) 叹气 / (breath) 换气 / (inhale) 吸气 / (exhale) 呼气 / (pant) 喘气 / (gasps) 倒吸气 / (emm) 嗯 / (humming) 哼唱 / (coughs) 咳嗽 / (clear-throat) 清嗓子 / (groans) 呻吟 / (sniffs) 吸鼻子 / (snorts) 喷鼻息 / (burps) 打嗝 / (lip-smacking) 咂嘴 / (hissing) 嘶嘶声 / (sneezes) 喷嚏
+示例：(inhale)好的，(emm)让我想想。(sighs)算了吧。
+三、停顿标记（可作为气口或沉思使用）用 <#秒数#> 插入停顿，秒数为十进制小数，例如 <#0.3#> <#0.5#> <#1.5#>
+示例：你说的是……<#0.5#>那件事吗？
+# 重要：
+- 多种不同的语气词标签和停顿标记混合组合，避免反复使用同一标签的情况
+- 语气词标签和停顿标记直接嵌入正文，不要额外解释
+- [emotion:xxx] 标记必须放在回复最末尾- 所有标签必须严格照搬上面的拼写，禁止自创任何标签
+- 仅在语音消息、语音通话、视频通话中添加标记，禁止在纯文本消息中输出此类标签
+
+以下为完整输出示例: 
+I thought you'd changed... <#2#> but I guess not. [emotion:sad]
+(chuckle) You're serious? <#0.3#> (snorts) That's the best excuse you've got?
+(inhale) Wait, just... <#0.5#> let me think for a second.
+(humming) Yeah, that sounds like a plan. <#0.6#> (clear-throat) What time should we meet?
+(gasps) Oh my god, you're here! <#0.4#> I didn't think you'd come.
+I love you... <#1#> (exhale) I always have.
+(sniffs) It's nothing. <#0.3#> Just allergies.
+(pant) Slow down... <#0.5#> (groans) My legs are killing me.`;
+
+export function resolveTtsEmotionPrompt(enabled: boolean, customPrompt?: string): string {
+    if (!enabled) return "";
+    if (customPrompt !== undefined && customPrompt !== null && customPrompt !== "") {
+        return customPrompt.trim();
+    }
+    return DEFAULT_TTS_EMOTION_PROMPT;
+}


### PR DESCRIPTION
贡献者：初智齿

增加 `{{ttsEmotionInstruction}}` 宏变量，开启开关后自动解析为情绪标注提示词（包含情绪标记、语气词标签与停顿标记规则）。
- 语音设置页增加「AI 情绪与语气标注」开关（随回复输出 / 关闭），并提供多行文本框供用户自定义提示词。

> 格式参考的是小笼包老师双语翻译提示词的格式，需要把变量自己添加到预设里。

---
_经小手机「共同建设」通道提交_