### PR TITLE
feat: 原生内置 Minimax 语音情绪与语气标注 (2/2)

### DIFF
--- a/components/chat/group-call-screen.tsx
+++ b/components/chat/group-call-screen.tsx
@@ -271,7 +271,14 @@ export function GroupCallScreen({ type, session, characters, onEnd, initiator = 
                 const voiceConfig = resolveVoiceConfig(r.characterId);
                 if (voiceConfig && speechText.trim()) {
                     try {
-                        const audioBlob = await synthesizeSpeech(speechText, voiceConfig);
+                        // AI 情绪标注（inline 模式）：读取 parseAIResponse 遗留的情绪标记
+                        let callEmotion: string | undefined;
+                        if (voiceConfig.aiEmotionMode === "inline" && voiceConfig.provider === "Minimax") {
+                            const w = window as Record<string, unknown>;
+                            callEmotion = w.__ttsEmotionHint as string | undefined;
+                            if (callEmotion) delete w.__ttsEmotionHint;
+                        }
+                        const audioBlob = await synthesizeSpeech(speechText, voiceConfig, callEmotion ? { emotion: callEmotion } : undefined);
                         if (stateRef.current === "ENDED") return;
                         if (audioBlob) {
                             const { promise, abort } = playCallAudio(audioBlob);

--- a/components/chat/message-bubble.tsx
+++ b/components/chat/message-bubble.tsx
@@ -2210,7 +2210,16 @@ function synthesizeVoiceForMessage(msgId: string, characterId: string, speechTex
         const { resolveVoiceConfig, synthesizeSpeech } = await import("@/lib/tts-service");
         const vc = resolveVoiceConfig(characterId);
         if (!vc) throw new Error("未绑定语音配置");
-        const blob = await synthesizeSpeech(speechText, vc);
+
+        // AI 情绪标注（inline 模式）：读取 parseAIResponse 遗留的情绪标记
+        let callEmotion: string | undefined;
+        if (vc.aiEmotionMode === "inline" && vc.provider === "Minimax") {
+            const w = window as Record<string, unknown>;
+            callEmotion = w.__ttsEmotionHint as string | undefined;
+            if (callEmotion) delete w.__ttsEmotionHint;
+        }
+
+        const blob = await synthesizeSpeech(speechText, vc, callEmotion ? { emotion: callEmotion } : undefined);
         if (!blob) throw new Error("合成失败");
         const dataUrl = await new Promise<string>((resolve, reject) => {
             const reader = new FileReader();

--- a/components/chat/video-call-screen.tsx
+++ b/components/chat/video-call-screen.tsx
@@ -412,7 +412,14 @@ export function VideoCallScreen({ session, character, onEnd, onConnect, initiato
             const voiceConfig = resolveVoiceConfig(session.contactId);
             if (voiceConfig && !isSpeakerMutedRef.current) {
                 try {
-                    const audioBlob = await synthesizeSpeech(speechText, voiceConfig);
+                    // AI 情绪标注（inline 模式）：读取 parseAIResponse 遗留的情绪标记
+                    let callEmotion: string | undefined;
+                    if (voiceConfig.aiEmotionMode === "inline" && voiceConfig.provider === "Minimax") {
+                        const w = window as Record<string, unknown>;
+                        callEmotion = w.__ttsEmotionHint as string | undefined;
+                        if (callEmotion) delete w.__ttsEmotionHint;
+                    }
+                    const audioBlob = await synthesizeSpeech(speechText, voiceConfig, callEmotion ? { emotion: callEmotion } : undefined);
                     if (stateRef.current === "ENDED") return;
                     if (audioBlob && !isSpeakerMutedRef.current) {
                         const { promise, abort } = playCallAudio(audioBlob);

--- a/components/chat/voice-call-screen.tsx
+++ b/components/chat/voice-call-screen.tsx
@@ -352,7 +352,14 @@ export function VoiceCallScreen({ session, character, onEnd, onConnect, initiato
             const voiceConfig = resolveVoiceConfig(session.contactId);
             if (voiceConfig) {
                 try {
-                    const audioBlob = await synthesizeSpeech(speechText, voiceConfig);
+                    // AI 情绪标注（inline 模式）：读取 parseAIResponse 遗留的情绪标记
+                    let callEmotion: string | undefined;
+                    if (voiceConfig.aiEmotionMode === "inline" && voiceConfig.provider === "Minimax") {
+                        const w = window as Record<string, unknown>;
+                        callEmotion = w.__ttsEmotionHint as string | undefined;
+                        if (callEmotion) delete w.__ttsEmotionHint;
+                    }
+                    const audioBlob = await synthesizeSpeech(speechText, voiceConfig, callEmotion ? { emotion: callEmotion } : undefined);
                     if (stateRef.current === "ENDED") return;
 
                     if (audioBlob) {

--- a/lib/chat-engine.ts
+++ b/lib/chat-engine.ts
@@ -20,7 +20,6 @@ import {
     normalizeVisionImagePromptLimit,
     createResponseBatchId,
     createToolExecutionId,
-    isSessionStreamingEnabled,
 } from "./chat-storage";
 import { extractTextToolDirectiveText, stripTextToolDirectives } from "./text-tool-protocol";
 import type { ApiConfig, PresetConfig, Prompt, PromptOrderEntry, RegexConfig } from "./settings-types";
@@ -54,7 +53,6 @@ import {
 } from "./llm-provider-adapter";
 import { setDebugPromptSnapshot, type DebugPromptSnapshot } from "./debug-store";
 import { extractFinishReason } from "./api-helpers";
-import { fetchLlmPayload } from "./llm-http";
 import { loadMemoryConfig, incrementEventCounter } from "./memory-storage";
 import { retrieveCoreMemoriesForPrompt, retrieveMemoriesForPrompt } from "./memory-service";
 import { formatCoreMemories, formatLongTermMemories } from "./memory-injector";
@@ -74,9 +72,7 @@ import { buildCalendarScheduleMarker, getCurrentCalendarScheduleForPrompt } from
 import { getWeekStartIso } from "./calendar-utils";
 import { buildCharacterTimeContext } from "./character-time";
 import { getPromptTimestampOptionsForTimeContext } from "./prompt-time";
-import { kvGet, kvSet, registerKvMigration } from "./kv-db";
-import { pushApiLog } from "./api-log-store";
-export { getApiLogs, clearApiLogs, type DebugInfo } from "./api-log-store";
+import { kvGet, kvSet, kvRemove, registerKvMigration } from "./kv-db";
 import { stripStateAndInnerForPrompt } from "./prompt-sanitizer";
 import { getInternalCapability, getInternalCapabilitySubToolDefinitions } from "./internal-capability-storage";
 import { isMediaStoreRef, loadMediaBlob } from "./media-cache-storage";
@@ -87,7 +83,9 @@ import {
     DEFAULT_OFFLINE_CHAT_BILINGUAL_PROMPT,
     resolveBilingualPrompt,
 } from "./bilingual-prompt-defaults";
-import { parseOfflineResponse, extractThinkingTag, type ParsedOfflineResponse } from "./chat-offline-storage";
+import { resolveTtsEmotionPrompt } from "./tts-emotion-defaults";
+import { resolveVoiceConfig } from "./tts-service";
+import { parseOfflineResponse, type ParsedOfflineResponse } from "./chat-offline-storage";
 import { throwIfAborted } from "./abort-utils";
 import { armShortcutContinuation, SHORTCUT_VISION_OFF_NOTE, type ShortcutContinuationHandle, type ShortcutContinuationStyle } from "./shortcut-continuation-client";
 
@@ -337,8 +335,32 @@ export function applyVisionImagePromptLimit(history: ChatMessage[], limitValue: 
     return history;
 }
 
-// API 调用日志存储已抽到 ./api-log-store（聊天引擎与 simpleLLMCall 通用），
-// 本文件通过上方 re-export 保持 getApiLogs/clearApiLogs/DebugInfo 的对外路径不变。
+// API Log store — captures recent request/response history for inspection
+export type DebugInfo = {
+    id: string;
+    characterName?: string;
+    model?: string;
+    messages: { role: string; content: string; marker?: string }[];
+    rawResponse: string;
+    timestamp: string;
+    usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+};
+const MAX_API_LOGS = 50;
+const API_LOGS_KEY = "ai_phone_api_logs_v1";
+registerKvMigration(API_LOGS_KEY);
+
+function _loadLogs(): DebugInfo[] {
+    try {
+        const raw = typeof window !== "undefined" ? kvGet(API_LOGS_KEY) : null;
+        return raw ? JSON.parse(raw) as DebugInfo[] : [];
+    } catch { return []; }
+}
+function _saveLogs(logs: DebugInfo[]): void {
+    try { kvSet(API_LOGS_KEY, JSON.stringify(logs)); } catch { /* quota exceeded — ignore */ }
+}
+
+export function getApiLogs(): DebugInfo[] { return _loadLogs(); }
+export function clearApiLogs(): void { try { kvRemove(API_LOGS_KEY); } catch { } }
 
 export type DebugPromptRequestOptions = {
     appId?: string;
@@ -410,25 +432,6 @@ function mergeAppTags(base: string[] | undefined, extra: string[] | undefined, f
     return Array.from(tags);
 }
 
-/** 从输出正文中剥离思维链标签块（仅标签解析开启时用于清洗展示文本）。 */
-export function stripOnlineThinkingTag(rawOutput: string, tag: string): string {
-    if (!tag.trim()) return rawOutput;
-    return rawOutput
-        .replace(new RegExp(`<${tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}>[\\s\\S]*?</${tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}>`, "gi"), "")
-        .trim();
-}
-
-/** 剔除预设配置的文本片段（如 <思考结束> 残留标签）。字面量删除，不走正则，避免编译/回溯开销。 */
-export function stripPresetTexts(text: string, preset: PresetConfig | null | undefined): string {
-    const list = preset?.strip_texts;
-    if (!list || list.length === 0 || !text) return text;
-    let result = text;
-    for (const s of list) {
-        if (s) result = result.split(s).join("");
-    }
-    return result;
-}
-
 function getPromptFilterTags(prompt: Prompt): string[] | null {
     if (prompt.tags && prompt.tags.length > 0) return prompt.tags;
     const legacy: string[] = [];
@@ -468,26 +471,10 @@ function isRealUserHistoryMessage(message: ChatMessage): boolean {
         || message.mediaType === "memory_write_request") return false;
     return Boolean(
         message.content.trim()
-            || message.mediaType
-            || message.mediaUrl
-            || message.mediaData,
+        || message.mediaType
+        || message.mediaUrl
+        || message.mediaData,
     );
-}
-
-/** history 末尾是工具流程消息（工具结果/工具通知/记忆写入请求）→ 当前处于同一次生成的工具循环中段。 */
-function isToolFlowHistoryMessage(message: ChatMessage): boolean {
-    return message.mediaType === "tool_result"
-        || message.mediaType === "tool_notice"
-        || message.mediaType === "memory_write_request";
-}
-
-/** 日志分流：工坊（appId === "qa"）经聊天引擎发出的调用（答疑 Agent 原生工具循环）归工坊环，
- *  其余归底层调用日志环。channel 不能硬编码——工坊的 Agent 循环复用 sendLLMToolStreamRequest，
- *  旧逻辑靠 characterName === "工坊" 分流，改成显式字段后必须从 appId 派生，否则工坊记录漏进主环。 */
-function apiLogChannelFor(options?: { appId?: string }): { source: "chat" | "qa"; channel: "chat" | "qa" } {
-    return options?.appId === "qa"
-        ? { source: "qa", channel: "qa" }
-        : { source: "chat", channel: "chat" };
 }
 
 export function appendEmptyGenerateGuardMessage(
@@ -500,21 +487,22 @@ export function appendEmptyGenerateGuardMessage(
     const hasRealUserHistory = history.some(isRealUserHistoryMessage);
     if (!hasRealUserHistory) return;
 
-    // 判定用户这次是否真的输入了新消息：看原始对话 history 的末尾，而不是组装后的 messages。
-    // 原因：预设里 role=assistant 的条目（例如「模型输出格式」放在 chatHistory 标记之后）会以
-    // assistant 角色注入到 messages 末尾，旧逻辑「最后一条 assistant 之后没有 user」就会把
-    // 「用户已输入」误判成「未输入」，错误追加续写提示（EMPTY_GENERATE_CONTINUATION_PROMPT）。
-    // history 末尾是真实用户消息（含图片/红包等媒体输入）→ 本次是正常回复，不追加续写提示；
-    // 末尾是 assistant / system（如 follow-up 静默提示）→ 用户未输入新消息，照常追加；
-    // 末尾是工具流程消息（tool_result / tool_notice / memory_write_request）→ 本次请求是
-    // 同一次生成在工具循环中的延续，续写提示反而会干扰模型基于工具结果作答（提示词里
-    // 明确禁止引用工具结果），同样不追加。
-    const lastHistoryMessage = history[history.length - 1];
-    if (lastHistoryMessage && (isRealUserHistoryMessage(lastHistoryMessage) || isToolFlowHistoryMessage(lastHistoryMessage))) {
-        return;
+    let lastAssistantIndex = -1;
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+        if (messages[index].role === "assistant") {
+            lastAssistantIndex = index;
+            break;
+        }
     }
+    if (lastAssistantIndex < 0) return;
 
-    messages.push({ role: "user", content: EMPTY_GENERATE_CONTINUATION_PROMPT });
+    const hasUserAfterLastAssistant = messages
+        .slice(lastAssistantIndex + 1)
+        .some(message => message.role === "user");
+
+    if (!hasUserAfterLastAssistant) {
+        messages.push({ role: "user", content: EMPTY_GENERATE_CONTINUATION_PROMPT });
+    }
 }
 
 export function publishDebugPromptSnapshot(params: {
@@ -795,67 +783,64 @@ export async function sendLLMStreamRequest(
         appId?: string;
         appTags?: string[];
         followUpCount?: number;
-        debugSessionId?: string;
         signal?: AbortSignal;
     },
     callbacks?: ChatCompletionStreamCallbacks,
 ): Promise<ChatCompletionStreamResult> {
     const pluginPurpose = options?.appId ?? "chat";
-    const afterPlugins = await applyChatPluginLlmRequest(preset, messages, pluginPurpose, options?.debugSessionId);
+    const afterPlugins = await applyChatPluginLlmRequest(preset, messages, pluginPurpose);
     const effectivePreset = afterPlugins.preset;
     const originalOnDelta = callbacks?.onDelta;
     const pluginCallbacks: ChatCompletionStreamCallbacks | undefined = callbacks ? {
         ...callbacks,
         onDelta: (text: string) => {
-            emitChatPluginEvent("llm.streamChunk", { chunk: text, sessionId: options?.debugSessionId, purpose: pluginPurpose });
+            emitChatPluginEvent("llm.streamChunk", { chunk: text, purpose: pluginPurpose });
             return originalOnDelta?.(text);
         },
     } : undefined;
     const requestMessages = toLlmRequestMessages(afterPlugins.messages);
     const request = buildProviderRequest(config, effectivePreset, requestMessages, { stream: true });
-    publishDebugPromptSnapshot({ request, config, preset: effectivePreset, meta, options, requestKind: "completion" });
+    const requestBodyJson = JSON.stringify(request.body);
     const llmAbort = new AbortController();
     const llmTimeout = setTimeout(() => llmAbort.abort(), 500_000);
     const detachExternalAbort = attachExternalAbort(llmAbort, options?.signal);
 
     try {
-        const response = await fetchLlmPayload(request, { signal: llmAbort.signal });
+        const response = await fetch(request.url, {
+            method: "POST",
+            headers: request.headers,
+            body: requestBodyJson,
+            signal: llmAbort.signal,
+        });
         if (!response.ok) {
             const errorText = await response.text();
             throw new ChatEngineError(`API Stream Error ${response.status}: ${errorText}`);
         }
-        // 流式路径收集思维链原文：readSseStream 只通过 onReasoningDelta 回调透传，
-        // 不额外包一层的话日志里就只有清洗后的回复正文，思维链被吞。
-        // 注意：必须无条件创建回调对象（不能 callbacks 为空就不传），否则思维链收集不到。
-        let streamedReasoning = "";
-        const streamLogCallbacks: ChatCompletionStreamCallbacks = {
-            ...(pluginCallbacks ?? callbacks),
-            onReasoningDelta: async (text: string) => {
-                streamedReasoning += text;
-                await (pluginCallbacks ?? callbacks)?.onReasoningDelta?.(text);
-            },
-        };
-        const { content: streamedContent, rawResponse } = await readSseStream(response, request.providerKind, streamLogCallbacks, !options?.skipTimestampStrip);
+        const { content: streamedContent, rawResponse } = await readSseStream(response, request.providerKind, pluginCallbacks ?? callbacks, !options?.skipTimestampStrip);
         if (!streamedContent.trim()) {
             throw new ChatEngineError("流式响应没有解析到文本增量。");
         }
         let rawOutput = options?.skipTimestampStrip ? streamedContent.trim() : stripHallucinatedTimestamps(streamedContent.trim());
-        rawOutput = await applyChatPluginLlmResponse(rawOutput, pluginPurpose, options?.debugSessionId);
+        rawOutput = await applyChatPluginLlmResponse(rawOutput, pluginPurpose);
 
         // Store API log entry — mirror sendLLMRequest so streaming calls also show up
-        // in the "底层调用大模型日志" panel. reasoning 单独存思维链原文，供「查看原始」直接展示。
+        // in the "底层调用大模型日志" panel.
         const sanitizedMessages = request.messagesForLog.map(m => ({
             ...m,
             content: typeof m.content === "string" ? m.content : "[vision: 含图片的多模态消息]",
         }));
-        pushApiLog({
+        const logEntry: DebugInfo = {
+            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
             characterName: meta?.characterName,
-            ...apiLogChannelFor(options),
             model: config.defaultModel,
             messages: sanitizedMessages,
             rawResponse: rawOutput,
-            reasoning: streamedReasoning.trim() || undefined,
-        });
+            timestamp: new Date().toISOString(),
+        };
+        const logs = _loadLogs();
+        logs.push(logEntry);
+        while (logs.length > MAX_API_LOGS) logs.shift();
+        _saveLogs(logs);
 
         if (!options?.skipOutputRegex) {
             const macroEngine = new MacroEngine(meta?.characterName ?? "", meta?.userName ?? "用户");
@@ -938,7 +923,12 @@ export async function sendLLMRequest(
     const detachExternalAbort = attachExternalAbort(llmAbort, options?.signal);
 
     try {
-        const response = await fetchLlmPayload(request, { signal: llmAbort.signal });
+        const response = await fetch(request.url, {
+            method: "POST",
+            headers: request.headers,
+            body: requestBodyJson,
+            signal: llmAbort.signal,
+        });
 
         if (!response.ok) {
             const errorText = await response.text();
@@ -981,16 +971,19 @@ export async function sendLLMRequest(
             ...m,
             content: typeof m.content === "string" ? m.content : "[vision: 含图片的多模态消息]",
         }));
-        pushApiLog({
+        const logEntry: DebugInfo = {
+            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
             characterName: meta?.characterName,
-            ...apiLogChannelFor(options),
             model: config.defaultModel,
             messages: sanitizedMessages,
             rawResponse: rawOutput,
+            timestamp: new Date().toISOString(),
             usage: parsed.usage,
-            // 思维链只经 onReasoning 回调透传，之前没进日志；这里单独存一份原文
-            reasoning: parsed.reasoning || undefined,
-        });
+        };
+        const logs = _loadLogs();
+        logs.push(logEntry);
+        while (logs.length > MAX_API_LOGS) logs.shift();
+        _saveLogs(logs);
 
         if (options?.skipOutputRegex) {
             return rawOutput;
@@ -1103,6 +1096,7 @@ export async function sendLLMToolStreamRequest(
     const effectivePreset = afterPlugins.preset;
     const request = buildProviderRequest(config, effectivePreset, afterPlugins.messages, { tools, stream: true, maxTokens: options?.maxTokens });
     publishDebugPromptSnapshot({ request, config, preset: effectivePreset, meta, options, requestKind: "native-tools-stream", tools });
+    const requestBodyJson = JSON.stringify(request.body);
     const llmAbort = new AbortController();
     const llmTimeout = setTimeout(() => llmAbort.abort(), 500_000);
     const detachExternalAbort = attachExternalAbort(llmAbort, options?.signal);
@@ -1114,7 +1108,12 @@ export async function sendLLMToolStreamRequest(
     const firedToolCallStarts = new Set<number>();
 
     try {
-        const response = await fetchLlmPayload(request, { signal: llmAbort.signal });
+        const response = await fetch(request.url, {
+            method: "POST",
+            headers: request.headers,
+            body: requestBodyJson,
+            signal: llmAbort.signal,
+        });
 
         if (!response.ok) {
             const errorText = await response.text();
@@ -1198,15 +1197,18 @@ export async function sendLLMToolStreamRequest(
             content: typeof m.content === "string" ? m.content : "[vision: 含图片的多模态消息]",
         }));
         const { calls: toolCalls, truncatedNames } = finalizeStreamToolCalls(toolDrafts);
-        const logEntryRaw = JSON.stringify({ content, reasoning, toolCalls, raw: rawResponse });
-        pushApiLog({
+        const logEntry: DebugInfo = {
+            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
             characterName: meta?.characterName,
-            ...apiLogChannelFor(options),
             model: config.defaultModel,
             messages: sanitizedMessages,
-            rawResponse: logEntryRaw,
-            reasoning: reasoning || undefined,
-        });
+            rawResponse: JSON.stringify({ content, reasoning, toolCalls, raw: rawResponse }),
+            timestamp: new Date().toISOString(),
+        };
+        const logs = _loadLogs();
+        logs.push(logEntry);
+        while (logs.length > MAX_API_LOGS) logs.shift();
+        _saveLogs(logs);
 
         if (!content && toolCalls.length === 0 && truncatedNames.length === 0) {
             throw new ChatEngineError("原生动作流式响应没有解析到文本或动作。");
@@ -1218,7 +1220,7 @@ export async function sendLLMToolStreamRequest(
             openRouterReasoningDetails: undefined,
             toolCalls,
             truncatedToolCalls: truncatedNames.length ? truncatedNames : undefined,
-            rawResponse: logEntryRaw,
+            rawResponse: logEntry.rawResponse,
             providerKind: request.providerKind,
         };
     } catch (error: unknown) {
@@ -1257,12 +1259,18 @@ export async function sendLLMToolRequest(
     const effectivePreset = afterPlugins.preset;
     const request = buildProviderRequest(config, effectivePreset, afterPlugins.messages, { tools });
     publishDebugPromptSnapshot({ request, config, preset: effectivePreset, meta, options, requestKind: "native-tools", tools });
+    const requestBodyJson = JSON.stringify(request.body);
     const llmAbort = new AbortController();
     const llmTimeout = setTimeout(() => llmAbort.abort(), 500_000);
     const detachExternalAbort = attachExternalAbort(llmAbort, options?.signal);
 
     try {
-        const response = await fetchLlmPayload(request, { signal: llmAbort.signal });
+        const response = await fetch(request.url, {
+            method: "POST",
+            headers: request.headers,
+            body: requestBodyJson,
+            signal: llmAbort.signal,
+        });
 
         if (!response.ok) {
             const errorText = await response.text();
@@ -1275,6 +1283,8 @@ export async function sendLLMToolRequest(
         if (options?.includeReasoning && parsed.reasoning) {
             rawOutput = `<think>\n${parsed.reasoning}\n</think>\n\n${rawOutput}`;
         }
+        rawOutput = await applyChatPluginLlmResponse(rawOutput, pluginPurpose, options?.debugSessionId);
+
         rawOutput = await applyChatPluginLlmResponse(rawOutput, pluginPurpose, options?.debugSessionId);
 
         if (!rawOutput && parsed.toolCalls.length === 0) {
@@ -1301,14 +1311,19 @@ export async function sendLLMToolRequest(
             toolCalls: parsed.toolCalls,
             raw: parsed.raw,
         });
-        pushApiLog({
+        const logEntry: DebugInfo = {
+            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
             characterName: meta?.characterName,
-            ...apiLogChannelFor(options),
             model: config.defaultModel,
             messages: sanitizedMessages,
             rawResponse,
+            timestamp: new Date().toISOString(),
             usage: parsed.usage,
-        });
+        };
+        const logs = _loadLogs();
+        logs.push(logEntry);
+        while (logs.length > MAX_API_LOGS) logs.shift();
+        _saveLogs(logs);
 
         if (!options?.skipOutputRegex && rawOutput) {
             const macroEngine = new MacroEngine(meta?.characterName ?? "", meta?.userName ?? "用户");
@@ -1884,6 +1899,10 @@ export async function buildChatPromptMessages(
     const chatBilingualInstruction = !session.isGroup
         ? buildChatBilingualInstruction(session.bilingualTranslationEnabled !== false, "single", session.bilingualTranslationPrompt)
         : "";
+    const voiceConfig = resolveVoiceConfig(session.contactId);
+    const ttsEmotionInstruction = voiceConfig && voiceConfig.provider === "Minimax"
+        ? resolveTtsEmotionPrompt(voiceConfig.aiEmotionMode === "inline", voiceConfig.inlineEmotionPrompt)
+        : "";
     // 状态区宏：按会话配置解析（native=原文/off=空/custom=契约）；群聊条目不含宏，不受影响
     const statusRegionCfg = getStatusRegionConfig(session.id);
     const offlineBilingualInstruction = !session.isGroup
@@ -1929,6 +1948,7 @@ export async function buildChatPromptMessages(
         tools: toolsPrompt,
         customAppRichMediaDirectives,
         chatBilingualInstruction,
+        ttsEmotionInstruction,
         statusRegionSection: resolveStatusRegionSection(statusRegionCfg),
         statusRegionExampleLine: resolveStatusRegionExampleLine(statusRegionCfg),
         statusRegionComposition: resolveStatusRegionComposition(statusRegionCfg),
@@ -1963,9 +1983,6 @@ export type ChatCompletionCallbacks = {
         responseBatchId?: string;
         rawResponseText?: string;
     }) => void | Promise<void>;
-    /** 流式生成增量回调（仅在开启流式生成时触发）：每到达一段原文增量就调用一次，
-     *  由 UI 层累积后做预览净化显示。delta 为原始增量（可能含未闭合的富媒体/工具标签）。 */
-    onStreamDelta?: (delta: string) => void | Promise<void>;
     onToolNotice?: (notice: string) => void;
     onToolResult?: (content: string, options?: { toolExecutionId?: string }) => void;
     /** 每轮 LLM 调用解析出思维链（reasoning）时触发，先于该轮 onTextPart */
@@ -2002,7 +2019,7 @@ export type OfflineChatCompletionResult = ParsedOfflineResponse & {
 export async function generateOfflineChatCompletion(
     session: ChatSession,
     history: ChatMessage[],
-    options?: { signal?: AbortSignal; onStreamDelta?: (delta: string) => void },
+    options?: { signal?: AbortSignal },
 ): Promise<OfflineChatCompletionResult> {
     const { llmMessages, character, config, preset, regexes, userIdentity } = await buildChatPromptMessages(
         session,
@@ -2013,83 +2030,18 @@ export async function generateOfflineChatCompletion(
         },
     );
     const summaryTag = preset?.story_summary_tag?.trim() || "summary";
-    const thinkingTag = preset?.thinking_tag?.trim() || "thinking";
-    const offlineTagEnabled = preset?.offline_thinking_enabled === true;
     let reasoning = "";
-    const meta = { characterName: character.name, userName: userIdentity?.name };
-    const requestOptions = {
+    const rawOutput = await sendLLMRequest(config, preset, llmMessages, regexes, {
+        characterName: character.name,
+        userName: userIdentity?.name,
+    }, {
         appTags: ["chat", "offline"],
         debugSessionId: session.id,
         signal: options?.signal,
-        onReasoning: (t: string) => { reasoning = t; },
-    };
-    let rawOutput: string;
-    if (isSessionStreamingEnabled(session, false) && options?.onStreamDelta) {
-        // 线下流式：正文边生成边通过 onStreamDelta 交给 UI 做实时预览；
-        // 摘要补提仍走整段请求（输出短，无需流式）。
-        const streamResult = await sendLLMStreamRequest(config, preset, llmMessages, regexes, meta, {
-            appId: "chat",
-            appTags: ["chat", "offline"],
-            debugSessionId: session.id,
-            signal: options?.signal,
-        }, {
-            onDelta: (text) => options.onStreamDelta?.(text),
-            onReasoningDelta: (t) => { reasoning += t; },
-        });
-        rawOutput = streamResult.content;
-    } else {
-        rawOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, requestOptions);
-    }
-    // 剔除预设配置的文本片段（<思考结束> 等残留标签），不进入记录/提示词
-    rawOutput = stripPresetTexts(rawOutput, preset);
-    let parsed = parseOfflineResponse(rawOutput, summaryTag);
-    // 思维链：预设开启「线下标签解析」时从正文提取 <thinking> 标签；关闭时走模型原生 reasoning（官方默认行为）
-    if (offlineTagEnabled) {
-        const tagThinking = extractThinkingTag(rawOutput, thinkingTag);
-        if (tagThinking) reasoning = tagThinking;
-        // 模型漏写 <content> 时 parseOfflineResponse 兜底把全文当正文，thinking 块会残留其中：
-        // 这里统一剥掉，避免思考过程既进思维链又出现在正文（默认标签 thinking 兼容 thought）
-        let cleanedContent = parsed.content;
-        for (const tag of (thinkingTag === "thinking" ? ["thinking", "thought", "think"] : [thinkingTag])) {
-            cleanedContent = stripOnlineThinkingTag(cleanedContent, tag);
-        }
-        parsed = { ...parsed, content: cleanedContent };
-    }
-
-    // 摘要缺失时自动补提：只带最后一轮上下文（系统提示 + 最后一条用户消息 + 本次输出），
-    // 要求模型补一段摘要，避免「静默结束」导致该轮线下记录没有摘要、进不了短期记忆事件流。
-    // 不重发完整 llmMessages：长对话下 token/延迟成本高，且摘要本来就只针对本轮关键事件。
-    const MAX_SUMMARY_RETRY = 2;
-    const lastUserMessage = [...llmMessages].reverse().find(m => m.role === "user");
-    for (let attempt = 0; attempt < MAX_SUMMARY_RETRY; attempt += 1) {
-        if (parsed.summary.trim()) break;
-        if (!parsed.content.trim() && !rawOutput.trim()) break; // 连正文都没有，补提没有意义
-        const retryMessages: LLMMessage[] = [
-            ...(llmMessages[0]?.role === "system" ? [llmMessages[0]] : []),
-            ...(lastUserMessage ? [lastUserMessage] : []),
-            { role: "assistant", content: rawOutput },
-            {
-                role: "user",
-                content: `刚才的回复里没有输出 <${summaryTag}> 摘要。请只针对上面这段对话的关键事件补一段第三人称摘要，严格按以下格式输出，不要输出任何其他内容：\n<${summaryTag}>一句话摘要</${summaryTag}>`,
-            },
-        ];
-        throwIfAborted(options?.signal);
-        // 补提请求不带 onReasoning：避免用补提请求的思维链覆盖主请求已累积的完整思维链
-        const retryRaw = stripPresetTexts(await sendLLMRequest(config, preset, retryMessages, regexes, meta, { ...requestOptions, onReasoning: undefined }), preset);
-        const retried = parseOfflineResponse(retryRaw, summaryTag);
-        if (retried.summary.trim()) {
-            parsed = { ...parsed, summary: retried.summary.trim() };
-            break;
-        }
-    }
-
+        onReasoning: (t) => { reasoning = t; },
+    });
     return {
-        ...parsed,
-        // 标签解析开启时补 thinking/thinkingTag（供离线记录展示）；关闭时保持 undefined，思维链走 reasoning（模型原生）
-        ...(offlineTagEnabled ? {
-            thinking: extractThinkingTag(rawOutput, thinkingTag) || undefined,
-            thinkingTag,
-        } : {}),
+        ...parseOfflineResponse(rawOutput, summaryTag),
         model: config.defaultModel,
         presetName: preset?.name || "默认预设",
         reasoning: reasoning || undefined,
@@ -2130,52 +2082,24 @@ async function generateNativeChatCompletion(
     const expandableSourceKeys = new Set(enabledTools.filter(tool => !isNativeSingleTool(tool)).map(nativeToolSourceKey));
 
     const maxToolRounds = getMaxToolRounds();
-    const onlineThinkingEnabled = preset?.online_thinking_enabled === true;
-    const onlineThinkingTag = preset?.online_thinking_tag?.trim() || "thinking";
     for (let round = 0; round < maxToolRounds; round += 1) {
         let result: LLMToolRequestResult;
         try {
-            if (isSessionStreamingEnabled(session, true)) {
-                let streamReasoning = "";
-                result = await sendLLMToolStreamRequest(
-                    config,
-                    preset,
-                    requestMessages,
-                    nativeBundle.definitions,
-                    regexes,
-                    meta,
-                    {
-                        appId: options?.appId ?? "chat",
-                        appTags: requestAppTags,
-                        followUpCount: options?.followUpCount,
-                        debugSessionId: session.id,
-                        signal: options?.signal,
-                    },
-                    {
-                        onDelta: (text) => callbacks?.onStreamDelta?.(text),
-                        // 流式下 onReasoningDelta 收到的是单段增量：本地累积后再喂 onReasoning，
-                        // 保证下游拿到的是完整思维链（与整段请求的 onReasoning 语义一致）。
-                        // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
-                        onReasoningDelta: onlineThinkingEnabled ? undefined : (text) => { streamReasoning += text; callbacks?.onReasoning?.(streamReasoning); },
-                    },
-                );
-            } else {
-                result = await sendLLMToolRequest(
-                    config,
-                    preset,
-                    requestMessages,
-                    nativeBundle.definitions,
-                    regexes,
-                    meta,
-                    {
-                        appId: options?.appId ?? "chat",
-                        appTags: requestAppTags,
-                        followUpCount: options?.followUpCount,
-                        debugSessionId: session.id,
-                        signal: options?.signal,
-                    },
-                );
-            }
+            result = await sendLLMToolRequest(
+                config,
+                preset,
+                requestMessages,
+                nativeBundle.definitions,
+                regexes,
+                meta,
+                {
+                    appId: options?.appId ?? "chat",
+                    appTags: requestAppTags,
+                    followUpCount: options?.followUpCount,
+                    debugSessionId: session.id,
+                    signal: options?.signal,
+                },
+            );
         } catch (err) {
             const errMsg = `⚠️ 回复生成失败: ${err instanceof Error ? err.message : String(err)}`;
             if (parts.length > 0) {
@@ -2188,28 +2112,17 @@ async function generateNativeChatCompletion(
         }
         throwIfAborted(options?.signal);
 
-        // 线上思维链标签解析：开启时从正文提取 <tag> 思维链（覆盖原生），并剥离标签后再做后续解析
-        let displayContent = result.content;
-        if (onlineThinkingEnabled) {
-            const tagThinking = extractThinkingTag(displayContent, onlineThinkingTag);
-            if (tagThinking) callbacks?.onReasoning?.(tagThinking);
-            displayContent = stripOnlineThinkingTag(displayContent, onlineThinkingTag);
-        }
-        // 剔除预设配置的文本片段（<思考结束> 等残留标签）
-        displayContent = stripPresetTexts(displayContent, preset);
-
-        const { cleanText: afterActionStrip, actions } = parseActionTags(displayContent);
+        const { cleanText: afterActionStrip, actions } = parseActionTags(result.content);
         if (actions.length > 0) {
             throwIfAborted(options?.signal);
             dispatchActions(actions, actionContext).catch(err => console.warn("[ChatEngine] Action dispatch failed:", err));
         }
-        const assistantForToolContext = stripStateAndInnerForPrompt(displayContent);
+        const assistantForToolContext = stripStateAndInnerForPrompt(result.content);
 
         if (result.toolCalls.length === 0) {
             throwIfAborted(options?.signal);
             // 无工具调用的最终轮：把解析到的思维链先交给回调（先于 onTextPart，与非原生路径一致）
-            // 标签解析开启时已在上方用标签思维链覆盖，此处不再重复喂原生
-            if (result.reasoning && !onlineThinkingEnabled) callbacks?.onReasoning?.(result.reasoning);
+            if (result.reasoning) callbacks?.onReasoning?.(result.reasoning);
             await callbacks?.onTextPart?.(afterActionStrip);
             parts.push({ text: afterActionStrip });
             if (bailoutRef.shortcutHandles.length > 0) bailoutRef.shortcutCompleted = true;
@@ -2219,9 +2132,9 @@ async function generateNativeChatCompletion(
         throwIfAborted(options?.signal);
         await callbacks?.onNativeToolAssistantTurn?.({
             content: afterActionStrip,
-            rawContent: displayContent,
-            reasoning: onlineThinkingEnabled ? (extractThinkingTag(result.content, onlineThinkingTag) || undefined) : result.reasoning,
-            openRouterReasoningDetails: onlineThinkingEnabled ? undefined : result.openRouterReasoningDetails,
+            rawContent: result.content,
+            reasoning: result.reasoning,
+            openRouterReasoningDetails: result.openRouterReasoningDetails,
             toolCalls: result.toolCalls,
         });
         if (afterActionStrip) {
@@ -2582,42 +2495,17 @@ async function generateChatCompletionCore(
     const actionContext = { characterId: session.contactId, sessionId: session.id, sourceEngine: "chat" as const, signal: options?.signal };
 
     const maxToolRounds = getMaxToolRounds();
-    const onlineThinking = {
-        enabled: preset?.online_thinking_enabled === true,
-        tag: preset?.online_thinking_tag?.trim() || "thinking",
-        reasoning: undefined as string | undefined,
-    };
     for (let round = 0; round < maxToolRounds; round++) {
         let filteredOutput: string;
         try {
-            if (isSessionStreamingEnabled(session, true)) {
-                // 流式分支：与 sendLLMRequest 走同一套请求构造/日志/正则，仅把「整段等待」换成
-                // SSE 增量，并通过 onStreamDelta 把原文增量实时交给 UI 层做预览显示。
-                let streamReasoning = "";
-                const streamResult = await sendLLMStreamRequest(config, preset, llmMessages, regexes, meta, {
-                    appId: options?.appId ?? "chat",
-                    appTags: requestAppTags,
-                    followUpCount: options?.followUpCount,
-                    debugSessionId: session.id,
-                    signal: options?.signal,
-                }, {
-                    onDelta: (text) => callbacks?.onStreamDelta?.(text),
-                    // 流式下 onReasoningDelta 是单段增量：累积后再喂 onReasoning（保持整段请求语义）
-                    // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
-                    onReasoningDelta: onlineThinking.enabled ? undefined : (text) => { streamReasoning += text; callbacks?.onReasoning?.(streamReasoning); },
-                });
-                filteredOutput = streamResult.content;
-            } else {
-                filteredOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
-                    appId: options?.appId ?? "chat",
-                    appTags: requestAppTags,
-                    followUpCount: options?.followUpCount,
-                    debugSessionId: session.id,
-                    signal: options?.signal,
-                    // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
-                    onReasoning: onlineThinking.enabled ? undefined : callbacks?.onReasoning,
-                });
-            }
+            filteredOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
+                appId: options?.appId ?? "chat",
+                appTags: requestAppTags,
+                followUpCount: options?.followUpCount,
+                debugSessionId: session.id,
+                signal: options?.signal,
+                onReasoning: callbacks?.onReasoning,
+            });
         } catch (err) {
             const errMsg = `⚠️ 回复生成失败: ${err instanceof Error ? err.message : String(err)}`;
             if (parts.length > 0) {
@@ -2629,18 +2517,6 @@ async function generateChatCompletionCore(
             throw err;
         }
         throwIfAborted(options?.signal);
-
-        // 线上思维链标签解析：开启时每轮从正文提取 <tag> 思维链（覆盖原生），并剥离标签后再做后续解析
-        if (onlineThinking.enabled) {
-            const tagThinking = extractThinkingTag(filteredOutput, onlineThinking.tag);
-            if (tagThinking) {
-                onlineThinking.reasoning = tagThinking;
-                callbacks?.onReasoning?.(tagThinking);
-            }
-            filteredOutput = stripOnlineThinkingTag(filteredOutput, onlineThinking.tag);
-        }
-        // 剔除预设配置的文本片段（<思考结束> 等残留标签），不进入消息/提示词
-        filteredOutput = stripPresetTexts(filteredOutput, preset);
 
         // Parse actions (朋友圈 etc) — strip from display text but keep tool tags
         const { cleanText: afterActionStrip, actions } = parseActionTags(filteredOutput);
@@ -2818,41 +2694,15 @@ async function generateChatCompletionCore(
             // Last round — one final call
             if (round === maxToolRounds - 1) {
                 try {
-                    let finalOutput: string;
-                    if (isSessionStreamingEnabled(session, true)) {
-                        let streamReasoning = "";
-                        const streamFinal = await sendLLMStreamRequest(config, preset, llmMessages, regexes, meta, {
-                            appId: options?.appId ?? "chat",
-                            appTags: requestAppTags,
-                            followUpCount: options?.followUpCount,
-                            debugSessionId: session.id,
-                            signal: options?.signal,
-                        }, {
-                            onDelta: (text) => callbacks?.onStreamDelta?.(text),
-                            // 流式下 onReasoningDelta 是单段增量：累积后再喂 onReasoning（保持整段请求语义）。
-                            // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
-                            onReasoningDelta: onlineThinking.enabled ? undefined : (text) => { streamReasoning += text; callbacks?.onReasoning?.(streamReasoning); },
-                        });
-                        finalOutput = streamFinal.content;
-                    } else {
-                        finalOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
-                            appId: options?.appId ?? "chat",
-                            appTags: requestAppTags,
-                            followUpCount: options?.followUpCount,
-                            debugSessionId: session.id,
-                            signal: options?.signal,
-                            onReasoning: onlineThinking.enabled ? undefined : callbacks?.onReasoning,
-                        });
-                    }
+                    const finalOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
+                        appId: options?.appId ?? "chat",
+                        appTags: requestAppTags,
+                        followUpCount: options?.followUpCount,
+                        debugSessionId: session.id,
+                        signal: options?.signal,
+                        onReasoning: callbacks?.onReasoning,
+                    });
                     throwIfAborted(options?.signal);
-                    // 线上思维链标签解析：开启时从正文提取 <tag> 思维链并剥离标签
-                    if (onlineThinking.enabled) {
-                        const tagThinking = extractThinkingTag(finalOutput, onlineThinking.tag);
-                        if (tagThinking) callbacks?.onReasoning?.(tagThinking);
-                        finalOutput = stripOnlineThinkingTag(finalOutput, onlineThinking.tag);
-                    }
-                    // 剔除预设配置的文本片段（<思考结束> 等残留标签）
-                    finalOutput = stripPresetTexts(finalOutput, preset);
                     await callbacks?.onTextPart?.(finalOutput);
                     parts.push({ text: finalOutput });
                     if (bailoutRef.shortcutHandles.length > 0) bailoutRef.shortcutCompleted = true;

--- a/lib/group-chat-engine.ts
+++ b/lib/group-chat-engine.ts
@@ -1,7 +1,7 @@
 // lib/group-chat-engine.ts
 // Group chat engine: single API call for all characters.
 
-import { ChatSession, ChatMessage, loadChatAppSettings, createResponseBatchId, createResponseRoundId, createToolExecutionId, loadChatSessions, getLatestCharacterStateValues, isSessionStreamingEnabled } from "./chat-storage";
+import { ChatSession, ChatMessage, loadChatAppSettings, createResponseBatchId, createResponseRoundId, createToolExecutionId, loadChatSessions, getLatestCharacterStateValues } from "./chat-storage";
 import { extractTextToolDirectiveText } from "./text-tool-protocol";
 import type { ApiConfig, PresetConfig, RegexConfig } from "./settings-types";
 import { loadCharacters } from "./character-storage";
@@ -10,9 +10,7 @@ import { runChatPluginTransform } from "./chat-plugin-hooks";
 import { buildChatPluginPromptFragments } from "./chat-plugin-storage";
 import {
     sendLLMRequest,
-    sendLLMStreamRequest,
     sendLLMToolRequest,
-    sendLLMToolStreamRequest,
     ChatEngineError,
     buildMusicLocalMacro,
     buildMusicCloudMacro,
@@ -33,8 +31,6 @@ import {
     touchNativeExpandedToolSource,
     appendEmptyGenerateGuardMessage,
     applyCustomPromptProfileToPreset,
-    stripOnlineThinkingTag,
-    stripPresetTexts,
     type ChatCompletionCallbacks,
     type NativeChatToolBundle,
 } from "./chat-engine";
@@ -57,6 +53,8 @@ import {
     type LLMMessage,
     type GroupMemberData,
 } from "./llm-prompt-assembler";
+import { resolveVoiceConfig } from "./tts-service";
+import { resolveTtsEmotionPrompt } from "./tts-emotion-defaults";
 import {
     getStatusRegionConfig,
     resolveStatusRegionSection,
@@ -77,7 +75,7 @@ import { formatToolsForPrompt, formatGroupToolsForPrompt, formatToolSchema } fro
 import { parseToolCalls, parseToolFetches, executeToolCalls, formatToolResults, type ToolCall } from "./tool-executor";
 import { stripStateAndInnerForPrompt } from "./prompt-sanitizer";
 import { buildGroupRosterMacro } from "./group-admin";
-import { parseOfflineResponse, extractThinkingTag, type ParsedOfflineResponse } from "./chat-offline-storage";
+import { parseOfflineResponse, type ParsedOfflineResponse } from "./chat-offline-storage";
 import { buildProviderRequest, nativeToolProtocolForConfig, toLlmRequestMessages, type LlmRequestMessage, type LlmToolCall } from "./llm-provider-adapter";
 import type { DebugPromptSnapshot } from "./debug-store";
 import { throwIfAborted } from "./abort-utils";
@@ -457,6 +455,15 @@ async function buildGroupChatPromptMessages(
         userName,
     );
 
+    let ttsEmotionInstruction = "";
+    for (const m of members) {
+        const vc = resolveVoiceConfig(m.character.id);
+        if (vc?.provider === "Minimax" && vc.aiEmotionMode === "inline") {
+            ttsEmotionInstruction = resolveTtsEmotionPrompt(true, vc.inlineEmotionPrompt);
+            break;
+        }
+    }
+
     const llmMessages = assembleGroupPromptPayload({
         members,
         history: promptHistory,
@@ -485,6 +492,7 @@ async function buildGroupChatPromptMessages(
         groupRoster,
         customAppRichMediaDirectives,
         chatBilingualInstruction,
+        ttsEmotionInstruction,
         statusRegionSection: resolveStatusRegionSection(statusRegionCfg, "group"),
         statusRegionExampleLine: resolveStatusRegionExampleLine(statusRegionCfg),
         statusRegionComposition: resolveStatusRegionComposition(statusRegionCfg),
@@ -569,8 +577,6 @@ async function runNativeGroupToolLoop(params: {
 }): Promise<string> {
     const { session, llmMessages, config, preset, regexes, nameToId, memberNames, enabledTools, appTags, signal, callbacks } = params;
     const MAX_TOOL_ROUNDS = 5;
-    const onlineThinkingEnabled = preset?.online_thinking_enabled === true;
-    const onlineThinkingTag = preset?.online_thinking_tag?.trim() || "thinking";
     const persistedSession = loadChatSessions().find(item => item.id === session.id);
     let expandedSourceIds = normalizeNativeExpandedToolSourceIds(
         persistedSession?.nativeExpandedToolSourceIds || session.nativeExpandedToolSourceIds,
@@ -590,27 +596,12 @@ async function runNativeGroupToolLoop(params: {
     for (let round = 0; round < MAX_TOOL_ROUNDS; round += 1) {
         let result: Awaited<ReturnType<typeof sendLLMToolRequest>>;
         try {
-            if (isSessionStreamingEnabled(session, true)) {
-                let streamReasoning = "";
-                result = await sendLLMToolStreamRequest(config, preset, requestMessages, nativeBundle.definitions, regexes, meta, {
-                    appId: "group_chat",
-                    appTags,
-                    debugSessionId: session.id,
-                    signal,
-                }, {
-                    onDelta: (text) => callbacks?.onStreamDelta?.(text),
-                    // 流式下 onReasoningDelta 是单段增量：累积后再喂 onReasoning（保持整段请求语义）
-                    // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
-                    onReasoningDelta: onlineThinkingEnabled ? undefined : (text) => { streamReasoning += text; callbacks?.onReasoning?.(streamReasoning); },
-                });
-            } else {
-                result = await sendLLMToolRequest(config, preset, requestMessages, nativeBundle.definitions, regexes, meta, {
-                    appId: "group_chat",
-                    appTags,
-                    debugSessionId: session.id,
-                    signal,
-                });
-            }
+            result = await sendLLMToolRequest(config, preset, requestMessages, nativeBundle.definitions, regexes, meta, {
+                appId: "group_chat",
+                appTags,
+                debugSessionId: session.id,
+                signal,
+            });
         } catch (err) {
             if (finalRawOutput) {
                 throwIfAborted(signal);
@@ -621,31 +612,21 @@ async function runNativeGroupToolLoop(params: {
         }
         throwIfAborted(signal);
 
-        // 线上思维链标签解析：开启时每轮从正文提取 <tag> 思维链（覆盖原生），并剥离标签后再做后续解析
-        let displayContent = result.content;
-        if (onlineThinkingEnabled) {
-            const tagThinking = extractThinkingTag(displayContent, onlineThinkingTag);
-            if (tagThinking) callbacks?.onReasoning?.(tagThinking);
-            displayContent = stripOnlineThinkingTag(displayContent, onlineThinkingTag);
-        }
-        // 剔除预设配置的文本片段（<思考结束> 等残留标签）
-        displayContent = stripPresetTexts(displayContent, preset);
-        const assistantForToolContext = stripStateAndInnerForPrompt(displayContent);
+        const assistantForToolContext = stripStateAndInnerForPrompt(result.content);
         if (result.toolCalls.length === 0) {
             throwIfAborted(signal);
             // 无工具调用的最终轮：把解析到的思维链交给回调（随后由 processGroupParts 挂到本轮首条气泡）
-            // 标签解析开启时已用标签思维链覆盖，此处不再重复喂原生
-            if (result.reasoning && !onlineThinkingEnabled) callbacks?.onReasoning?.(result.reasoning);
-            finalRawOutput = displayContent;
+            if (result.reasoning) callbacks?.onReasoning?.(result.reasoning);
+            finalRawOutput = result.content;
             break;
         }
 
         throwIfAborted(signal);
         await callbacks?.onNativeToolAssistantTurn?.({
-            content: displayContent,
-            rawContent: displayContent,
-            reasoning: onlineThinkingEnabled ? (extractThinkingTag(result.content, onlineThinkingTag) || undefined) : result.reasoning,
-            openRouterReasoningDetails: onlineThinkingEnabled ? undefined : result.openRouterReasoningDetails,
+            content: result.content,
+            rawContent: result.content,
+            reasoning: result.reasoning,
+            openRouterReasoningDetails: result.openRouterReasoningDetails,
             toolCalls: result.toolCalls,
         });
 
@@ -751,8 +732,8 @@ async function runNativeGroupToolLoop(params: {
         requestMessages.push({
             role: "assistant",
             content: assistantForToolContext,
-            reasoning: onlineThinkingEnabled ? (extractThinkingTag(result.content, onlineThinkingTag) || undefined) : result.reasoning,
-            openRouterReasoningDetails: onlineThinkingEnabled ? undefined : result.openRouterReasoningDetails,
+            reasoning: result.reasoning,
+            openRouterReasoningDetails: result.openRouterReasoningDetails,
             toolCalls: result.toolCalls,
         });
         const toolExecutionId = createToolExecutionId();
@@ -811,9 +792,6 @@ export async function generateGroupChatCompletion(
     const MAX_TOOL_ROUNDS = 5;
     const meta = { characterName: `群聊:${session.groupName || "群聊"}` };
     let finalRawOutput = "";
-    // 线上思维链标签解析：预设开启时从正文提取 <tag> 思维链（覆盖原生），并剥离标签后再做后续解析
-    const onlineThinkingEnabled = preset?.online_thinking_enabled === true;
-    const onlineThinkingTag = preset?.online_thinking_tag?.trim() || "thinking";
 
     if (nativeToolProtocolForConfig(config) && enabledTools.length > 0) {
         finalRawOutput = await runNativeGroupToolLoop({
@@ -842,30 +820,13 @@ export async function generateGroupChatCompletion(
     for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
         let filteredOutput: string;
         try {
-            if (isSessionStreamingEnabled(session, true)) {
-                let streamReasoning = "";
-                const streamResult = await sendLLMStreamRequest(config, preset, llmMessages, regexes, meta, {
-                    appId: "group_chat",
-                    appTags,
-                    debugSessionId: session.id,
-                    signal: options?.signal,
-                }, {
-                    onDelta: (text) => callbacks?.onStreamDelta?.(text),
-                    // 流式下 onReasoningDelta 是单段增量：累积后再喂 onReasoning（保持整段请求语义）
-                    // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
-                    onReasoningDelta: onlineThinkingEnabled ? undefined : (text) => { streamReasoning += text; callbacks?.onReasoning?.(streamReasoning); },
-                });
-                filteredOutput = streamResult.content;
-            } else {
-                filteredOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
-                    appId: "group_chat",
-                    appTags,
-                    debugSessionId: session.id,
-                    signal: options?.signal,
-                    // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
-                    onReasoning: onlineThinkingEnabled ? undefined : callbacks?.onReasoning,
-                });
-            }
+            filteredOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
+                appId: "group_chat",
+                appTags,
+                debugSessionId: session.id,
+                signal: options?.signal,
+                onReasoning: callbacks?.onReasoning,
+            });
         } catch (err) {
             if (finalRawOutput) {
                 throwIfAborted(options?.signal);
@@ -875,15 +836,6 @@ export async function generateGroupChatCompletion(
             throw err;
         }
         throwIfAborted(options?.signal);
-
-        // 线上思维链标签解析：开启时每轮从正文提取 <tag> 思维链（覆盖原生），并剥离标签后再做后续解析
-        if (onlineThinkingEnabled) {
-            const tagThinking = extractThinkingTag(filteredOutput, onlineThinkingTag);
-            if (tagThinking) callbacks?.onReasoning?.(tagThinking);
-            filteredOutput = stripOnlineThinkingTag(filteredOutput, onlineThinkingTag);
-        }
-        // 剔除预设配置的文本片段（<思考结束> 等残留标签），不进入消息/提示词
-        filteredOutput = stripPresetTexts(filteredOutput, preset);
 
         const toolFetches = parseToolFetches(filteredOutput);
         const { toolCalls } = parseToolCalls(filteredOutput);
@@ -1017,39 +969,14 @@ export async function generateGroupChatCompletion(
 
             if (round === MAX_TOOL_ROUNDS - 1) {
                 try {
-                    if (isSessionStreamingEnabled(session, true)) {
-                        let streamReasoning = "";
-                        const streamFinal = await sendLLMStreamRequest(config, preset, llmMessages, regexes, meta, {
-                            appId: "group_chat",
-                            appTags,
-                            debugSessionId: session.id,
-                            signal: options?.signal,
-                        }, {
-                            onDelta: (text) => callbacks?.onStreamDelta?.(text),
-                            // 流式下 onReasoningDelta 是单段增量：累积后再喂 onReasoning（保持整段请求语义）
-                            // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
-                            onReasoningDelta: onlineThinkingEnabled ? undefined : (text) => { streamReasoning += text; callbacks?.onReasoning?.(streamReasoning); },
-                        });
-                        finalRawOutput = streamFinal.content;
-                    } else {
-                        finalRawOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
-                            appId: "group_chat",
-                            appTags,
-                            debugSessionId: session.id,
-                            signal: options?.signal,
-                            // 预设开启「线上标签解析」时不透传原生思维链（改由下方标签提取）
-                            onReasoning: onlineThinkingEnabled ? undefined : callbacks?.onReasoning,
-                        });
-                    }
+                    finalRawOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, {
+                        appId: "group_chat",
+                        appTags,
+                        debugSessionId: session.id,
+                        signal: options?.signal,
+                        onReasoning: callbacks?.onReasoning,
+                    });
                     throwIfAborted(options?.signal);
-                    // 线上思维链标签解析：开启时从正文提取 <tag> 思维链并剥离标签
-                    if (onlineThinkingEnabled) {
-                        const tagThinking = extractThinkingTag(finalRawOutput, onlineThinkingTag);
-                        if (tagThinking) callbacks?.onReasoning?.(tagThinking);
-                        finalRawOutput = stripOnlineThinkingTag(finalRawOutput, onlineThinkingTag);
-                    }
-                    // 剔除预设配置的文本片段（<思考结束> 等残留标签）
-                    finalRawOutput = stripPresetTexts(finalRawOutput, preset);
                 } catch {
                     throwIfAborted(options?.signal);
                     /* use last output */
@@ -1134,7 +1061,7 @@ export type GroupOfflineChatCompletionResult = ParsedOfflineResponse & {
 export async function generateGroupOfflineChatCompletion(
     session: ChatSession,
     history: ChatMessage[],
-    options?: { signal?: AbortSignal; onStreamDelta?: (delta: string) => void },
+    options?: { signal?: AbortSignal },
 ): Promise<GroupOfflineChatCompletionResult> {
     const { llmMessages, config, preset, regexes } = await buildGroupChatPromptMessages(
         session,
@@ -1146,82 +1073,18 @@ export async function generateGroupOfflineChatCompletion(
         },
     );
     const summaryTag = preset?.story_summary_tag?.trim() || "summary";
-    const thinkingTag = preset?.thinking_tag?.trim() || "thinking";
-    const offlineTagEnabled = preset?.offline_thinking_enabled === true;
     let reasoning = "";
-    const meta = { characterName: `群聊:${session.groupName || "群聊"}` };
-    const requestOptions = {
+    const rawOutput = await sendLLMRequest(config, preset, llmMessages, regexes, {
+        characterName: `群聊:${session.groupName || "群聊"}`,
+    }, {
         appId: "group_chat",
         appTags: ["group_chat", "offline"],
         debugSessionId: session.id,
         signal: options?.signal,
-        onReasoning: (t: string) => { reasoning = t; },
-    };
-    let rawOutput: string;
-    if (isSessionStreamingEnabled(session, false) && options?.onStreamDelta) {
-        const streamResult = await sendLLMStreamRequest(config, preset, llmMessages, regexes, meta, {
-            appId: "group_chat",
-            appTags: ["group_chat", "offline"],
-            debugSessionId: session.id,
-            signal: options?.signal,
-        }, {
-            onDelta: (text) => options.onStreamDelta?.(text),
-            onReasoningDelta: (t) => { reasoning += t; },
-        });
-        rawOutput = streamResult.content;
-    } else {
-        rawOutput = await sendLLMRequest(config, preset, llmMessages, regexes, meta, requestOptions);
-    }
-    // 剔除预设配置的文本片段（<思考结束> 等残留标签），不进入记录/提示词
-    rawOutput = stripPresetTexts(rawOutput, preset);
-    let parsed = parseOfflineResponse(rawOutput, summaryTag);
-    // 思维链：预设开启「线下标签解析」时从正文提取 <thinking> 标签；关闭时走模型原生 reasoning（官方默认行为）
-    if (offlineTagEnabled) {
-        const tagThinking = extractThinkingTag(rawOutput, thinkingTag);
-        if (tagThinking) reasoning = tagThinking;
-        // 模型漏写 <content> 时 parseOfflineResponse 兜底把全文当正文，thinking 块会残留其中：
-        // 这里统一剥掉，避免思考过程既进思维链又出现在正文（默认标签 thinking 兼容 thought）
-        let cleanedContent = parsed.content;
-        for (const tag of (thinkingTag === "thinking" ? ["thinking", "thought", "think"] : [thinkingTag])) {
-            cleanedContent = stripOnlineThinkingTag(cleanedContent, tag);
-        }
-        parsed = { ...parsed, content: cleanedContent };
-    }
-
-    // 摘要缺失时自动补提：只带最后一轮上下文（系统提示 + 最后一条用户消息 + 本次输出），
-    // 要求模型补一段摘要，避免「静默结束」导致该轮线下记录没有摘要、进不了短期记忆事件流。
-    // 不重发完整 llmMessages：长对话下 token/延迟成本高，且摘要本来就只针对本轮关键事件。
-    const MAX_SUMMARY_RETRY = 2;
-    const lastUserMessage = [...llmMessages].reverse().find(m => m.role === "user");
-    for (let attempt = 0; attempt < MAX_SUMMARY_RETRY; attempt += 1) {
-        if (parsed.summary.trim()) break;
-        if (!parsed.content.trim() && !rawOutput.trim()) break; // 连正文都没有，补提没有意义
-        const retryMessages: LLMMessage[] = [
-            ...(llmMessages[0]?.role === "system" ? [llmMessages[0]] : []),
-            ...(lastUserMessage ? [lastUserMessage] : []),
-            { role: "assistant", content: rawOutput },
-            {
-                role: "user",
-                content: `刚才的回复里没有输出 <${summaryTag}> 摘要。请只针对上面这段对话的关键事件补一段第三人称摘要，严格按以下格式输出，不要输出任何其他内容：\n<${summaryTag}>一句话摘要</${summaryTag}>`,
-            },
-        ];
-        throwIfAborted(options?.signal);
-        // 补提请求不带 onReasoning：避免用补提请求的思维链覆盖主请求已累积的完整思维链
-        const retryRaw = stripPresetTexts(await sendLLMRequest(config, preset, retryMessages, regexes, meta, { ...requestOptions, onReasoning: undefined }), preset);
-        const retried = parseOfflineResponse(retryRaw, summaryTag);
-        if (retried.summary.trim()) {
-            parsed = { ...parsed, summary: retried.summary.trim() };
-            break;
-        }
-    }
-
+        onReasoning: (t) => { reasoning = t; },
+    });
     return {
-        ...parsed,
-        // 标签解析开启时补 thinking/thinkingTag（供离线记录展示）；关闭时保持 undefined，思维链走 reasoning（模型原生）
-        ...(offlineTagEnabled ? {
-            thinking: extractThinkingTag(rawOutput, thinkingTag) || undefined,
-            thinkingTag,
-        } : {}),
+        ...parseOfflineResponse(rawOutput, summaryTag),
         model: config.defaultModel,
         presetName: preset?.name || "默认预设",
         reasoning: reasoning || undefined,
@@ -1253,7 +1116,7 @@ export async function previewGroupPromptRequestSnapshot(
     history: ChatMessage[],
     options?: GroupChatPromptBuildOptions,
 ): Promise<DebugPromptSnapshot> {
-    const { llmMessages, config, preset, memberNames, enabledTools, userName, appTags } = await buildGroupChatPromptMessages(session, history, { ...options });
+    const { llmMessages, config, preset, memberNames, enabledTools, userName, appTags } = await buildGroupChatPromptMessages(session, history, options);
     const requestMessages = toLlmRequestMessages(llmMessages);
     const meta = { characterName: `群聊:${session.groupName || "群聊"}`, userName };
 


### PR DESCRIPTION
贡献者：初智齿

响应解析与 TTS 合成全覆盖：`parseAIResponse` 自动提取并剥离 `[emotion:xxx]` 标记，提取的情绪值自动注入普通语音条、语音通话、视频通话、群聊通话的 Minimax TTS 合成参数中。
（接 1/2）

> 格式参考的是小笼包老师双语翻译提示词的格式，需要把变量自己添加到预设里。

---
_经小手机「共同建设」通道提交_