### PR TITLE
语音合成新增鱼声 (Fish Audio) TTS 支持：情绪标签归一化与设置界面接入

### DIFF
--- a/components/settings/voice-settings.tsx
+++ b/components/settings/voice-settings.tsx
@@ -10,7 +10,7 @@ import { ConfirmDialog } from "@/components/ui/modal";
 import { Toggle, Input } from "@/components/ui/form";
 import { Alert } from "@/components/ui/feedback";
 
-const SUPPORTED_VOICE_PROVIDERS = new Set(["Minimax", "OpenAI"]);
+const SUPPORTED_VOICE_PROVIDERS = new Set(["Minimax", "OpenAI", "FishAudio"]);
 const MINIMAX_BASE_URL_OPTIONS = [
     { id: "cn", label: "国内版", baseUrl: "https://api.minimaxi.com/v1" },
     { id: "global", label: "海外版", baseUrl: "https://api.minimax.io/v1" },
@@ -30,6 +30,7 @@ const VOICE_PROVIDER_OPTIONS = [
     { value: "OpenAI", label: "OpenAI TTS" },
     { value: "MinimaxCN", label: "Minimax 语音国内版" },
     { value: "MinimaxGlobal", label: "Minimax 语音海外版" },
+    { value: "FishAudio", label: "鱼声 (Fish Audio) 语音" },
 ];
 
 const DEFAULT_VOICE_CONFIGS: VoiceApiConfig[] = [
@@ -182,7 +183,9 @@ function uniqueOptions(options: VoiceOption[]): VoiceOption[] {
 }
 
 function defaultVoiceOptions(provider: string): VoiceOption[] {
-    return provider === "OpenAI" ? DEFAULT_OPENAI_VOICES : DEFAULT_MINIMAX_VOICES;
+    if (provider === "OpenAI") return DEFAULT_OPENAI_VOICES;
+    if (provider === "FishAudio") return [];
+    return DEFAULT_MINIMAX_VOICES;
 }
 
 function voiceOptionsForConfig(config: VoiceApiConfig, fetchedVoices: Record<string, VoiceOption[]>): VoiceOption[] {
@@ -222,6 +225,7 @@ function makeCloneVoiceId(config: VoiceApiConfig): string {
 
 function providerSelectValue(config: VoiceApiConfig): string {
     if (config.provider === "OpenAI") return "OpenAI";
+    if (config.provider === "FishAudio") return "FishAudio";
     return config.baseUrl === GLOBAL_MINIMAX_BASE_URL ? "MinimaxGlobal" : "MinimaxCN";
 }
 
@@ -313,6 +317,18 @@ export function VoiceSettings() {
             });
             setManualModelIds(prev => ({ ...prev, [id]: true }));
             setManualVoiceIds(prev => ({ ...prev, [id]: false }));
+            return;
+        }
+        if (providerOption === "FishAudio") {
+            updateConfig(id, {
+                provider: "FishAudio",
+                baseUrl: "https://api.fish.audio/v1",
+                model: "s2.1-pro-free",
+                defaultVoice: "",
+                speechSpeed: 1.0,
+            });
+            setManualModelIds(prev => ({ ...prev, [id]: true }));
+            setManualVoiceIds(prev => ({ ...prev, [id]: true }));
             return;
         }
         const wasMinimax = current?.provider === "Minimax";
@@ -474,6 +490,11 @@ export function VoiceSettings() {
         setFetchError(prev => ({ ...prev, [config.id]: "" }));
 
         try {
+            if (config.provider === "FishAudio") {
+                setFetchedVoices(prev => ({ ...prev, [config.id]: [] }));
+                setFetchError(prev => ({ ...prev, [config.id]: "鱼声语音请在下方直接输入参考音色 reference_id" }));
+                return;
+            }
             if (config.provider === "Minimax") {
                 if (!config.apiKey.trim()) {
                     setFetchedVoices(prev => ({ ...prev, [config.id]: config.customVoices || [] }));
@@ -531,6 +552,8 @@ export function VoiceSettings() {
         try {
             const previewText = config.provider === "Minimax" && config.languageBoost
                 ? MINIMAX_PREVIEW_TEXT[config.languageBoost] || "你好，很高兴认识你。这是一段语音试听。"
+                : config.provider === "FishAudio"
+                ? "你好，我是鱼声语音，这是一段试听。"
                 : "你好，我现在是" + (config.defaultVoice || "默认") + "音色。很高兴认识你。";
             const blob = await synthesizeSpeech(
                 previewText,
@@ -668,6 +691,29 @@ export function VoiceSettings() {
                                             </select>
                                         </div>
 
+                                        {config.provider === "FishAudio" && (
+                                            <>
+                                                <div className="flex flex-col gap-1">
+                                                    <label className="menu-desc ml-1">接口地址 (Base URL)</label>
+                                                    <Input
+                                                        type="text"
+                                                        value={config.baseUrl || ""}
+                                                        onChange={(e) => updateConfig(config.id, { baseUrl: e.target.value })}
+                                                        placeholder="https://api.fish.audio/v1"
+                                                    />
+                                                </div>
+                                                <div className="flex flex-col gap-1">
+                                                    <label className="menu-desc ml-1">语音模型 (TTS Model)</label>
+                                                    <Input
+                                                        type="text"
+                                                        value={config.model || ""}
+                                                        onChange={(e) => updateConfig(config.id, { model: e.target.value })}
+                                                        placeholder="s2.1-pro-free"
+                                                    />
+                                                </div>
+                                            </>
+                                        )}
+
                                         <div className="flex flex-col gap-1">
                                             <label className="menu-desc ml-1">API Key</label>
                                             <Input
@@ -740,7 +786,7 @@ export function VoiceSettings() {
                                             </>
                                         )}
 
-                                        {config.provider === "Minimax" && (
+                                        {(config.provider === "Minimax" || config.provider === "FishAudio") && (
                                             <>
                                                 <div className="flex flex-col gap-1">
                                                     <div className="flex items-center justify-between px-1">
@@ -755,7 +801,7 @@ export function VoiceSettings() {
                                                         value={config.speechSpeed ?? DEFAULT_SPEECH_SPEED}
                                                         onChange={(e) => updateConfig(config.id, { speechSpeed: Number(e.target.value) })}
                                                         className="w-full accent-black"
-                                                        aria-label="Minimax 语速"
+                                                        aria-label="语速"
                                                     />
                                                     <div className="relative h-4 px-1 text-xs text-gray-500" aria-hidden="true">
                                                         <span className="absolute left-1 whitespace-nowrap">{MINIMAX_SPEED_MIN.toFixed(1)}×</span>
@@ -763,106 +809,114 @@ export function VoiceSettings() {
                                                         <span className="absolute right-1 whitespace-nowrap">{MINIMAX_SPEED_MAX.toFixed(1)}×</span>
                                                     </div>
                                                 </div>
-                                                <div className="flex flex-col gap-1 -mt-1">
-                                                    <div className="flex items-center justify-between px-1">
-                                                        <label className="menu-desc">音调 (Pitch)</label>
-                                                        <span className="menu-label font-medium">{config.speechPitch ?? DEFAULT_SPEECH_PITCH}</span>
-                                                    </div>
-                                                    <input
-                                                        type="range"
-                                                        min={MINIMAX_PITCH_MIN}
-                                                        max={MINIMAX_PITCH_MAX}
-                                                        step={MINIMAX_PITCH_STEP}
-                                                        value={config.speechPitch ?? DEFAULT_SPEECH_PITCH}
-                                                        onChange={(e) => updateConfig(config.id, { speechPitch: Number(e.target.value) })}
-                                                        className="w-full accent-black"
-                                                        aria-label="Minimax 音调"
-                                                    />
-                                                    <div className="relative h-4 px-1 text-xs text-gray-500" aria-hidden="true">
-                                                        <span className="absolute left-1 whitespace-nowrap">{MINIMAX_PITCH_MIN}</span>
-                                                        <span className="absolute whitespace-nowrap" style={{ left: "50%", transform: "translateX(-50%)" }}>0 默认</span>
-                                                        <span className="absolute right-1 whitespace-nowrap">+{MINIMAX_PITCH_MAX}</span>
-                                                    </div>
-                                                </div>
-                                                <div className="flex flex-col gap-1 mt-1">
-                                                    <label className="menu-desc ml-1">朗读语言</label>
-                                                    <select
-                                                        value={config.languageBoost || ""}
-                                                        onChange={(e) => updateConfig(config.id, { languageBoost: e.target.value || undefined })}
-                                                        className="ui-select"
-                                                    >
-                                                        {MINIMAX_LANGUAGE_OPTIONS.map(option => (
-                                                            <option key={option.value || "default"} value={option.value}>{option.label}</option>
-                                                        ))}
-                                                    </select>
-                                                </div>
-                                                <div className="flex flex-col gap-1">
-                                                    <label className="menu-desc ml-1">语音模型 (TTS Model)</label>
-                                                    <div className="flex flex-col gap-2">
-                                                        {manualModelIds[config.id] ? (
-                                                            <div className="flex gap-2">
-                                                                <Input
-                                                                    type="text"
-                                                                    value={config.model || ""}
-                                                                    onChange={(e) => updateConfig(config.id, { model: e.target.value })}
-                                                                    placeholder="手动输入模型 ID"
-                                                                    className="flex-1"
-                                                                />
-                                                                <button
-                                                                    type="button"
-                                                                    onClick={() => setManualModelIds(prev => ({ ...prev, [config.id]: false }))}
-                                                                    className="ui-icon-btn"
-                                                                    aria-label="返回模型下拉选择"
-                                                                    title="返回模型下拉选择"
-                                                                >
-                                                                    <List size={20} />
-                                                                </button>
+                                                {config.provider === "Minimax" && (
+                                                    <>
+                                                        <div className="flex flex-col gap-1 -mt-1">
+                                                            <div className="flex items-center justify-between px-1">
+                                                                <label className="menu-desc">音调 (Pitch)</label>
+                                                                <span className="menu-label font-medium">{config.speechPitch ?? DEFAULT_SPEECH_PITCH}</span>
                                                             </div>
-                                                        ) : (
+                                                            <input
+                                                                type="range"
+                                                                min={MINIMAX_PITCH_MIN}
+                                                                max={MINIMAX_PITCH_MAX}
+                                                                step={MINIMAX_PITCH_STEP}
+                                                                value={config.speechPitch ?? DEFAULT_SPEECH_PITCH}
+                                                                onChange={(e) => updateConfig(config.id, { speechPitch: Number(e.target.value) })}
+                                                                className="w-full accent-black"
+                                                                aria-label="Minimax 音调"
+                                                            />
+                                                            <div className="relative h-4 px-1 text-xs text-gray-500" aria-hidden="true">
+                                                                <span className="absolute left-1 whitespace-nowrap">{MINIMAX_PITCH_MIN}</span>
+                                                                <span className="absolute whitespace-nowrap" style={{ left: "50%", transform: "translateX(-50%)" }}>0 默认</span>
+                                                                <span className="absolute right-1 whitespace-nowrap">+{MINIMAX_PITCH_MAX}</span>
+                                                            </div>
+                                                        </div>
+                                                        <div className="flex flex-col gap-1 mt-1">
+                                                            <label className="menu-desc ml-1">朗读语言</label>
                                                             <select
-                                                                value={DEFAULT_MINIMAX_MODELS.some(m => m.id === config.model) ? config.model : "__manual__"}
-                                                                onChange={(e) => {
-                                                                    if (e.target.value === "__manual__") {
-                                                                        setManualModelIds(prev => ({ ...prev, [config.id]: true }));
-                                                                        return;
-                                                                    }
-                                                                    updateConfig(config.id, { model: e.target.value });
-                                                                }}
+                                                                value={config.languageBoost || ""}
+                                                                onChange={(e) => updateConfig(config.id, { languageBoost: e.target.value || undefined })}
                                                                 className="ui-select"
                                                             >
-                                                                {DEFAULT_MINIMAX_MODELS.map(model => (
-                                                                    <option key={model.id} value={model.id}>{model.name}</option>
+                                                                {MINIMAX_LANGUAGE_OPTIONS.map(option => (
+                                                                    <option key={option.value || "default"} value={option.value}>{option.label}</option>
                                                                 ))}
-                                                                <option value="__manual__">手动输入...</option>
                                                             </select>
-                                                        )}
-                                                    </div>
-                                                </div>
+                                                        </div>
+                                                        <div className="flex flex-col gap-1">
+                                                            <label className="menu-desc ml-1">语音模型 (TTS Model)</label>
+                                                            <div className="flex flex-col gap-2">
+                                                                {manualModelIds[config.id] ? (
+                                                                    <div className="flex gap-2">
+                                                                        <Input
+                                                                            type="text"
+                                                                            value={config.model || ""}
+                                                                            onChange={(e) => updateConfig(config.id, { model: e.target.value })}
+                                                                            placeholder="手动输入模型 ID"
+                                                                            className="flex-1"
+                                                                        />
+                                                                        <button
+                                                                            type="button"
+                                                                            onClick={() => setManualModelIds(prev => ({ ...prev, [config.id]: false }))}
+                                                                            className="ui-icon-btn"
+                                                                            aria-label="返回模型下拉选择"
+                                                                            title="返回模型下拉选择"
+                                                                        >
+                                                                            <List size={20} />
+                                                                        </button>
+                                                                    </div>
+                                                                ) : (
+                                                                    <select
+                                                                        value={DEFAULT_MINIMAX_MODELS.some(m => m.id === config.model) ? config.model : "__manual__"}
+                                                                        onChange={(e) => {
+                                                                            if (e.target.value === "__manual__") {
+                                                                                setManualModelIds(prev => ({ ...prev, [config.id]: true }));
+                                                                                return;
+                                                                            }
+                                                                            updateConfig(config.id, { model: e.target.value });
+                                                                        }}
+                                                                        className="ui-select"
+                                                                    >
+                                                                        {DEFAULT_MINIMAX_MODELS.map(model => (
+                                                                            <option key={model.id} value={model.id}>{model.name}</option>
+                                                                        ))}
+                                                                        <option value="__manual__">手动输入...</option>
+                                                                    </select>
+                                                                )}
+                                                            </div>
+                                                        </div>
+                                                    </>
+                                                )}
                                             </>
                                         )}
 
                                         <div className="flex flex-col gap-1">
-                                            <label className="menu-desc ml-1">默认音色 (Default Voice) 或 自定义 Voice ID</label>
+                                            <label className="menu-desc ml-1">
+                                                {config.provider === "FishAudio" ? "参考音色 ID (reference_id) [支持填入 32位 鱼声音色ID]" : "默认音色 (Default Voice) 或 自定义 Voice ID"}
+                                            </label>
                                             <div className="flex flex-col gap-2">
                                                 <div className="flex gap-2">
-                                                    {manualVoiceIds[config.id] ? (
+                                                    {manualVoiceIds[config.id] || config.provider === "FishAudio" ? (
                                                         <>
                                                             <Input
                                                                 type="text"
                                                                 value={config.defaultVoice}
                                                                 onChange={(e) => updateConfig(config.id, { defaultVoice: e.target.value })}
-                                                                placeholder={config.provider === "OpenAI" ? "alloy" : "male-qn-qingse 或克隆 Voice ID"}
+                                                                placeholder={config.provider === "FishAudio" ? "填入鱼声的 32位 reference_id" : config.provider === "OpenAI" ? "alloy" : "male-qn-qingse 或克隆 Voice ID"}
                                                                 className="flex-1"
                                                             />
-                                                            <button
-                                                                type="button"
-                                                                onClick={() => setManualVoiceIds(prev => ({ ...prev, [config.id]: false }))}
-                                                                className="ui-icon-btn"
-                                                                aria-label="返回音色下拉选择"
-                                                                title="返回音色下拉选择"
-                                                            >
-                                                                <List size={20} />
-                                                            </button>
+                                                            {config.provider !== "FishAudio" && (
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() => setManualVoiceIds(prev => ({ ...prev, [config.id]: false }))}
+                                                                    className="ui-icon-btn"
+                                                                    aria-label="返回音色下拉选择"
+                                                                    title="返回音色下拉选择"
+                                                                >
+                                                                    <List size={20} />
+                                                                </button>
+                                                            )}
                                                         </>
                                                     ) : (
                                                         (() => {
@@ -896,26 +950,28 @@ export function VoiceSettings() {
                                                     </button>
                                                 </div>
 
-                                                <div className="flex gap-2 mt-0.5">
-                                                    <button
-                                                        onClick={() => fetchVoices(config)}
-                                                        disabled={isFetching[config.id]}
-                                                        className="ui-btn ui-btn ui-btn-soft-action w-full"
-                                                    >
-                                                        <RefreshCw size={16} className={isFetching[config.id] ? "animate-spin" : ""} />
-                                                        {isFetching[config.id] ? "同步中..." : config.provider === "Minimax" ? "同步音色列表" : "显示默认音色"}
-                                                    </button>
-                                                    {config.provider === "Minimax" && (
+                                                {config.provider !== "FishAudio" && (
+                                                    <div className="flex gap-2 mt-0.5">
                                                         <button
-                                                            onClick={() => openCloneModal(config)}
-                                                            disabled={!config.apiKey.trim()}
-                                                            className="ui-btn ui-btn-soft-action w-full"
+                                                            onClick={() => fetchVoices(config)}
+                                                            disabled={isFetching[config.id]}
+                                                            className="ui-btn ui-btn ui-btn-soft-action w-full"
                                                         >
-                                                            <Upload size={16} />
-                                                            上传音频克隆音色
+                                                            <RefreshCw size={16} className={isFetching[config.id] ? "animate-spin" : ""} />
+                                                            {isFetching[config.id] ? "同步中..." : config.provider === "Minimax" ? "同步音色列表" : "显示默认音色"}
                                                         </button>
-                                                    )}
-                                                </div>
+                                                        {config.provider === "Minimax" && (
+                                                            <button
+                                                                onClick={() => openCloneModal(config)}
+                                                                disabled={!config.apiKey.trim()}
+                                                                className="ui-btn ui-btn-soft-action w-full"
+                                                            >
+                                                                <Upload size={16} />
+                                                                上传音频克隆音色
+                                                            </button>
+                                                        )}
+                                                    </div>
+                                                )}
 
                                                 {fetchError[config.id] && (
                                                     <Alert variant="danger">

--- a/lib/tts-service.ts
+++ b/lib/tts-service.ts
@@ -43,6 +43,10 @@ export async function synthesizeSpeech(
         return synthesizeOpenAI(text, voiceConfig);
     }
 
+    if (provider === "FishAudio") {
+        return synthesizeFishAudio(text, voiceConfig, options?.emotion);
+    }
+
     return null;
 }
 
@@ -168,6 +172,130 @@ async function synthesizeOpenAI(text: string, config: VoiceApiConfig): Promise<B
     if (!response.ok) {
         const errText = await response.text().catch(() => "");
         throw new Error(`OpenAI TTS 请求失败 (${response.status}): ${errText}`);
+    }
+
+    const blob = await response.blob();
+    return new Blob([await blob.arrayBuffer()], { type: "audio/mpeg" });
+}
+
+// ── Fish Audio TTS ───────────────────────────────────
+
+// 鱼声 S2.1 官方可靠支持的标签集（来自 app UI 调色板），超出此范围的标签容易造成平读或念错
+const FISH_SUPPORTED_CUES = new Set([
+    'angry', 'sad', 'embarrassed', 'emphasis', 'whispering', 'soft', 'breathy', 'excited',
+    'laughing', 'chuckling', 'moaning', 'clear throat', 'sobbing', 'crying loudly',
+    'sighing', 'panting', 'groaning', 'crowd laughing', 'background laughter', 'audience laughing',
+    'pause', 'long pause',
+]);
+
+const FISH_CUE_SYNONYMS: Record<string, string> = {
+    'break': 'pause', 'short pause': 'pause',
+    'long-break': 'long pause', 'longbreak': 'long pause', 'long break': 'long pause',
+    happy: 'excited', joyful: 'excited', delighted: 'excited', cheerful: 'excited', glad: 'excited',
+    smug: 'excited', proud: 'excited', gleeful: 'excited', playful: 'excited', teasing: 'excited',
+    confident: 'excited', surprised: 'excited', amazed: 'excited', curious: 'excited', hopeful: 'excited',
+    enthusiastic: 'excited', eager: 'excited',
+    annoyed: 'angry', irritated: 'angry', frustrated: 'angry', mad: 'angry', furious: 'angry', grumpy: 'angry',
+    unhappy: 'sad', disappointed: 'sad', hurt: 'sad', depressed: 'sad', pleading: 'sad', sulking: 'sad', lonely: 'sad', regretful: 'sad',
+    shy: 'embarrassed', bashful: 'embarrassed', awkward: 'embarrassed', flustered: 'embarrassed',
+    'soft tone': 'soft', gentle: 'soft', tender: 'soft', warm: 'soft', calm: 'soft', soothing: 'soft',
+    tired: 'soft', sleepy: 'soft', relaxed: 'soft', sincere: 'soft',
+    nervous: 'breathy', anxious: 'breathy', scared: 'breathy', fearful: 'breathy', worried: 'breathy', timid: 'breathy',
+    whisper: 'whispering', hushed: 'whispering', murmuring: 'whispering',
+    emphatic: 'emphasis', stressing: 'emphasis',
+    laugh: 'laughing', laughs: 'laughing',
+    giggle: 'chuckling', giggling: 'chuckling', giggles: 'chuckling', chuckle: 'chuckling', chuckles: 'chuckling',
+    sigh: 'sighing', sighs: 'sighing',
+    sob: 'sobbing', sobs: 'sobbing', crying: 'crying loudly', cry: 'crying loudly',
+    groan: 'groaning', groans: 'groaning',
+    pant: 'panting', pants: 'panting', gasp: 'panting', gasps: 'panting', gasping: 'panting', 'out of breath': 'panting',
+    moan: 'moaning', moans: 'moaning',
+    'clears throat': 'clear throat', ahem: 'clear throat', cough: 'clear throat', coughs: 'clear throat',
+};
+
+const FISH_EMOTION_MAP: Record<string, string> = {
+    happy: 'excited',
+    sad: 'sad',
+    angry: 'angry',
+    fearful: 'breathy',
+    disgusted: 'angry',
+    surprised: 'excited',
+    calm: 'soft',
+};
+
+function normalizeFishCue(inner: string): string {
+    const key = (inner || '').trim().toLowerCase().replace(/\s+/g, ' ');
+    if (!key) return '';
+    if (FISH_SUPPORTED_CUES.has(key)) return key;
+    if (FISH_CUE_SYNONYMS[key]) return FISH_CUE_SYNONYMS[key];
+    for (const [syn, canon] of Object.entries(FISH_CUE_SYNONYMS)) {
+        if (key.includes(syn)) return canon;
+    }
+    for (const canon of FISH_SUPPORTED_CUES) {
+        if (key.includes(canon)) return canon;
+    }
+    return '';
+}
+
+function cleanTextForTtsFish(raw: string): string {
+    if (!raw) return '';
+    let text = raw
+        .replace(/\[\[.*?\]\]/g, '')                 // 去除系统标记 [[..]]
+        .replace(/%%BILINGUAL%%[\s\S]*/i, '')        // 移除双语分割线
+        .replace(/（[^）]{0,48}）/g, '')              // 去除中文圆括号舞台指示
+        .replace(/<#\s*[\d.]+\s*#>/g, '')            // 过滤 MiniMax 停顿标记
+        .replace(/\(([^)]{1,40})\)/g, '[$1]')        // 圆括号转方括号，便于归一
+        .replace(/\n{2,}/g, ' [long pause] ')        // 换行替换为停顿
+        .replace(/\n+/g, ' [pause] ')
+        .replace(/\[([^\[\]]{1,40})\]/g, (_m, inner: string) => {
+            const canon = normalizeFishCue(inner);
+            return canon ? `[${canon}]` : '';
+        })
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    return text;
+}
+
+async function synthesizeFishAudio(text: string, config: VoiceApiConfig, emotion?: string): Promise<Blob | null> {
+    if (!config.apiKey) throw new Error("鱼声 (Fish Audio) API Key 未配置");
+
+    const baseUrl = (config.baseUrl || "https://api.fish.audio/v1").replace(/\/$/, "");
+    let spoken = cleanTextForTtsFish(text);
+
+    // 兜底：如果外部传了 emotion，且文中没有方括号 cue，前置一个情绪
+    const hasInlineCue = spoken.includes('[') && spoken.includes(']');
+    const fishEmotion = emotion ? FISH_EMOTION_MAP[emotion.toLowerCase()] : undefined;
+    if (fishEmotion && !hasInlineCue) {
+        spoken = `[${fishEmotion}] ${spoken}`;
+    }
+
+    if (!spoken.trim()) return null;
+
+    const payload: Record<string, any> = {
+        text: spoken,
+        reference_id: config.defaultVoice || undefined,
+        format: "mp3",
+        normalize: true,
+    };
+
+    // 语速配置，支持在设置里拉动的语速
+    const speed = typeof config.speechSpeed === "number" && config.speechSpeed > 0 ? config.speechSpeed : 1.0;
+    payload.prosody = { speed: Math.max(0.5, Math.min(2.0, speed)) };
+
+    const response = await fetchWithTimeout(`${baseUrl}/tts`, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${config.apiKey}`,
+            "Content-Type": "application/json",
+            model: config.model || "s2.1-pro-free",
+        },
+        body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+        const errText = await response.text().catch(() => "");
+        throw new Error(`鱼声 TTS 请求失败 (${response.status}): ${errText}`);
     }
 
     const blob = await response.blob();


### PR DESCRIPTION
贡献者：Jcin004（@Jcin004）

新增 Fish Audio（鱼声）作为 TTS 语音合成服务商：\n\n1. lib/tts-service.ts：新增 synthesizeFishAudio 实现，调用 fish.audio /tts 接口；内置 S2.1 官方支持的情绪/拟声标签白名单与约百条同义词归一化映射（如 giggle→chuckling、whisper→whispering），文本清洗管线（去除 [[..]] 系统标记、双语分割线、中文舞台指示、MiniMax 停顿标记，圆括号转方括号，换行转停顿标签）；支持外部 emotion 兜底前置、prosody 语速（0.5–2.0 限幅）、默认模型 s2.1-pro-free。\n2. components/settings/voice-settings.tsx：供应商下拉新增「鱼声 (Fish Audio) 语音」选项；新增 Base URL 与 TTS 模型输入框；参考音色改为直接填写 reference_id（不走在线拉取）；试听文案适配；语速滑杆复用 Minimax 分支。\n\n验证：本地 test 分支已运行，配置鱼声 API Key 后设置界面可选、可试听、语速生效；情绪标签清洗对含嵌套方括号与舞台指示的文本输出正常。

---
_经小手机「共同建设」通道提交_