### PR TITLE
提示词查看器+快捷操作悬浮球贴边隐藏功能

### DIFF
--- a/components/debug-prompt-panel.tsx
+++ b/components/debug-prompt-panel.tsx
@@ -1,10 +1,18 @@
 "use client";
 
-import { useState, useEffect, useRef, useSyncExternalStore, useMemo, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent } from "react";
+import { useState, useEffect, useRef, useSyncExternalStore, useMemo, useCallback, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type CSSProperties } from "react";
 import { getDebugChatState, getDebugPromptSnapshot, subscribeDebugChatState, subscribeDebugPromptSnapshot, type DebugPromptSnapshot } from "@/lib/debug-store";
 import { previewPromptRequestSnapshot, ChatEngineError } from "@/lib/chat-engine";
 import { previewGroupPromptRequestSnapshot } from "@/lib/group-chat-engine";
 import { FileText, X } from "lucide-react";
+import {
+    getFloatingDockState,
+    subscribeFloatingDockState,
+    expandFloatingDock,
+    collapseFloatingDock,
+    setFloatingDockAnchor,
+    setActiveFloatingTool,
+} from "@/lib/floating-dock-store";
 import {
     previewMomentsPostPrompt,
     previewMomentsCommentPrompt,
@@ -102,6 +110,9 @@ export function DebugPromptPanel() {
     const [mode, setMode] = useState<DebugMode>("chat");
     const [floatingPosition, setFloatingPosition] = useState<FloatingPosition | null>(null);
     const [draggingFloatingButton, setDraggingFloatingButton] = useState(false);
+    const [floatingDockEnabled, setFloatingDockEnabled] = useState(false);
+    const [quickActionEnabled, setQuickActionEnabled] = useState(false);
+    const dockState = useSyncExternalStore(subscribeFloatingDockState, getFloatingDockState, getFloatingDockState);
     const floatingDragRef = useRef<FloatingDragState | null>(null);
     const suppressFloatingClickRef = useRef(false);
     const [selectedChatSessionId, setSelectedChatSessionId] = useState("");
@@ -233,19 +244,43 @@ export function DebugPromptPanel() {
         if (nextSessionId !== selectedChatSessionId) setSelectedChatSessionId(nextSessionId);
     }, [chatSessionOptions, chatState?.session?.id, selectedChatSessionId]);
 
+    const handleClosePanel = useCallback(() => {
+        setCollapsed(true);
+        if (floatingDockEnabled) {
+            collapseFloatingDock();
+        }
+    }, [floatingDockEnabled]);
+
     useEffect(() => {
         const syncEnabled = (event?: Event) => {
             const detail = (event as CustomEvent | undefined)?.detail;
+            const settings = loadChatAppSettings();
             const nextEnabled = typeof detail?.promptViewerEnabled === "boolean"
                 ? detail.promptViewerEnabled
-                : loadChatAppSettings().promptViewerEnabled === true;
+                : settings.promptViewerEnabled === true;
             setEnabled(nextEnabled);
+            setQuickActionEnabled(typeof detail?.quickActionEnabled === "boolean" ? detail.quickActionEnabled : settings.quickActionEnabled === true);
+            setFloatingDockEnabled(typeof detail?.floatingDockEnabled === "boolean" ? detail.floatingDockEnabled : settings.floatingDockEnabled === true);
             if (!nextEnabled) setCollapsed(true);
         };
         syncEnabled();
         window.addEventListener(CHAT_APP_SETTINGS_UPDATED_EVENT, syncEnabled);
         return () => window.removeEventListener(CHAT_APP_SETTINGS_UPDATED_EVENT, syncEnabled);
     }, []);
+
+    useEffect(() => {
+        if (collapsed) return;
+        const handlePointerDown = (event: PointerEvent) => {
+            const panel = document.querySelector(".pv-panel");
+            const floatBtn = (event.target as HTMLElement | null)?.closest(".prompt-viewer-float-button");
+            if (floatBtn) return;
+            if (panel && !panel.contains(event.target as Node)) {
+                handleClosePanel();
+            }
+        };
+        document.addEventListener("pointerdown", handlePointerDown);
+        return () => document.removeEventListener("pointerdown", handlePointerDown);
+    }, [collapsed, handleClosePanel]);
 
     useEffect(() => {
         if (mode !== "chat" || !activeChatSnapshot) return;
@@ -567,7 +602,7 @@ export function DebugPromptPanel() {
         return Math.min(Math.max(value, 12), max);
     }
 
-    function getFloatingButtonBounds(button: HTMLButtonElement) {
+    function getFloatingButtonBounds(button: HTMLButtonElement, currentPos: FloatingPosition | null) {
         const parent = button.offsetParent instanceof HTMLElement ? button.offsetParent : null;
         const parentRect = parent?.getBoundingClientRect() ?? {
             left: 0,
@@ -575,19 +610,30 @@ export function DebugPromptPanel() {
             width: window.innerWidth,
             height: window.innerHeight,
         };
-        const rect = button.getBoundingClientRect();
+        // 始终使用未变换的纯净布局坐标：优先使用 state 中的位置，若初始未拖拽则取 offsetLeft / offsetTop（不受 CSS transform 影响）
+        const left = currentPos ? currentPos.left : button.offsetLeft;
+        const top = currentPos ? currentPos.top : button.offsetTop;
         return {
-            left: rect.left - parentRect.left,
-            top: rect.top - parentRect.top,
-            maxLeft: Math.max(12, parentRect.width - rect.width - 12),
-            maxTop: Math.max(12, parentRect.height - rect.height - 12),
+            left,
+            top,
+            maxLeft: Math.max(12, parentRect.width - 56 - 12),
+            maxTop: Math.max(12, parentRect.height - 56 - 12),
+            parentWidth: parentRect.width,
+            parentHeight: parentRect.height,
         };
     }
 
     function handleFloatingPointerDown(event: ReactPointerEvent<HTMLButtonElement>) {
+        const isDual = floatingDockEnabled && quickActionEnabled && enabled;
+        const isPromptPrimary = !isDual || dockState.primaryTool === "prompt-viewer";
+        if (dockState.isExpanded || (isDual && !isPromptPrimary)) {
+            // 双球模式下且并非当前停靠主球，或处于展开挑选态时，不接受拖拽
+            return;
+        }
         event.stopPropagation();
         const button = event.currentTarget;
-        const bounds = getFloatingButtonBounds(button);
+        const anchor = isDual ? dockState.anchorPosition : null;
+        const bounds = getFloatingButtonBounds(button, (isDual && anchor) ? anchor : floatingPosition);
         floatingDragRef.current = {
             pointerId: event.pointerId,
             startClientX: event.clientX,
@@ -598,7 +644,7 @@ export function DebugPromptPanel() {
             maxTop: bounds.maxTop,
             moved: false,
         };
-        setDraggingFloatingButton(true);
+        // 不在 pointerDown 立即 setDraggingFloatingButton(true)，避免普通点击时瞬间取消 is-docked 产生动画抖动
         button.setPointerCapture(event.pointerId);
     }
 
@@ -608,8 +654,14 @@ export function DebugPromptPanel() {
         event.stopPropagation();
         const deltaX = event.clientX - drag.startClientX;
         const deltaY = event.clientY - drag.startClientY;
-        if (Math.abs(deltaX) > 3 || Math.abs(deltaY) > 3) {
-            drag.moved = true;
+        if (!drag.moved) {
+            // 超过 3px 移动阈值才判定为拖拽，杜绝手指/鼠标微小震颤把贴边位移写入 floatingPosition
+            if (Math.abs(deltaX) > 3 || Math.abs(deltaY) > 3) {
+                drag.moved = true;
+                setDraggingFloatingButton(true);
+            } else {
+                return;
+            }
         }
         setFloatingPosition({
             left: clampFloatingPosition(drag.left + deltaX, drag.maxLeft),
@@ -621,7 +673,25 @@ export function DebugPromptPanel() {
         const drag = floatingDragRef.current;
         if (!drag || drag.pointerId !== event.pointerId) return;
         event.stopPropagation();
-        if (drag.moved) suppressFloatingClickRef.current = true;
+        if (drag.moved) {
+            suppressFloatingClickRef.current = true;
+            if (floatingDockEnabled) {
+                const bounds = getFloatingButtonBounds(event.currentTarget, floatingPosition);
+                const midX = bounds.parentWidth / 2;
+                const currentX = drag.left + (event.clientX - drag.startClientX);
+                const currentTop = drag.top + (event.clientY - drag.startClientY);
+                const isLeft = currentX < midX;
+                const snappedLeft = isLeft ? 18 : Math.max(18, bounds.parentWidth - 56 - 18);
+                const snappedTop = clampFloatingPosition(currentTop, bounds.maxTop);
+                const newPos = { left: snappedLeft, top: snappedTop };
+                setFloatingPosition(newPos);
+                setFloatingDockAnchor({ ...newPos, dockSide: isLeft ? "left" : "right" });
+                if (collapsed) {
+                    collapseFloatingDock();
+                }
+            }
+        }
+
         floatingDragRef.current = null;
         setDraggingFloatingButton(false);
         if (event.currentTarget.hasPointerCapture(event.pointerId)) {
@@ -634,6 +704,20 @@ export function DebugPromptPanel() {
         if (suppressFloatingClickRef.current) {
             suppressFloatingClickRef.current = false;
             return;
+        }
+        if (!collapsed) {
+            handleClosePanel();
+            return;
+        }
+        if (floatingDockEnabled) {
+            const isDual = quickActionEnabled && enabled;
+            const isPromptPrimary = !isDual || dockState.primaryTool === "prompt-viewer";
+            // Dual-ball mode: if currently docked as primary and not expanded, clicking expands both balls!
+            if (isDual && isPromptPrimary && dockState.isDocked && !dockState.isExpanded) {
+                expandFloatingDock();
+                return;
+            }
+            setActiveFloatingTool("prompt-viewer");
         }
         setCollapsed(false);
     }
@@ -756,24 +840,66 @@ export function DebugPromptPanel() {
 
     if (!enabled) return null;
 
+    const isPanelOpen = !collapsed;
+    const showFloatingButton = collapsed || floatingDockEnabled;
+    const isDual = floatingDockEnabled && quickActionEnabled && enabled;
+    const isPromptPrimary = !isDual || dockState.primaryTool === "prompt-viewer";
+
+    const isHiddenBehind = isDual && !isPromptPrimary && !isPanelOpen && !dockState.isExpanded;
+    const isDocked = floatingDockEnabled && !isPanelOpen && (
+        isPromptPrimary
+            ? (dockState.isDocked && !draggingFloatingButton)
+            : false
+    );
+    const isExpanded = floatingDockEnabled && !isPanelOpen && dockState.isExpanded;
+    const isPaired = isDual && !isPromptPrimary && !isPanelOpen && dockState.isExpanded;
+    const anchor = isDual ? dockState.anchorPosition : null;
+    const dockSide = dockState.dockSide;
+
+    const buttonClass = [
+        "prompt-viewer-float-button",
+        isHiddenBehind ? "is-hidden-behind" : "",
+        isDocked ? "is-docked" : "",
+        isPanelOpen ? "is-open" : "",
+        isExpanded ? "is-expanded" : "",
+        isPaired ? "is-paired" : "",
+    ].filter(Boolean).join(" ");
+
+    let buttonStyle: CSSProperties | undefined;
+    if (draggingFloatingButton && floatingPosition) {
+        buttonStyle = { left: floatingPosition.left, top: floatingPosition.top };
+    } else if (isDual && anchor) {
+        buttonStyle = { left: anchor.left, top: anchor.top };
+    } else if (floatingPosition) {
+        buttonStyle = { left: floatingPosition.left, top: floatingPosition.top };
+    } else if (isDual) {
+        buttonStyle = { bottom: 148, right: 18 };
+    }
+    if (isPanelOpen) {
+        buttonStyle = { ...buttonStyle, zIndex: 100001 };
+    }
+
+    const floatingButton = showFloatingButton ? (
+        <button
+            type="button"
+            className={buttonClass}
+            aria-label={isPanelOpen ? "关闭提示词查看器" : "打开提示词查看器"}
+            data-positioned={(isDual ? !!anchor : !!floatingPosition) ? "" : undefined}
+            data-dragging={draggingFloatingButton ? "" : undefined}
+            data-dock-side={floatingDockEnabled ? dockSide : undefined}
+            onPointerDown={handleFloatingPointerDown}
+            onPointerMove={handleFloatingPointerMove}
+            onPointerUp={handleFloatingPointerEnd}
+            onPointerCancel={handleFloatingPointerEnd}
+            onClick={handleFloatingButtonClick}
+            style={buttonStyle}
+        >
+            <FileText size={24} strokeWidth={1.9} />
+        </button>
+    ) : null;
+
     if (collapsed) {
-        return (
-            <button
-                type="button"
-                className="prompt-viewer-float-button"
-                aria-label="打开提示词查看器"
-                data-positioned={floatingPosition ? "" : undefined}
-                data-dragging={draggingFloatingButton ? "" : undefined}
-                onPointerDown={handleFloatingPointerDown}
-                onPointerMove={handleFloatingPointerMove}
-                onPointerUp={handleFloatingPointerEnd}
-                onPointerCancel={handleFloatingPointerEnd}
-                onClick={handleFloatingButtonClick}
-                style={floatingPosition ? { left: floatingPosition.left, top: floatingPosition.top } : undefined}
-            >
-                <FileText size={24} strokeWidth={1.9} />
-            </button>
-        );
+        return floatingButton;
     }
 
     const renderCharSelect = (value: string, onChange: (v: string) => void) => (
@@ -917,13 +1043,15 @@ export function DebugPromptPanel() {
     );
 
     return (
-        <div className="pv-panel" onPointerDown={e => e.stopPropagation()}>
+        <>
+            {floatingButton}
+            <div className="pv-panel" onPointerDown={e => e.stopPropagation()}>
             {/* Header */}
             <div className="pv-header">
                 <span className="pv-header-title">提示词查看器</span>
                 {resultMeta && <span className="pv-header-meta">{resultMeta.characterName}</span>}
                 <span style={{ flex: 1 }} />
-                <button type="button" className="pv-close-btn" aria-label="关闭" onClick={(e) => { e.stopPropagation(); setCollapsed(true); }}>
+                <button type="button" className="pv-close-btn" aria-label="关闭" onClick={(e) => { e.stopPropagation(); handleClosePanel(); }}>
                     <X size={18} strokeWidth={2} />
                 </button>
             </div>
@@ -1092,5 +1220,6 @@ export function DebugPromptPanel() {
                 </>
             )}
         </div>
+        </>
     );
 }

--- a/components/phone-settings-app.tsx
+++ b/components/phone-settings-app.tsx
@@ -112,6 +112,8 @@ export function PhoneSettingsApp({ onClose, onNotice }: SettingsPageProps) {
     const [timeAware, setTimeAware] = useState(true);
     const [promptViewerEnabled, setPromptViewerEnabled] = useState(false);
     const [quickActionEnabled, setQuickActionEnabled] = useState(false);
+    const [floatingDockEnabled, setFloatingDockEnabled] = useState(false);
+    const [floatingDockSheetOpen, setFloatingDockSheetOpen] = useState(false);
     const [keepAlive, setKeepAlive] = useState(false);
     // 角色电脑：施工中弹窗（返回 / 仍要看看）
     const pageBodyRef = useRef<HTMLDivElement | null>(null);
@@ -237,6 +239,12 @@ export function PhoneSettingsApp({ onClose, onNotice }: SettingsPageProps) {
         onNotice(next ? "已开启快捷操作" : "已关闭快捷操作");
     }, [onNotice]);
 
+    const handleFloatingDockChange = useCallback((next: boolean) => {
+        setFloatingDockEnabled(next);
+        saveChatAppSettings({ ...loadChatAppSettings(), floatingDockEnabled: next });
+        onNotice(next ? "已开启悬浮球贴边收拢" : "已关闭悬浮球贴边收拢");
+    }, [onNotice]);
+
     const handleKeepAliveChange = useCallback((next: boolean) => {
         setKeepAlive(next);
         saveKeepAlive(next);
@@ -345,6 +353,7 @@ export function PhoneSettingsApp({ onClose, onNotice }: SettingsPageProps) {
         setTimeAware(settings.timeAware !== false);
         setPromptViewerEnabled(settings.promptViewerEnabled === true);
         setQuickActionEnabled(settings.quickActionEnabled === true);
+        setFloatingDockEnabled(settings.floatingDockEnabled === true);
         setKeepAlive(loadKeepAlive());
     }, []);
 
@@ -458,7 +467,24 @@ export function PhoneSettingsApp({ onClose, onNotice }: SettingsPageProps) {
                             </div>
                         ) : null}
                         <div className="settings-tools-section">
-                            <h3 className="settings-menu-section-title">Tools</h3>
+                            <div className="settings-tools-header">
+                                <div className="settings-tools-title-wrap">
+                                    <h3 className="settings-menu-section-title">Tools</h3>
+                                    <button
+                                        type="button"
+                                        className="settings-tools-info-btn"
+                                        onClick={() => setFloatingDockSheetOpen(true)}
+                                        aria-label="悬浮球偏好设置"
+                                        title="悬浮球偏好设置"
+                                    >
+                                        <span className="settings-tools-info-circle">
+                                            <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                                <path d="M15.32 18.27L15.10 19.19Q14.09 19.58 13.49 19.79Q12.89 20 12.10 20Q10.88 20 10.21 19.41Q9.53 18.81 9.53 17.90Q9.53 17.54 9.58 17.17Q9.63 16.80 9.74 16.33L10.58 13.37Q10.69 12.94 10.77 12.56Q10.84 12.18 10.84 11.86Q10.84 11.29 10.61 11.07Q10.37 10.85 9.71 10.85Q9.39 10.85 9.05 10.95Q8.71 11.05 8.46 11.14L8.69 10.23Q9.51 9.89 10.26 9.65Q11.01 9.41 11.69 9.41Q12.89 9.41 13.55 10Q14.20 10.58 14.20 11.52Q14.20 11.71 14.16 12.20Q14.11 12.69 13.99 13.09L13.16 16.05Q13.06 16.40 12.98 16.86Q12.89 17.32 12.89 17.55Q12.89 18.14 13.16 18.35Q13.42 18.57 14.07 18.57Q14.38 18.57 14.76 18.46Q15.15 18.35 15.32 18.27M15.54 5.87Q15.54 6.64 14.95 7.18Q14.37 7.73 13.54 7.73Q12.72 7.73 12.13 7.18Q11.54 6.64 11.54 5.87Q11.54 5.10 12.13 4.55Q12.72 4 13.54 4Q14.37 4 14.95 4.55Q15.54 5.10 15.54 5.87" />
+                                            </svg>
+                                        </span>
+                                    </button>
+                                </div>
+                            </div>
                             <div className="menu-group settings-tools-menu">
                                 <div className="menu-item settings-tools-menu-item">
                                     <span className="card-icon card-icon-glass">
@@ -491,6 +517,32 @@ export function PhoneSettingsApp({ onClose, onNotice }: SettingsPageProps) {
                             labelClassName="settings-menu-section-title"
                             items={SETTINGS_MENU.filter(item => ["identity", "about"].includes(item.id)).map(makeCardItem)}
                         />
+                        {floatingDockSheetOpen && (
+                            <div className="modal-overlay modal-overlay-bottom" data-ui="modal" onClick={() => setFloatingDockSheetOpen(false)}>
+                                <div className="modal-sheet" data-ui="modal-sheet" onClick={event => event.stopPropagation()}>
+                                    <div className="modal-header" data-ui="modal-header">
+                                        <span style={{ width: 44 }} />
+                                        <h3 className="modal-title">悬浮球设置</h3>
+                                        <button className="modal-header-btn modal-header-btn-muted" onClick={() => setFloatingDockSheetOpen(false)} aria-label="关闭"><X size={18} /></button>
+                                    </div>
+                                    <div className="modal-body modal-body-tight" data-ui="modal-body">
+                                        <div className="menu-group">
+                                            <div className="menu-item settings-tools-menu-item">
+                                                <span className="card-icon card-icon-glass">
+                                                    <SlidersHorizontal size={20} strokeWidth={1.8} />
+                                                </span>
+                                                <span className="settings-tools-menu-copy">
+                                                    <span className="menu-label appearance-menu-item-label">贴边半透明收拢模式</span>
+                                                </span>
+                                                <span className="menu-right settings-tools-menu-toggle">
+                                                    <Toggle checked={floatingDockEnabled} onChange={handleFloatingDockChange} className="settings-toggle-control" />
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
                         {accountSheetOpen && (
                             <div className="modal-overlay modal-overlay-bottom" data-ui="modal" onClick={() => setAccountSheetOpen(false)}>
                                 <div className="modal-sheet" data-ui="modal-sheet" onClick={event => event.stopPropagation()}>

--- a/components/quick-action-float.tsx
+++ b/components/quick-action-float.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type CSSProperties } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type CSSProperties } from "react";
 import { BookOpen, Check, ChevronDown, Code2, SlidersHorizontal, UserRound, X } from "lucide-react";
 import { CHAT_APP_SETTINGS_UPDATED_EVENT, loadChatAppSettings } from "@/lib/chat-storage";
+import {
+    getFloatingDockState,
+    subscribeFloatingDockState,
+    expandFloatingDock,
+    collapseFloatingDock,
+    setFloatingDockAnchor,
+    setActiveFloatingTool,
+} from "@/lib/floating-dock-store";
 import {
     getCharacterBinding,
     loadApiConfigs,
@@ -58,10 +66,20 @@ export function QuickActionFloat() {
     const [floatingPosition, setFloatingPosition] = useState<FloatingPosition | null>(null);
     const [popoverPosition, setPopoverPosition] = useState<PopoverPosition | null>(null);
     const [draggingFloatingButton, setDraggingFloatingButton] = useState(false);
+    const [floatingDockEnabled, setFloatingDockEnabled] = useState(false);
+    const [promptViewerEnabled, setPromptViewerEnabled] = useState(false);
+    const dockState = useSyncExternalStore(subscribeFloatingDockState, getFloatingDockState, getFloatingDockState);
     const layerRef = useRef<HTMLDivElement | null>(null);
     const floatingButtonRef = useRef<HTMLButtonElement | null>(null);
     const floatingDragRef = useRef<FloatingDragState | null>(null);
     const suppressFloatingClickRef = useRef(false);
+
+    const handleClose = useCallback(() => {
+        setOpen(false);
+        if (floatingDockEnabled) {
+            collapseFloatingDock();
+        }
+    }, [floatingDockEnabled]);
 
     const reloadData = useCallback(() => {
         const nextCharacters = loadCharacters();
@@ -78,10 +96,13 @@ export function QuickActionFloat() {
     useEffect(() => {
         const syncEnabled = (event?: Event) => {
             const detail = (event as CustomEvent | undefined)?.detail;
+            const settings = loadChatAppSettings();
             const nextEnabled = typeof detail?.quickActionEnabled === "boolean"
                 ? detail.quickActionEnabled
-                : loadChatAppSettings().quickActionEnabled === true;
+                : settings.quickActionEnabled === true;
             setEnabled(nextEnabled);
+            setPromptViewerEnabled(typeof detail?.promptViewerEnabled === "boolean" ? detail.promptViewerEnabled : settings.promptViewerEnabled === true);
+            setFloatingDockEnabled(typeof detail?.floatingDockEnabled === "boolean" ? detail.floatingDockEnabled : settings.floatingDockEnabled === true);
             if (!nextEnabled) setOpen(false);
         };
         syncEnabled();
@@ -105,11 +126,30 @@ export function QuickActionFloat() {
     useEffect(() => {
         if (!open) return;
         const handlePointerDown = (event: PointerEvent) => {
-            if (!layerRef.current?.contains(event.target as Node)) setOpen(false);
+            if (!layerRef.current?.contains(event.target as Node)) {
+                handleClose();
+            }
         };
         document.addEventListener("pointerdown", handlePointerDown);
         return () => document.removeEventListener("pointerdown", handlePointerDown);
-    }, [open]);
+    }, [open, handleClose]);
+
+    useEffect(() => {
+        if (!floatingDockEnabled || !dockState.isExpanded || open) return;
+        const handleOutside = (e: PointerEvent) => {
+            const target = e.target as HTMLElement | null;
+            if (!target?.closest(".prompt-viewer-float-button")) {
+                collapseFloatingDock();
+            }
+        };
+        const timer = setTimeout(() => {
+            document.addEventListener("pointerdown", handleOutside);
+        }, 60);
+        return () => {
+            clearTimeout(timer);
+            document.removeEventListener("pointerdown", handleOutside);
+        };
+    }, [floatingDockEnabled, dockState.isExpanded, open]);
 
     useLayoutEffect(() => {
         const layer = layerRef.current;
@@ -120,21 +160,25 @@ export function QuickActionFloat() {
         }
         const rect = layer.getBoundingClientRect();
         const buttonRect = button.getBoundingClientRect();
-        const anchor = floatingPosition ?? {
-            left: buttonRect.left - rect.left,
-            top: buttonRect.top - rect.top,
-        };
+        const posAnchor = (draggingFloatingButton && floatingPosition)
+            ? floatingPosition
+            : (dockState.anchorPosition)
+                ? dockState.anchorPosition
+                : (floatingPosition ?? {
+                    left: buttonRect.left - rect.left,
+                    top: buttonRect.top - rect.top,
+                });
         const width = Math.min(344, rect.width - 32);
         const statusSafeTop = getStatusSafeTop(layer);
         const estimatedHeight = Math.min(520, Math.max(240, rect.height - statusSafeTop - 12));
-        const left = anchor.left - width - 8;
-        const top = anchor.top - estimatedHeight - 8;
+        const left = posAnchor.left - width - 8;
+        const top = posAnchor.top - estimatedHeight - 8;
         const maxTop = Math.max(statusSafeTop, rect.height - estimatedHeight - 12);
         setPopoverPosition({
             left: Math.min(Math.max(12, left), Math.max(12, rect.width - width - 12)),
             top: Math.min(Math.max(statusSafeTop, top), maxTop),
         });
-    }, [open, floatingPosition]);
+    }, [open, floatingPosition, dockState.anchorPosition, draggingFloatingButton]);
 
     const currentSlot: BindingSlot = useMemo(() => {
         if (scope === "global") return config.globalDefaults || {};
@@ -192,7 +236,7 @@ export function QuickActionFloat() {
         updateWorldBooks(next);
     }, [selectedWorldBookIds, updateWorldBooks]);
 
-    function getFloatingButtonBounds(button: HTMLButtonElement) {
+    function getFloatingButtonBounds(button: HTMLButtonElement, currentPos: FloatingPosition | null) {
         const parent = button.offsetParent instanceof HTMLElement ? button.offsetParent : null;
         const parentRect = parent?.getBoundingClientRect() ?? {
             left: 0,
@@ -200,19 +244,30 @@ export function QuickActionFloat() {
             width: window.innerWidth,
             height: window.innerHeight,
         };
-        const rect = button.getBoundingClientRect();
+        // 始终使用未变换的纯净布局坐标：优先使用 state 中的位置，若初始未拖拽则取 offsetLeft / offsetTop（不受 CSS transform 影响）
+        const left = currentPos ? currentPos.left : button.offsetLeft;
+        const top = currentPos ? currentPos.top : button.offsetTop;
         return {
-            left: rect.left - parentRect.left,
-            top: rect.top - parentRect.top,
-            maxLeft: Math.max(12, parentRect.width - rect.width - 12),
-            maxTop: Math.max(12, parentRect.height - rect.height - 12),
+            left,
+            top,
+            maxLeft: Math.max(12, parentRect.width - 56 - 12),
+            maxTop: Math.max(12, parentRect.height - 56 - 12),
+            parentWidth: parentRect.width,
+            parentHeight: parentRect.height,
         };
     }
 
     function handleFloatingPointerDown(event: ReactPointerEvent<HTMLButtonElement>) {
+        const isDual = floatingDockEnabled && promptViewerEnabled && enabled;
+        const isQuickPrimary = !isDual || dockState.primaryTool === "quick-action";
+        if (dockState.isExpanded || (isDual && !isQuickPrimary)) {
+            // 展开挑选模式、或并非当前停靠的主球时，不接受拖拽
+            return;
+        }
         event.stopPropagation();
         const button = event.currentTarget;
-        const bounds = getFloatingButtonBounds(button);
+        const anchor = isDual ? dockState.anchorPosition : null;
+        const bounds = getFloatingButtonBounds(button, (isDual && anchor) ? anchor : floatingPosition);
         floatingDragRef.current = {
             pointerId: event.pointerId,
             startClientX: event.clientX,
@@ -223,7 +278,7 @@ export function QuickActionFloat() {
             maxTop: bounds.maxTop,
             moved: false,
         };
-        setDraggingFloatingButton(true);
+        // 不在 pointerDown 立即 setDraggingFloatingButton(true)，避免普通点击时瞬间取消 is-docked 产生动画抖动
         button.setPointerCapture(event.pointerId);
     }
 
@@ -233,7 +288,15 @@ export function QuickActionFloat() {
         event.stopPropagation();
         const deltaX = event.clientX - drag.startClientX;
         const deltaY = event.clientY - drag.startClientY;
-        if (Math.abs(deltaX) > 3 || Math.abs(deltaY) > 3) drag.moved = true;
+        if (!drag.moved) {
+            // 超过 3px 移动阈值才判定为拖拽，杜绝手指/鼠标微小震颤把贴边位移写入 floatingPosition
+            if (Math.abs(deltaX) > 3 || Math.abs(deltaY) > 3) {
+                drag.moved = true;
+                setDraggingFloatingButton(true);
+            } else {
+                return;
+            }
+        }
         setFloatingPosition({
             left: clampFloatingPosition(drag.left + deltaX, drag.maxLeft),
             top: clampFloatingPosition(drag.top + deltaY, drag.maxTop),
@@ -244,7 +307,26 @@ export function QuickActionFloat() {
         const drag = floatingDragRef.current;
         if (!drag || drag.pointerId !== event.pointerId) return;
         event.stopPropagation();
-        if (drag.moved) suppressFloatingClickRef.current = true;
+        if (drag.moved) {
+            suppressFloatingClickRef.current = true;
+            if (floatingDockEnabled) {
+                // Auto-snap to closest edge (left or right)
+                const bounds = getFloatingButtonBounds(event.currentTarget, floatingPosition);
+                const midX = bounds.parentWidth / 2;
+                const currentX = drag.left + (event.clientX - drag.startClientX);
+                const currentTop = drag.top + (event.clientY - drag.startClientY);
+                const isLeft = currentX < midX;
+                const snappedLeft = isLeft ? 18 : Math.max(18, bounds.parentWidth - 56 - 18);
+                const snappedTop = clampFloatingPosition(currentTop, bounds.maxTop);
+                const newPos = { left: snappedLeft, top: snappedTop };
+                setFloatingPosition(newPos);
+                setFloatingDockAnchor({ ...newPos, dockSide: isLeft ? "left" : "right" });
+                if (!open) {
+                    collapseFloatingDock();
+                }
+            }
+        }
+
         floatingDragRef.current = null;
         setDraggingFloatingButton(false);
         if (event.currentTarget.hasPointerCapture(event.pointerId)) {
@@ -258,8 +340,26 @@ export function QuickActionFloat() {
             suppressFloatingClickRef.current = false;
             return;
         }
+
+        // If already open, clicking it collapses back to dock
+        if (open) {
+            handleClose();
+            return;
+        }
+
+        if (floatingDockEnabled) {
+            const isDual = promptViewerEnabled && enabled;
+            const isQuickPrimary = !isDual || dockState.primaryTool === "quick-action";
+            // Dual-ball mode: if currently docked as primary and not expanded, clicking expands both balls!
+            if (isDual && isQuickPrimary && dockState.isDocked && !dockState.isExpanded) {
+                expandFloatingDock();
+                return;
+            }
+            setActiveFloatingTool("quick-action");
+        }
+
         reloadData();
-        setOpen(prev => !prev);
+        setOpen(true);
     }
 
     if (!enabled) return null;
@@ -279,21 +379,60 @@ export function QuickActionFloat() {
         ? { left: popoverPosition.left, top: popoverPosition.top }
         : undefined;
 
+    const isDual = floatingDockEnabled && promptViewerEnabled && enabled;
+    const isQuickPrimary = !isDual || dockState.primaryTool === "quick-action";
+    const isPromptViewerActive = floatingDockEnabled && promptViewerEnabled && dockState.activeTool === "prompt-viewer";
+
+    const isHiddenBehind = isDual && !isQuickPrimary && !open && !dockState.isExpanded;
+    const isDocked = floatingDockEnabled && !open && (
+        isQuickPrimary ? (dockState.isDocked && !draggingFloatingButton) : false
+    );
+    const isOpen = open;
+    const isExpanded = floatingDockEnabled && !open && dockState.isExpanded;
+    const isPaired = isDual && !isQuickPrimary && !open && dockState.isExpanded;
+    const dockSide = dockState.dockSide;
+    const anchor = isDual ? dockState.anchorPosition : null;
+
+    const buttonClass = [
+        "prompt-viewer-float-button",
+        "quick-action-float-button",
+        isHiddenBehind ? "is-hidden-behind" : "",
+        isDocked ? "is-docked" : "",
+        isOpen ? "is-open" : "",
+        isExpanded ? "is-expanded" : "",
+        isPaired ? "is-paired" : "",
+    ].filter(Boolean).join(" ");
+
+    let buttonStyle: CSSProperties | undefined;
+    if (draggingFloatingButton && floatingPosition) {
+        buttonStyle = { left: floatingPosition.left, top: floatingPosition.top };
+    } else if (isDual && anchor) {
+        buttonStyle = { left: anchor.left, top: anchor.top };
+    } else if (floatingPosition) {
+        buttonStyle = { left: floatingPosition.left, top: floatingPosition.top };
+    } else if (isDual) {
+        buttonStyle = { bottom: 148, right: 18 };
+    }
+    if (isPromptViewerActive) {
+        buttonStyle = { ...buttonStyle, display: "none" };
+    }
+
     return (
         <div className="quick-action-layer" ref={layerRef}>
             <button
                 ref={floatingButtonRef}
                 type="button"
-                className="prompt-viewer-float-button quick-action-float-button"
+                className={buttonClass}
                 aria-label="打开快捷操作"
-                data-positioned={floatingPosition ? "" : undefined}
+                data-positioned={(isDual ? !!anchor : !!floatingPosition) ? "" : undefined}
                 data-dragging={draggingFloatingButton ? "" : undefined}
+                data-dock-side={floatingDockEnabled ? dockSide : undefined}
                 onPointerDown={handleFloatingPointerDown}
                 onPointerMove={handleFloatingPointerMove}
                 onPointerUp={handleFloatingPointerEnd}
                 onPointerCancel={handleFloatingPointerEnd}
                 onClick={handleFloatingButtonClick}
-                style={floatingPosition ? { left: floatingPosition.left, top: floatingPosition.top } : undefined}
+                style={buttonStyle}
             >
                 <SlidersHorizontal size={24} strokeWidth={1.9} />
             </button>
@@ -315,7 +454,7 @@ export function QuickActionFloat() {
                                 <p>{scope === "global" ? "全局默认" : selectedCharacter?.name || "角色默认"}</p>
                             </div>
                         </div>
-                        <button type="button" className="quick-action-icon-btn" onClick={() => setOpen(false)} aria-label="关闭快捷操作">
+                        <button type="button" className="quick-action-icon-btn" onClick={handleClose} aria-label="关闭快捷操作">
                             <X size={18} />
                         </button>
                     </div>

--- a/fab_reference.js
+++ b/fab_reference.js
@@ -1,0 +1,256 @@
+/**
+ * =========================================================================
+ * 悬浮球组件独立参考代码 (Floating Action Button Reference Implementation)
+ * 提取自：英语消息词典 V84
+ * 英文术语：Reference（参考 / 参考实现）
+ * 
+ * 核心特性：
+ * 1. 拟物毛玻璃材质 (Glassmorphism): 24px 背景高斯模糊 + 饱和度提升 + 微光内阴影
+ * 2. 自动吸附与半隐藏 (Edge Snapping & Half-Hidden): 离手时自动吸附至屏幕左/右边缘，并露出 29px（缩进 15px）
+ * 3. 贴边自适应半透明 (Auto Dimming): 停靠边缘时透明度自动降至 0.55，不遮挡页面视线
+ * 4. 严谨的手势防误触 (Pointer Drag & Click Discrimination): 
+ *    - 移动 > 10px 判定为拖拽（跟随手指，零延迟过渡）；
+ *    - 移动 <= 10px 判定为点击（弹出主界面）；
+ * 5. 全局物理状态锁 (State Lock): 记录位置与停靠状态，界面刷新时不重置位置。
+ * =========================================================================
+ */
+
+// ==========================================
+// 一、悬浮球样式 (CSS Styles)
+// ==========================================
+export const FAB_STYLES = `
+  /* 悬浮球基础样式（毛玻璃质感） */
+  .fdict-fab-glass {
+    position: fixed;
+    z-index: 9990;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    margin: 0;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.65);
+    backdrop-filter: blur(24px) saturate(180%);
+    -webkit-backdrop-filter: blur(24px) saturate(180%);
+    border: 1px solid rgba(255, 255, 255, 0.9);
+    box-shadow: 0 8px 24px rgba(31, 38, 135, 0.1), inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+    color: #475569;
+    cursor: pointer;
+    touch-action: none;
+    user-select: none;
+  }
+
+  /* 悬浮球内图标 */
+  .fdict-fab-glass svg {
+    width: 24px;
+    height: 24px;
+    stroke-width: 1.8;
+  }
+
+  /* 贴边半隐藏状态（降低不透明度，减淡底色） */
+  .fdict-fab-glass.is-snapped {
+    opacity: 0.55;
+    background: rgba(255, 255, 255, 0.45);
+  }
+
+  /* 点击按压动效 */
+  .fdict-fab-glass:active {
+    transform: scale(0.92);
+  }
+
+  /* 暗色模式适配 (Dark Mode) */
+  @media (prefers-color-scheme: dark) {
+    .fdict-fab-glass {
+      background: rgba(30, 41, 59, 0.65);
+      color: #cbd5e1;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3), inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+    }
+    .fdict-fab-glass.is-snapped {
+      opacity: 0.55;
+      background: rgba(15, 23, 42, 0.5);
+    }
+  }
+`;
+
+// ==========================================
+// 二、悬浮球核心控制器 (FAB Controller)
+// ==========================================
+
+/**
+ * 悬浮球全局物理状态锁（防止宿主界面重新渲染或刷新插槽时位置被重置）
+ */
+export const fabState = {
+  left: -1,
+  top: -1,
+  snapped: true
+};
+
+/**
+ * 创建并初始化悬浮球
+ * @param {Object} options 配置项
+ * @param {Function} options.onClick 点击悬浮球时的回调函数（例如打开词典窗口）
+ * @param {HTMLElement} [options.container=document.body] 挂载容器，默认是 document.body
+ * @param {boolean} [options.enabled=true] 是否默认显示
+ * @returns {Function} 销毁函数 (cleanup)
+ */
+export function initFloatingBall(options = {}) {
+  const {
+    onClick = () => console.log("FAB Clicked!"),
+    container = document.body,
+    enabled = true
+  } = options;
+
+  // 1. 若已有旧实例，先清理
+  const existing = document.getElementById("fdict-global-fab");
+  if (existing) existing.remove();
+
+  // 2. 注入样式（若页面尚未注入）
+  if (!document.getElementById("fdict-fab-styles")) {
+    const styleEl = document.createElement("style");
+    styleEl.id = "fdict-fab-styles";
+    styleEl.textContent = FAB_STYLES;
+    document.head.appendChild(styleEl);
+  }
+
+  // 3. 构建 DOM 元素
+  const fab = document.createElement("button");
+  fab.id = "fdict-global-fab";
+  fab.className = "fdict-fab-glass";
+  fab.style.display = enabled ? "flex" : "none";
+  fab.setAttribute("aria-label", "快捷查词悬浮球");
+
+  // 词典小书本 + 放大镜 SVG 图标
+  fab.innerHTML = `
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path>
+      <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path>
+      <path d="M10 9a2 2 0 1 0 4 0 2 2 0 0 0-4 0z"></path>
+      <path d="m13 12 2 2"></path>
+    </svg>
+  `;
+
+  // 4. 尺寸与初次布局计算
+  const fabSize = 44;       // 悬浮球宽高 44px
+  const hideOffset = 15;    // 停靠时嵌入屏幕边缘的隐藏量 (15px)
+  const vw = document.documentElement.clientWidth || window.innerWidth;
+  const vh = document.documentElement.clientHeight || window.innerHeight;
+
+  // 若从未初始化过位置，默认吸附在右下侧（高度 70% 处）
+  if (fabState.left === -1) {
+    fabState.left = vw - (fabSize - hideOffset);
+    fabState.top = vh * 0.7;
+  }
+
+  fab.style.left = fabState.left + "px";
+  fab.style.top = fabState.top + "px";
+  if (fabState.snapped) {
+    fab.classList.add("is-snapped");
+  }
+
+  // 5. 拖拽交互状态机
+  let isDragging = false;
+  let hasMoved = false;
+  let startX = 0, startY = 0, startLeft = 0, startTop = 0;
+
+  // 自动贴边计算函数
+  const snapToEdge = () => {
+    fab.classList.add("is-snapped");
+    fabState.snapped = true;
+    const currentVw = document.documentElement.clientWidth || window.innerWidth;
+    const centerX = fabState.left + fabSize / 2;
+
+    // 靠左贴边还是靠右贴边
+    if (centerX < currentVw / 2) {
+      fabState.left = -hideOffset;
+    } else {
+      fabState.left = currentVw - (fabSize - hideOffset);
+    }
+    fab.style.left = fabState.left + "px";
+  };
+
+  // ==========================================
+  // 三、手势监听 (Pointer Events: 统一鼠标与触摸)
+  // ==========================================
+
+  // 按下：记录初始坐标，启用捕获
+  fab.addEventListener("pointerdown", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    isDragging = true;
+    hasMoved = false;
+    startX = e.clientX;
+    startY = e.clientY;
+    startLeft = fabState.left;
+    startTop = fabState.top;
+
+    // 拖拽过程中必须移除 CSS transition，否则跟手会有明显的延迟粘滞感
+    fab.style.transition = "none";
+    fab.setPointerCapture(e.pointerId);
+  });
+
+  // 移动：判定是否触发拖拽位移阈值 (10px)
+  fab.addEventListener("pointermove", (e) => {
+    if (!isDragging) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+
+    // 只有绝对移动距离超过 10px，才认定用户是“想拖拽”而不是“轻微手抖的点按”
+    if (Math.abs(dx) > 10 || Math.abs(dy) > 10) {
+      hasMoved = true;
+      fab.classList.remove("is-snapped"); // 离边移动时立刻恢复 100% 不透明度
+      fabState.snapped = false;
+    }
+
+    if (hasMoved) {
+      const currentVh = document.documentElement.clientHeight || window.innerHeight;
+      fabState.left = startLeft + dx;
+      // 限制垂直方向不超出可视区域顶部与底部
+      fabState.top = Math.max(0, Math.min(currentVh - fabSize, startTop + dy));
+      fab.style.left = fabState.left + "px";
+      fab.style.top = fabState.top + "px";
+    }
+  });
+
+  // 抬起：释放捕获，平滑回弹贴边，或触发点击
+  fab.addEventListener("pointerup", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (!isDragging) return;
+    isDragging = false;
+    fab.releasePointerCapture(e.pointerId);
+
+    // 抬起后赋予极佳阻尼感的贝塞尔过渡曲线，实现丝滑回弹入位
+    fab.style.transition = "left 0.3s cubic-bezier(0.25, 0.8, 0.25, 1), top 0.3s ease, opacity 0.3s ease, transform 0.2s ease, background 0.3s ease";
+
+    // 执行贴边吸附
+    snapToEdge();
+
+    // 如果手指没有真正拖动（位移 <= 10px），判定为有效点击！
+    if (!hasMoved) {
+      setTimeout(() => {
+        onClick();
+      }, 50);
+    }
+  });
+
+  // 阻止浏览器的原生合成 click 事件冒泡
+  fab.addEventListener("click", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  });
+
+  // 挂载到容器中
+  container.appendChild(fab);
+
+  // 返回卸载清理方法
+  return function destroy() {
+    if (container.contains(fab)) {
+      container.removeChild(fab);
+    }
+  };
+}

--- a/lib/chat-storage.ts
+++ b/lib/chat-storage.ts
@@ -264,6 +264,7 @@ export type ChatAppSettings = {
     enterToSendEnabled?: boolean; // When true, Enter sends chat input and Shift+Enter inserts a newline
     callVibrationEnabled?: boolean; // 语音/视频来电等待接听时循环振动（默认开；iOS 网页不支持振动则无效果）
     maxToolRounds?: number; // 单条消息的工具循环轮数上限（默认 5；每轮=一次模型请求，轮内调用条数不限）
+    floatingDockEnabled?: boolean; // 悬浮球贴边半隐藏收拢模式（默认关）
 };
 
 /** 单条消息工具循环轮数上限（默认 5，夹在 1–20 之间） */
@@ -545,6 +546,7 @@ const DEFAULT_CHAT_APP_SETTINGS: ChatAppSettings = {
     promptViewerEnabled: false,
     quickActionEnabled: false,
     enterToSendEnabled: false,
+    floatingDockEnabled: false,
 };
 
 // ── In-Memory Caches (hydrated from IndexedDB on startup) ──────────

--- a/lib/floating-dock-store.ts
+++ b/lib/floating-dock-store.ts
@@ -1,0 +1,207 @@
+// lib/floating-dock-store.ts
+// Lightweight global store for coordinating floating tools (Prompt Viewer & Quick Action)
+// in edge-docking and horizontal-expanding modes.
+
+export type DockSide = "left" | "right";
+
+export type FloatingDockPosition = {
+    left: number;
+    top: number;
+    dockSide?: DockSide;
+};
+
+export type ActiveFloatingTool = "none" | "quick-action" | "prompt-viewer";
+export type PrimaryFloatingTool = "quick-action" | "prompt-viewer";
+
+const PRIMARY_TOOL_STORAGE_KEY = "phone_primary_floating_tool";
+const ANCHOR_STORAGE_KEY = "phone_floating_dock_anchor";
+
+function getInitialPrimaryTool(): PrimaryFloatingTool {
+    if (typeof window === "undefined") return "quick-action";
+    try {
+        const stored = localStorage.getItem(PRIMARY_TOOL_STORAGE_KEY);
+        if (stored === "prompt-viewer" || stored === "quick-action") return stored;
+    } catch {
+        // ignore
+    }
+    return "quick-action";
+}
+
+function getInitialAnchor(): FloatingDockPosition | null {
+    if (typeof window === "undefined") return null;
+    try {
+        const stored = localStorage.getItem(ANCHOR_STORAGE_KEY);
+        if (stored) {
+            const parsed = JSON.parse(stored);
+            if (typeof parsed?.left === "number" && typeof parsed?.top === "number") {
+                return parsed;
+            }
+        }
+    } catch {
+        // ignore
+    }
+    return null;
+}
+
+export type FloatingDockState = {
+    /** Whether the floating dock is currently docked/snapped to the edge */
+    isDocked: boolean;
+    /** Whether the dock is expanded horizontally showing both tools for selection */
+    isExpanded: boolean;
+    /** Which side of the screen the dock is docked on ("left" | "right") */
+    dockSide: DockSide;
+    /** Position anchor of the primary floating ball */
+    anchorPosition: FloatingDockPosition | null;
+    /** Which tool currently has its window/panel open */
+    activeTool: ActiveFloatingTool;
+    /** Which tool was most recently opened/used and serves as the single docked ball */
+    primaryTool: PrimaryFloatingTool;
+};
+
+const _initialAnchor = getInitialAnchor();
+let _dockState: FloatingDockState = {
+    isDocked: true,
+    isExpanded: false,
+    dockSide: _initialAnchor?.dockSide || "right",
+    anchorPosition: _initialAnchor,
+    activeTool: "none",
+    primaryTool: getInitialPrimaryTool(),
+};
+
+const _listeners = new Set<() => void>();
+let _autoCollapseTimer: ReturnType<typeof setTimeout> | null = null;
+
+function notifyListeners() {
+    _listeners.forEach(fn => fn());
+}
+
+export function getFloatingDockState(): FloatingDockState {
+    return _dockState;
+}
+
+export function subscribeFloatingDockState(fn: () => void): () => void {
+    _listeners.add(fn);
+    return () => {
+        _listeners.delete(fn);
+    };
+}
+
+/** Set position anchor of the primary dock button (syncs position and dockSide to paired buttons) */
+export function setFloatingDockAnchor(pos: FloatingDockPosition | null): void {
+    const nextDockSide = pos?.dockSide || _dockState.dockSide;
+    if (
+        _dockState.anchorPosition?.left === pos?.left &&
+        _dockState.anchorPosition?.top === pos?.top &&
+        _dockState.dockSide === nextDockSide
+    ) {
+        return;
+    }
+    if (pos) {
+        try {
+            localStorage.setItem(ANCHOR_STORAGE_KEY, JSON.stringify(pos));
+        } catch {
+            // ignore
+        }
+    }
+    _dockState = {
+        ..._dockState,
+        dockSide: nextDockSide,
+        anchorPosition: pos,
+    };
+    notifyListeners();
+}
+
+/** Explicitly update the dock side ("left" | "right") */
+export function setFloatingDockSide(side: DockSide): void {
+    if (_dockState.dockSide === side) return;
+    _dockState = {
+        ..._dockState,
+        dockSide: side,
+    };
+    notifyListeners();
+}
+
+/** Set the active open tool ("none" | "quick-action" | "prompt-viewer") */
+export function setActiveFloatingTool(tool: ActiveFloatingTool): void {
+    clearCollapseTimer();
+    const nextPrimary = tool === "none" ? _dockState.primaryTool : tool;
+    if (tool !== "none") {
+        try {
+            localStorage.setItem(PRIMARY_TOOL_STORAGE_KEY, tool);
+        } catch {
+            // ignore
+        }
+    }
+    if (_dockState.activeTool === tool && _dockState.primaryTool === nextPrimary) return;
+    _dockState = {
+        ..._dockState,
+        activeTool: tool,
+        primaryTool: nextPrimary,
+        isDocked: true,
+        isExpanded: false,
+    };
+    notifyListeners();
+}
+
+/** Clear any pending auto-collapse timer */
+function clearCollapseTimer() {
+    if (_autoCollapseTimer) {
+        clearTimeout(_autoCollapseTimer);
+        _autoCollapseTimer = null;
+    }
+}
+
+/** Expand the dock: slide out from edge and horizontally arrange balls */
+export function expandFloatingDock(): void {
+    clearCollapseTimer();
+    _dockState = {
+        ..._dockState,
+        isDocked: false,
+        isExpanded: true,
+        activeTool: "none",
+    };
+    notifyListeners();
+
+    // Auto-collapse after 5 seconds of no user interaction
+    _autoCollapseTimer = setTimeout(() => {
+        collapseFloatingDock();
+    }, 5000);
+}
+
+/** Collapse the dock back to edge-docked half-hidden state */
+export function collapseFloatingDock(): void {
+    clearCollapseTimer();
+    if (_dockState.isDocked && !_dockState.isExpanded && _dockState.activeTool === "none") return;
+    _dockState = {
+        ..._dockState,
+        isDocked: true,
+        isExpanded: false,
+        activeTool: "none",
+    };
+    notifyListeners();
+}
+
+/** Mark dock as temporarily undocked (e.g. when panel/popover is actively open) */
+export function setFloatingDockActive(): void {
+    clearCollapseTimer();
+    _dockState = {
+        ..._dockState,
+        isDocked: false,
+        isExpanded: false,
+    };
+    notifyListeners();
+}
+
+/** Reset to default docked state */
+export function resetFloatingDock(): void {
+    clearCollapseTimer();
+    _dockState = {
+        isDocked: true,
+        isExpanded: false,
+        dockSide: "right",
+        anchorPosition: null,
+        activeTool: "none",
+        primaryTool: getInitialPrimaryTool(),
+    };
+    notifyListeners();
+}

--- a/lib/settings-storage.ts
+++ b/lib/settings-storage.ts
@@ -12,6 +12,7 @@ import type {
     CharacterBinding,
     Prompt,
     PromptOrderEntry,
+    GenerationParameterKey,
 } from "./settings-types";
 import type { UserIdentity } from "@/components/settings/user-identity";
 import { createBuiltinPreset, BUILTIN_PRESET_VERSION } from "./builtin-preset";
@@ -326,7 +327,7 @@ export function parsePresetFromJson(text: string, fallbackName: string = "导入
         if (typeof obj.openai_max_context === "number") preset.openai_max_context = obj.openai_max_context;
         if (Array.isArray(obj.enabled_generation_parameters)) {
             preset.enabled_generation_parameters = [
-                ...new Set(obj.enabled_generation_parameters.filter(isGenerationParameterKey)),
+                ...new Set<GenerationParameterKey>(obj.enabled_generation_parameters.filter(isGenerationParameterKey)),
             ];
         }
         // New preset globals

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "AGPL-3.0-only",
   "scripts": {
     "dev": "node --max-old-space-size=4096 scripts/local-next-server.mjs --dev",
+    "dev:3002": "node --max-old-space-size=4096 scripts/local-next-server.mjs --dev --port 3002",
     "build": "node scripts/build-weixin-assistant-dist.mjs && node scripts/build-personal-push-dist.mjs && next build && node scripts/restore-backdrop-filter.mjs",
     "start": "node scripts/local-next-server.mjs --prod",
     "lint": "next lint",

--- a/styles/components.css
+++ b/styles/components.css
@@ -1527,6 +1527,54 @@
 .settings-tools-menu-toggle {
   margin-left: 12px;
 }
+.settings-tools-header {
+  margin: 8px 4px 0;
+}
+.settings-tools-title-wrap {
+  display: inline-flex;
+  align-items: flex-start;
+  position: relative;
+}
+.settings-tools-title-wrap .settings-menu-section-title {
+  margin: 0;
+}
+.settings-tools-info-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  border-radius: 999px;
+  outline: none;
+  margin-left: 3px;
+  transform: translateY(-5px);
+  position: relative;
+}
+.settings-tools-info-btn::before {
+  content: "";
+  position: absolute;
+  top: -8px;
+  left: -8px;
+  right: -8px;
+  bottom: -8px;
+}
+.settings-tools-info-circle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 15px;
+  height: 15px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--c-icon) 22%, transparent);
+  color: var(--c-icon-active);
+  transition: all 0.2s ease;
+}
+.settings-tools-info-btn:hover .settings-tools-info-circle {
+  background: color-mix(in srgb, var(--c-icon) 38%, transparent);
+  transform: scale(1.08);
+}
 .card-featured-chevron {
   color: var(--c-icon);
   flex-shrink: 0;
@@ -1639,6 +1687,62 @@
   box-shadow:
     0 0 32px 8px rgba(96, 218, 195, 0.26),
     0 6px 18px rgba(70, 154, 195, 0.18);
+}
+
+/* 悬浮球贴边停靠状态（半隐藏、低透明度、平滑阻尼动效） */
+.prompt-viewer-float-button.is-docked {
+  transform: translateX(36px) scale(0.75);
+  opacity: 0.55;
+  animation: none !important;
+  transition: transform 320ms cubic-bezier(0.25, 0.8, 0.25, 1), opacity 240ms ease, box-shadow 200ms ease;
+}
+
+.prompt-viewer-float-button.is-docked[data-dock-side="left"] {
+  transform: translateX(-36px) scale(0.75);
+}
+
+.prompt-viewer-float-button.is-docked:hover {
+  opacity: 0.9;
+  transform: translateX(24px) scale(0.78);
+}
+
+.prompt-viewer-float-button.is-docked[data-dock-side="left"]:hover {
+  transform: translateX(-24px) scale(0.78);
+}
+
+/* 弹窗打开态与展开挑选状态：恢复完全可见，停止原浮动动画保证贴边过渡丝滑无跳帧 */
+.prompt-viewer-float-button.is-open,
+.prompt-viewer-float-button.is-expanded {
+  transform: translateX(0) scale(0.75);
+  opacity: 1;
+  animation: none !important;
+  transition: transform 320ms cubic-bezier(0.25, 0.8, 0.25, 1), opacity 240ms ease, box-shadow 200ms ease;
+}
+
+/* 双球模式横向并排展开：靠右贴边时，提示词球在快捷操作球左侧并排（间距约 10px） */
+.prompt-viewer-float-button.is-expanded.is-paired {
+  transform: translateX(-52px) scale(0.75) !important;
+  opacity: 1 !important;
+  pointer-events: auto !important;
+  animation: none !important;
+}
+
+/* 靠左贴边时，提示词球在快捷操作球右侧并排 */
+.prompt-viewer-float-button.is-expanded.is-paired[data-dock-side="left"] {
+  transform: translateX(52px) scale(0.75) !important;
+}
+
+/* 双球贴边收拢时，次级球叠在主球内部，展开时横向丝滑滑出 */
+.prompt-viewer-float-button.is-hidden-behind {
+  opacity: 0 !important;
+  pointer-events: none !important;
+  transform: translateX(36px) scale(0.4) !important;
+  animation: none !important;
+  transition: transform 320ms cubic-bezier(0.25, 0.8, 0.25, 1), opacity 240ms ease;
+}
+
+.prompt-viewer-float-button.is-hidden-behind[data-dock-side="left"] {
+  transform: translateX(-36px) scale(0.4) !important;
 }
 
 .quick-action-popover {


### PR DESCRIPTION
贡献者：什锦杂货铺
功能入口：设置——tools的右上角小i，默认功能是关闭的，开启就可以看到本次pr的功能。
一直觉得两个悬浮球不能贴边躲着，容易遮拦信息，所以做了这个功能。
希望被采纳！！各种各样小逻辑bug、动效之类的也是反复检查验证修改过的。