### PR TITLE
feat(xiaohongshu): 支持发帖多图及详情页左右滑动轮播

### DIFF
--- a/components/xiaohongshu/xiaohongshu-app.tsx
+++ b/components/xiaohongshu/xiaohongshu-app.tsx
@@ -404,17 +404,64 @@ function createCharacterPost(character: Character, activity: ParsedXiaohongshuCh
   };
 }
 
+function NoteDetailSlider({
+  note,
+  imageIds,
+  imageMap,
+}: {
+  note: XiaohongshuNote;
+  imageIds: string[];
+  imageMap: Record<string, string>;
+}) {
+  const [activeSlide, setActiveSlide] = useState(0);
+  return (
+    <div className="xhs-note-slider-container" style={getImageFrameStyle(note.imageWidth, note.imageHeight)}>
+      <div
+        className="xhs-note-slider-track"
+        onScroll={(e) => {
+          const el = e.currentTarget;
+          const index = Math.round(el.scrollLeft / (el.clientWidth || 1));
+          setActiveSlide(index);
+        }}
+      >
+        {imageIds.map((id, idx) => (
+          <div key={id || idx} className="xhs-note-slider-item">
+            {imageMap[id] ? (
+              <img src={imageMap[id]} alt={`Slide ${idx + 1}`} className="xhs-note-real-image" />
+            ) : (
+              <div className="cp-xhs-cover cp-xhs-cover--ivory" style={{ width: "100%", height: "100%" }} />
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="xhs-note-slider-indicator">
+        {activeSlide + 1} / {imageIds.length}
+      </div>
+      <div className="xhs-note-slider-dots">
+        {imageIds.map((_, idx) => (
+          <span key={idx} className={`xhs-slider-dot ${idx === activeSlide ? "is-active" : ""}`} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function NoteImage({
   note,
   imageMap,
   hideTextImageDescription = false,
   collapseBilingualTranslation,
+  isDetail,
 }: {
   note: XiaohongshuNote;
   imageMap: Record<string, string>;
   hideTextImageDescription?: boolean;
   collapseBilingualTranslation: boolean;
+  isDetail?: boolean;
 }) {
+  const imageIds = (note.imageAssetIds && note.imageAssetIds.length > 0)
+    ? note.imageAssetIds
+    : (note.imageAssetId ? [note.imageAssetId] : []);
   if (note.type === "video") {
     return (
       <div className={`cp-xhs-cover cp-xhs-cover--video cp-xhs-cover--${note.tone}`} style={VIDEO_XHS_IMAGE_FRAME_STYLE}>
@@ -434,10 +481,22 @@ function NoteImage({
       </div>
     );
   }
-  if (note.imageAssetId && imageMap[note.imageAssetId]) {
+  if (imageIds.length > 0 && imageIds.some(id => Boolean(imageMap[id]))) {
+    if (isDetail && imageIds.length > 1) {
+      return <NoteDetailSlider note={note} imageIds={imageIds} imageMap={imageMap} />;
+    }
+    const firstImgId = imageIds.find(id => Boolean(imageMap[id])) || imageIds[0];
     return (
       <div className="xhs-note-real-image-frame" style={getImageFrameStyle(note.imageWidth, note.imageHeight)}>
-        <img src={imageMap[note.imageAssetId]} alt="" className="xhs-note-real-image" />
+        <img src={imageMap[firstImgId]} alt="" className="xhs-note-real-image" />
+        {!isDetail && imageIds.length > 1 ? (
+          <div className="xhs-waterfall-multi-badge">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+              <rect x="3" y="3" width="14" height="14" rx="2" />
+              <path d="M7 21h12a2 2 0 0 0 2-2V7" />
+            </svg>
+          </div>
+        ) : null}
       </div>
     );
   }
@@ -1295,7 +1354,7 @@ export function XiaohongshuApp({ onClose, onNotice, visible = true, onIdle, onBu
 
   useEffect(() => {
     const assetIds = Array.from(new Set([
-      ...state.notes.map(note => note.imageAssetId).filter(Boolean),
+      ...state.notes.flatMap(note => (note.imageAssetIds && note.imageAssetIds.length > 0 ? note.imageAssetIds : [note.imageAssetId])),
       state.profile.coverImageAssetId,
     ].filter(Boolean))) as string[];
     assetIds.forEach((assetId) => {
@@ -1464,53 +1523,77 @@ export function XiaohongshuApp({ onClose, onNotice, visible = true, onIdle, onBu
     setSettingsDraft(DEFAULT_XIAOHONGSHU_SETTINGS);
   }
 
-  async function handleImageChange(event: ChangeEvent<HTMLInputElement>) {
-    const file = event.target.files?.[0];
-    if (!file) return;
-    const image = new Image();
-    const objectUrl = URL.createObjectURL(file);
-    image.onload = () => {
-      const canvas = document.createElement("canvas");
-      const maxSize = 960;
-      const sourceWidth = image.width;
-      let sourceHeight = image.height;
-      const sourceX = 0;
-      let sourceY = 0;
-      if (sourceHeight / sourceWidth > XHS_MAX_IMAGE_HEIGHT_RATIO) {
-        sourceHeight = Math.round(sourceWidth * XHS_MAX_IMAGE_HEIGHT_RATIO);
-        sourceY = Math.round((image.height - sourceHeight) / 2);
-      }
-      let width = sourceWidth;
-      let height = sourceHeight;
-      if (width > maxSize || height > maxSize) {
-        if (width > height) {
-          height = Math.round(height / width * maxSize);
-          width = maxSize;
-        } else {
-          width = Math.round(width / height * maxSize);
-          height = maxSize;
+  async function processImageFile(file: File): Promise<XiaohongshuDraftImage | null> {
+    return new Promise((resolve) => {
+      const image = new Image();
+      const objectUrl = URL.createObjectURL(file);
+      image.onload = () => {
+        const canvas = document.createElement("canvas");
+        const maxSize = 960;
+        const sourceWidth = image.width;
+        let sourceHeight = image.height;
+        const sourceX = 0;
+        let sourceY = 0;
+        if (sourceHeight / sourceWidth > XHS_MAX_IMAGE_HEIGHT_RATIO) {
+          sourceHeight = Math.round(sourceWidth * XHS_MAX_IMAGE_HEIGHT_RATIO);
+          sourceY = Math.round((image.height - sourceHeight) / 2);
         }
-      }
-      canvas.width = width;
-      canvas.height = height;
-      const context = canvas.getContext("2d");
-      if (!context) {
+        let width = sourceWidth;
+        let height = sourceHeight;
+        if (width > maxSize || height > maxSize) {
+          if (width > height) {
+            height = Math.round(height / width * maxSize);
+            width = maxSize;
+          } else {
+            width = Math.round(width / height * maxSize);
+            height = maxSize;
+          }
+        }
+        canvas.width = width;
+        canvas.height = height;
+        const context = canvas.getContext("2d");
+        if (!context) {
+          URL.revokeObjectURL(objectUrl);
+          resolve(null);
+          return;
+        }
+        context.drawImage(image, sourceX, sourceY, sourceWidth, sourceHeight, 0, 0, width, height);
+        canvas.toBlob((blob) => {
+          URL.revokeObjectURL(objectUrl);
+          if (!blob) {
+            resolve(null);
+            return;
+          }
+          saveChatImageToIndexedDB(blob).then((assetId) => {
+            const preview = URL.createObjectURL(blob);
+            setImageMap(prev => ({ ...prev, [assetId]: preview }));
+            resolve({ assetId, dataUrl: preview, width: canvas.width, height: canvas.height });
+          }).catch(() => resolve(null));
+        }, "image/jpeg", 0.82);
+      };
+      image.onerror = () => {
         URL.revokeObjectURL(objectUrl);
-        return;
-      }
-      context.drawImage(image, sourceX, sourceY, sourceWidth, sourceHeight, 0, 0, width, height);
-      canvas.toBlob((blob) => {
-        URL.revokeObjectURL(objectUrl);
-        if (!blob) return;
-        saveChatImageToIndexedDB(blob).then((assetId) => {
-          const preview = URL.createObjectURL(blob);
-          setDraft(prev => ({ ...prev, image: { assetId, dataUrl: preview, width: canvas.width, height: canvas.height } }));
-          setImageMap(prev => ({ ...prev, [assetId]: preview }));
-        });
-      }, "image/jpeg", 0.82);
-    };
-    image.src = objectUrl;
+        resolve(null);
+      };
+      image.src = objectUrl;
+    });
+  }
+
+  async function handleImageChange(event: ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(event.target.files || []);
     event.target.value = "";
+    if (files.length === 0) return;
+    const results = (await Promise.all(files.map(processImageFile))).filter((img): img is XiaohongshuDraftImage => Boolean(img));
+    if (results.length === 0) return;
+    setDraft((prev) => {
+      const existing = prev.images || (prev.image?.dataUrl ? [prev.image] : []);
+      const nextImages = [...existing, ...results];
+      return {
+        ...prev,
+        image: nextImages[0] || {},
+        images: nextImages,
+      };
+    });
   }
 
   async function handleProfileCoverChange(event: ChangeEvent<HTMLInputElement>) {
@@ -2696,6 +2779,7 @@ export function XiaohongshuApp({ onClose, onNotice, visible = true, onIdle, onBu
                   note={selectedNote}
                   imageMap={imageMap}
                   collapseBilingualTranslation={state.settings.collapseBilingualTranslation}
+                  isDetail={true}
                 />
               </div>
               <div className="cp-xhs-note-detail-card">
@@ -3019,31 +3103,61 @@ export function XiaohongshuApp({ onClose, onNotice, visible = true, onIdle, onBu
             </header>
             <div className="xhs-publish-content">
               <div className="xhs-publish-left">
-                {draft.image?.dataUrl === undefined && draft.image?.description === undefined ? (
+                {((draft.images && draft.images.length > 0) || draft.image?.dataUrl) ? (
+                  <div className="xhs-publish-multi-images">
+                    <div className="xhs-publish-images-grid">
+                      {(draft.images || [draft.image!]).map((img, idx) => (
+                        <div key={img.assetId || idx} className="xhs-publish-grid-item">
+                          <img src={img.dataUrl} alt={`Preview ${idx + 1}`} />
+                          <button
+                            type="button"
+                            className="xhs-publish-img-remove"
+                            onClick={() => {
+                              setDraft((prev) => {
+                                const list = (prev.images || [prev.image!]).filter((_, i) => i !== idx);
+                                return {
+                                  ...prev,
+                                  image: list[0] || {},
+                                  images: list.length > 0 ? list : undefined,
+                                };
+                              });
+                            }}
+                            aria-label="删除图片"
+                          >
+                            ×
+                          </button>
+                        </div>
+                      ))}
+                      <button
+                        type="button"
+                        className="xhs-publish-grid-add"
+                        onClick={() => fileRef.current?.click()}
+                        aria-label="继续添加图片"
+                      >
+                        <Plus size={24} />
+                        <span>添加</span>
+                      </button>
+                    </div>
+                    <input ref={fileRef} type="file" accept="image/*" multiple hidden onChange={handleImageChange} />
+                    <button
+                      type="button"
+                      className="xhs-upload-change-btn"
+                      onClick={() => setDraft(prev => ({ ...prev, image: {}, images: undefined }))}
+                    >
+                      清空所有图片
+                    </button>
+                  </div>
+                ) : draft.image?.description === undefined ? (
                   <div className="xhs-image-upload-area">
                     <div className="xhs-publish-placeholder">
                       <ImagePlus size={42} strokeWidth={1.5} color="#bbb" />
                       <div className="xhs-placeholder-actions">
-                        <button type="button" onClick={() => fileRef.current?.click()}>上传图片</button>
+                        <button type="button" onClick={() => fileRef.current?.click()}>上传图片 (支持多张)</button>
                         <button type="button" onClick={() => setDraft(prev => ({ ...prev, image: { ...prev.image, description: "" } }))}>描述图片</button>
                       </div>
                     </div>
-                    <input ref={fileRef} type="file" accept="image/*" hidden onChange={handleImageChange} />
+                    <input ref={fileRef} type="file" accept="image/*" multiple hidden onChange={handleImageChange} />
                   </div>
-                ) : draft.image?.dataUrl ? (
-                  <>
-                    <div
-                      className="xhs-image-upload-area is-image-preview"
-                      style={getImageFrameStyle(draft.image.width, draft.image.height)}
-                      onClick={() => fileRef.current?.click()}
-                    >
-                      <img src={draft.image.dataUrl} alt="Preview" className="xhs-publish-preview-img" />
-                      <input ref={fileRef} type="file" accept="image/*" hidden onChange={handleImageChange} />
-                    </div>
-                    <button type="button" className="xhs-upload-change-btn" onClick={() => setDraft(prev => ({ ...prev, image: {} }))}>
-                      取消并重新选择
-                    </button>
-                  </>
                 ) : (
                   <>
                     <div className="xhs-image-upload-area is-text-mode">

--- a/lib/xiaohongshu-storage.ts
+++ b/lib/xiaohongshu-storage.ts
@@ -278,6 +278,9 @@ export function normalizeXiaohongshuNote(raw: unknown): XiaohongshuNote | null {
     recentSaveNames: normalizeNameList(record.recentSaveNames ?? record.recent_save_names),
     comments,
     imageAssetId: cleanText(record.imageAssetId ?? record.image_asset_id, 160) || undefined,
+    imageAssetIds: Array.isArray(record.imageAssetIds ?? record.image_asset_ids)
+      ? (record.imageAssetIds ?? record.image_asset_ids as unknown[]).map(id => cleanText(id, 160)).filter(Boolean)
+      : undefined,
     imageDescription: cleanMultiline(record.imageDescription ?? record.image_description, 500) || undefined,
     imageWidth: optionalPositiveNumber(record.imageWidth ?? record.image_width),
     imageHeight: optionalPositiveNumber(record.imageHeight ?? record.image_height),
@@ -381,6 +384,10 @@ export function saveXiaohongshuState(state: XiaohongshuState): XiaohongshuState 
 
 export function createUserXiaohongshuNote(input: XiaohongshuUserPostInput, profile: XiaohongshuUserProfile): XiaohongshuNote {
   const now = new Date().toISOString();
+  const imageAssetIds = (input.images && input.images.length > 0)
+    ? input.images.map(img => img.assetId).filter((id): id is string => Boolean(id))
+    : (input.image?.assetId ? [input.image.assetId] : undefined);
+  const primaryImage = input.images?.[0] || input.image;
   return {
     id: makeId("xhs_user_note"),
     type: "post",
@@ -389,7 +396,7 @@ export function createUserXiaohongshuNote(input: XiaohongshuUserPostInput, profi
     authorName: profile.nickname || "我",
     title: cleanText(input.title, 80) || cleanMultiline(input.body, 120).slice(0, 24) || "新的笔记",
     body: cleanMultiline(input.body, 3000),
-    coverIcon: input.image?.assetId ? "▧" : "✎",
+    coverIcon: (imageAssetIds && imageAssetIds.length > 0) || input.image?.assetId ? "▧" : "✎",
     tone: "ivory",
     tags: normalizeTags(input.tags),
     likeCount: 0,
@@ -400,10 +407,11 @@ export function createUserXiaohongshuNote(input: XiaohongshuUserPostInput, profi
     recentLikeNames: [],
     recentSaveNames: [],
     comments: [],
-    imageAssetId: input.image?.assetId,
-    imageDescription: cleanMultiline(input.image?.description, 500) || undefined,
-    imageWidth: optionalPositiveNumber(input.image?.width),
-    imageHeight: optionalPositiveNumber(input.image?.height),
+    imageAssetId: primaryImage?.assetId,
+    imageAssetIds: imageAssetIds && imageAssetIds.length > 0 ? imageAssetIds : undefined,
+    imageDescription: cleanMultiline(primaryImage?.description, 500) || undefined,
+    imageWidth: optionalPositiveNumber(primaryImage?.width),
+    imageHeight: optionalPositiveNumber(primaryImage?.height),
     createdAt: now,
     updatedAt: now,
   };

--- a/lib/xiaohongshu-types.ts
+++ b/lib/xiaohongshu-types.ts
@@ -45,6 +45,7 @@ export type XiaohongshuNote = {
   recentSaveNames: string[];
   comments: XiaohongshuComment[];
   imageAssetId?: string;
+  imageAssetIds?: string[];
   imageDescription?: string;
   imageWidth?: number;
   imageHeight?: number;
@@ -110,6 +111,7 @@ export type XiaohongshuUserPostInput = {
   body: string;
   tags: string[];
   image?: XiaohongshuDraftImage;
+  images?: XiaohongshuDraftImage[];
 };
 
 export type XiaohongshuUserInteractions = {

--- a/styles/xiaohongshu.css
+++ b/styles/xiaohongshu.css
@@ -1,3 +1,163 @@
+/* ===== Xiaohongshu Multi-Image & Slider Styles ===== */
+.xhs-publish-multi-images {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.xhs-publish-images-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  width: 100%;
+}
+
+.xhs-publish-grid-item {
+  position: relative;
+  aspect-ratio: 1 / 1;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #f0f0f0;
+}
+
+.xhs-publish-grid-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.xhs-publish-img-remove {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.xhs-publish-grid-add {
+  aspect-ratio: 1 / 1;
+  border-radius: 8px;
+  border: 1.5px dashed #ccc;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  color: #888;
+  font-size: calc(12px * var(--app-text-scale, 1));
+  cursor: pointer;
+}
+
+.xhs-publish-grid-add:active {
+  background: #f0f0f0;
+}
+
+.xhs-waterfall-multi-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(4px);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.xhs-note-slider-container {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  background: #000;
+}
+
+.xhs-note-slider-track {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.xhs-note-slider-track::-webkit-scrollbar {
+  display: none;
+}
+
+.xhs-note-slider-item {
+  flex: 0 0 100%;
+  width: 100%;
+  height: 100%;
+  scroll-snap-align: start;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.xhs-note-slider-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: #000;
+}
+
+.xhs-note-slider-indicator {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
+  color: #ffffff;
+  font-size: calc(12px * var(--app-text-scale, 1));
+  font-weight: 550;
+  letter-spacing: 0.5px;
+  pointer-events: none;
+}
+
+.xhs-note-slider-dots {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  gap: 5px;
+  pointer-events: none;
+}
+
+.xhs-slider-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.45);
+  transition: all 200ms ease;
+}
+
+.xhs-slider-dot.is-active {
+  width: 14px;
+  border-radius: 3px;
+  background: #ffffff;
+}
+
 .xhs-app {
   position: relative;
   width: 100%;


### PR DESCRIPTION
贡献者：Narcissuscycle（@Narcissuscycle）

为小红书应用新增多图支持：
1. 发帖面板支持一次选择多张图片并支持九宫格预览与单张删除；
2. 帖子详情页图片区域支持多图左右滑动轮播浏览（带指示器与指示圆点）；
3. 列表瀑布流卡片支持多图角标标识并向下兼容旧帖子。

---
_经小手机「共同建设」通道提交_