### PR TITLE
fix: 优化参考图判定与重试控制，完善生成中断容灾与换图平滑度

### DIFF
--- a/components/chat/message-bubble.tsx
+++ b/components/chat/message-bubble.tsx
@@ -23,6 +23,7 @@ import remarkBreaks from "remark-breaks";
 import { createPortal } from "react-dom";
 import { Blocks, Maximize2, ReceiptText } from "lucide-react";
 import { retryChatGeneratedImage } from "@/lib/generated-image-retry";
+import { hasCharacterReferenceImage } from "@/lib/image-generation-service";
 import { GeneratedImageErrorDialog } from "./generated-image-error-dialog";
 import { ScanPayCard } from "@/components/chat/scan-pay-card";
 import { payWithWalletBalance } from "@/lib/wallet-storage";
@@ -1178,6 +1179,9 @@ function GeneratedImagePromptDialog({
     onConfirm,
     busy,
     error,
+    useReferenceImage,
+    onUseReferenceImageChange,
+    hasReferenceImage,
 }: {
     value: string;
     onChange: (value: string) => void;
@@ -1185,6 +1189,9 @@ function GeneratedImagePromptDialog({
     onConfirm: () => void;
     busy: boolean;
     error?: string;
+    useReferenceImage: boolean;
+    onUseReferenceImageChange: (useRef: boolean) => void;
+    hasReferenceImage: boolean;
 }) {
     return (
         <div
@@ -1212,6 +1219,19 @@ function GeneratedImagePromptDialog({
                         placeholder="输入图片提示词"
                         disabled={busy}
                     />
+                    {hasReferenceImage ? (
+                        <label className="chat-generated-image-prompt-check">
+                            <input
+                                type="checkbox"
+                                checked={useReferenceImage}
+                                disabled={busy}
+                            onChange={e => onUseReferenceImageChange(e.target.checked)}
+                            />
+                            <span>使用角色参考图（角色出镜）</span>
+                        </label>
+                    ) : (
+                        <div className="chat-generated-image-prompt-empty-hint">该角色未配置参考图</div>
+                    )}
                     {error && <div className="chat-generated-image-retry-error">{error}</div>}
                 </div>
                 <div className="modal-footer" data-ui="modal-footer">
@@ -1251,9 +1271,12 @@ function ImageBubble({
     // retryError 只用于提示词弹窗内的即时校验；生成失败改用一次性弹窗，不再挂红字
     const [retryError, setRetryError] = useState("");
     const [failureNotice, setFailureNotice] = useState("");
-    const isPending = d?.imageGenerationStatus === "pending";
-    const canRegenerate = !isPending && Boolean(d?.label?.trim());
+    const isPending = regenerating || (!resolvedUrl && d?.imageGenerationStatus === "pending");
+    const canRegenerate = Boolean(d?.label?.trim());
     const [showPreview, setShowPreview] = useState(false);
+
+    const [hasRef, setHasRef] = useState(() => hasCharacterReferenceImage(characterId));
+    const [useReferenceDraft, setUseReferenceDraft] = useState(d?.useReferenceImage === true);
 
     useEffect(() => {
         if (!isMediaStoreRef(rawUrl)) {
@@ -1270,10 +1293,13 @@ function ImageBubble({
     }, [rawUrl]);
 
     const openPromptEditor = useCallback(() => {
+        const latestHasRef = hasCharacterReferenceImage(characterId);
+        setHasRef(latestHasRef);
         setPromptDraft(d?.label?.trim() || "");
+        setUseReferenceDraft(latestHasRef && d?.useReferenceImage === true);
         setRetryError("");
         setShowPromptEditor(true);
-    }, [d?.label]);
+    }, [characterId, d?.label, d?.useReferenceImage]);
 
     const handleRetry = useCallback(() => {
         const nextDescription = promptDraft.trim();
@@ -1281,11 +1307,21 @@ function ImageBubble({
             setRetryError("提示词不能为空");
             return;
         }
+        const latestHasRef = hasCharacterReferenceImage(characterId);
         setShowPromptEditor(false);
         setRegenerating(true);
         setRetryError("");
-        retryChatGeneratedImage(msg, characterId, nextDescription)
-            .then(updated => {
+        retryChatGeneratedImage(msg, characterId, nextDescription, latestHasRef ? useReferenceDraft : false)
+            .then(async (updated) => {
+                if (updated?.mediaUrl) {
+                    try {
+                        const img = new Image();
+                        img.src = updated.mediaUrl;
+                        if ("decode" in img) await img.decode().catch(() => {});
+                    } catch {
+                        // ignore predecode error
+                    }
+                }
                 onUpdate?.(updated);
             })
             .catch(error => {
@@ -1294,7 +1330,7 @@ function ImageBubble({
             .finally(() => {
                 setRegenerating(false);
             });
-    }, [characterId, msg, onUpdate, promptDraft]);
+    }, [characterId, msg, onUpdate, promptDraft, useReferenceDraft]);
 
     // 预览层与提示词对话框：图片正常/失败占位两种形态共用（操作按钮统一收在点开后的预览层里）
     const previewAndDialog = (
@@ -1313,6 +1349,9 @@ function ImageBubble({
                 <GeneratedImagePromptDialog
                     value={promptDraft}
                     onChange={setPromptDraft}
+                    useReferenceImage={useReferenceDraft}
+                    onUseReferenceImageChange={setUseReferenceDraft}
+                    hasReferenceImage={hasRef}
                     onConfirm={handleRetry}
                     onCancel={() => setShowPromptEditor(false)}
                     busy={regenerating}
@@ -1920,11 +1959,17 @@ function MediaFileBubble({
         setProgress(audio.currentTime / audio.duration);
     }, []);
 
+    const [hasRef, setHasRef] = useState(() => hasCharacterReferenceImage(characterId));
+    const [imageUseReferenceDraft, setImageUseReferenceDraft] = useState(msg.mediaData?.useReferenceImage === true);
+
     const openImagePromptEditor = useCallback(() => {
+        const latestHasRef = hasCharacterReferenceImage(characterId);
+        setHasRef(latestHasRef);
         setImagePromptDraft(msg.mediaData?.label?.trim() || "");
+        setImageUseReferenceDraft(latestHasRef && msg.mediaData?.useReferenceImage === true);
         setImageRetryError("");
         setShowImagePromptEditor(true);
-    }, [msg.mediaData?.label]);
+    }, [characterId, msg.mediaData?.label, msg.mediaData?.useReferenceImage]);
 
     const handleRegenerateImage = useCallback(() => {
         const nextDescription = imagePromptDraft.trim();
@@ -1932,11 +1977,21 @@ function MediaFileBubble({
             setImageRetryError("提示词不能为空");
             return;
         }
+        const latestHasRef = hasCharacterReferenceImage(characterId);
         setShowImagePromptEditor(false);
         setImageRegenerating(true);
         setImageRetryError("");
-        retryChatGeneratedImage(msg, characterId, nextDescription)
-            .then(updated => {
+        retryChatGeneratedImage(msg, characterId, nextDescription, latestHasRef ? imageUseReferenceDraft : false)
+            .then(async (updated) => {
+                if (updated?.mediaUrl) {
+                    try {
+                        const img = new Image();
+                        img.src = updated.mediaUrl;
+                        if ("decode" in img) await img.decode().catch(() => {});
+                    } catch {
+                        // ignore predecode error
+                    }
+                }
                 onUpdate?.(updated);
             })
             .catch(error => {
@@ -1945,7 +2000,7 @@ function MediaFileBubble({
             .finally(() => {
                 setImageRegenerating(false);
             });
-    }, [characterId, imagePromptDraft, msg, onUpdate]);
+    }, [characterId, imagePromptDraft, imageUseReferenceDraft, msg, onUpdate]);
 
     const handleSeek = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
         e.stopPropagation();
@@ -2040,10 +2095,8 @@ function MediaFileBubble({
         const displayTitle = msg.mediaData?.imageGenerationPrompt ? "" : title;
         // 重试把状态落库为 pending（见 generated-image-retry.ts），角标据此显示——
         // 比组件内的 imageRegenerating 可靠：滚远了卸载再回来，角标还在。
-        const imageRegenPending = msg.mediaData?.imageGenerationStatus === "pending";
-        const canRegenerateImage = !imageRegenPending
-            && Boolean(msg.mediaData?.label?.trim())
-            && (msg.mediaData?.imageGenerationStatus === "generated" || Boolean(msg.mediaData?.imageGenerationPrompt));
+        const imageRegenPending = imageRegenerating;
+        const canRegenerateImage = Boolean(msg.mediaData?.label?.trim());
         return (
             <div className="chat-generated-image-retry-stack">
                 <div className="chat-generated-image-regen-wrap">
@@ -2065,6 +2118,9 @@ function MediaFileBubble({
                     <GeneratedImagePromptDialog
                         value={imagePromptDraft}
                         onChange={setImagePromptDraft}
+                        useReferenceImage={imageUseReferenceDraft}
+                        onUseReferenceImageChange={setImageUseReferenceDraft}
+                        hasReferenceImage={hasRef}
                         onConfirm={handleRegenerateImage}
                         onCancel={() => setShowImagePromptEditor(false)}
                         busy={imageRegenerating}

--- a/components/chat/moment-post-card.tsx
+++ b/components/chat/moment-post-card.tsx
@@ -19,6 +19,7 @@ import { buildTwoLevelMomentThreads } from "@/lib/moments-comment-threading";
 import { getChatImageFromIndexedDB } from "@/lib/chat-asset-storage";
 import { splitBilingualText } from "@/lib/bilingual-text";
 import { retryMomentGeneratedPhoto } from "@/lib/generated-image-retry";
+import { hasCharacterReferenceImage } from "@/lib/image-generation-service";
 import { GeneratedImageErrorDialog } from "./generated-image-error-dialog";
 import { Trash2, MoreHorizontal, MapPin, Heart, MessageCircle, Pencil } from "lucide-react";
 import { ConfirmDialog } from "@/components/ui";
@@ -42,6 +43,9 @@ export function MomentPostCard({ post, onUpdate, onRequestDelete, onOpenCommentC
     const [showPhotoPromptEditor, setShowPhotoPromptEditor] = useState(false);
     const [photoPromptDraft, setPhotoPromptDraft] = useState("");
     const [photoRegenerating, setPhotoRegenerating] = useState(false);
+    const characterId = post.authorType === "character" ? post.authorId : undefined;
+    const [hasRef, setHasRef] = useState(() => hasCharacterReferenceImage(characterId));
+    const [photoUseReferenceDraft, setPhotoUseReferenceDraft] = useState(post.photoUseReferenceImage === true);
     const [showFallbackPreview, setShowFallbackPreview] = useState(false);
     // photoRetryError 只用于提示词弹窗内的即时校验；生成失败改用一次性弹窗，不再挂红字
     const [photoRetryError, setPhotoRetryError] = useState("");
@@ -62,22 +66,34 @@ export function MomentPostCard({ post, onUpdate, onRequestDelete, onOpenCommentC
     const [resolvedPhotoUrl, setResolvedPhotoUrl] = useState<string | null>(null);
     useEffect(() => {
         let cancelled = false;
-        setResolvedPhotoUrl(null);
 
-        if (post.photoUrl?.startsWith("asset://")) {
+        if (!post.photoUrl) {
+            setResolvedPhotoUrl(null);
+            return;
+        }
+
+        if (post.photoUrl.startsWith("asset://")) {
             const assetId = post.photoUrl.slice(8);
             getChatImageFromIndexedDB(assetId).then(url => {
                 if (cancelled) return;
                 setResolvedPhotoUrl(url || null);
             });
         } else {
-            setResolvedPhotoUrl(post.photoUrl || null);
+            setResolvedPhotoUrl(post.photoUrl);
         }
 
         return () => {
             cancelled = true;
         };
     }, [post.photoUrl]);
+
+    // 如果落库状态为 pending 但实际并没有任何异步任务在跑（比如被刷新/大退杀掉了），
+    // 且帖子本身已有正常 photoUrl，将残留的 pending 复位，防止变成僵尸任务。
+    useEffect(() => {
+        if (post.photoUrl && post.photoGenerationStatus === "pending" && !photoRegenerating) {
+            updateMomentPost(post.id, { photoGenerationStatus: "generated" });
+        }
+    }, [post.id, post.photoUrl, post.photoGenerationStatus, photoRegenerating]);
 
     const chars = loadCharacters();
     // 角色帖子下，用户名用该角色绑定的用户人设；用户自己的帖子用默认人设
@@ -242,32 +258,49 @@ export function MomentPostCard({ post, onUpdate, onRequestDelete, onOpenCommentC
     const canRetryPhoto = Boolean(fallbackPhotoDescription);
     const canRegeneratePhoto = Boolean(resolvedPhotoUrl)
         && Boolean(post.photoUrl)
-        && Boolean(post.photoDescription?.trim())
-        && post.photoGenerationStatus !== "pending"
-        && (post.photoGenerationStatus === "generated" || Boolean(post.photoGenerationPrompt));
+        && Boolean(post.photoDescription?.trim());
     const openPhotoPromptEditor = useCallback(() => {
+        const latestHasRef = hasCharacterReferenceImage(characterId);
+        setHasRef(latestHasRef);
         setPhotoPromptDraft(post.photoDescription?.trim() || "");
+        setPhotoUseReferenceDraft(latestHasRef && post.photoUseReferenceImage === true);
         setPhotoRetryError("");
         setShowPhotoPromptEditor(true);
-    }, [post.photoDescription]);
+    }, [characterId, post.photoDescription, post.photoUseReferenceImage]);
     const handleRegeneratePhotoWithPrompt = useCallback(() => {
         const nextDescription = photoPromptDraft.trim();
         if (!nextDescription) {
             setPhotoRetryError("提示词不能为空");
             return;
         }
+        const latestHasRef = hasCharacterReferenceImage(characterId);
         setShowPhotoPromptEditor(false);
         setPhotoRegenerating(true);
         setPhotoRetryError("");
-        retryMomentGeneratedPhoto(post, nextDescription)
-            .then(() => onUpdate())
+        retryMomentGeneratedPhoto(post, nextDescription, latestHasRef ? photoUseReferenceDraft : false)
+            .then(async (updated) => {
+                if (updated?.photoUrl?.startsWith("asset://")) {
+                    const assetId = updated.photoUrl.slice(8);
+                    try {
+                        const url = await getChatImageFromIndexedDB(assetId);
+                        if (url) {
+                            const img = new Image();
+                            img.src = url;
+                            if ("decode" in img) await img.decode().catch(() => {});
+                        }
+                    } catch {
+                        // ignore predecode error
+                    }
+                }
+                onUpdate();
+            })
             .catch(error => {
                 setPhotoFailureNotice(error instanceof Error ? error.message : String(error));
             })
             .finally(() => {
                 setPhotoRegenerating(false);
             });
-    }, [onUpdate, photoPromptDraft, post]);
+    }, [characterId, onUpdate, photoPromptDraft, photoUseReferenceDraft, post]);
 
     return (
         <div data-moment-post-id={post.id} className="feed-post relative border-b-[2.5px] border-[var(--c-card-border)] pb-5 mb-5 w-full bg-transparent px-4 pt-2">
@@ -355,7 +388,7 @@ export function MomentPostCard({ post, onUpdate, onRequestDelete, onOpenCommentC
                         regenerating={photoRegenerating}
                     />
                 )}
-                {resolvedPhotoUrl && post.photoGenerationStatus === "pending" && (
+                {resolvedPhotoUrl && photoRegenerating && (
                     <div className="ts-12 text-[var(--c-icon)] opacity-80">图片重新生成中…</div>
                 )}
                 {fallbackPhotoDescription && (
@@ -398,6 +431,19 @@ export function MomentPostCard({ post, onUpdate, onRequestDelete, onOpenCommentC
                                 placeholder="输入图片提示词"
                                 disabled={photoRegenerating}
                             />
+                            {hasRef ? (
+                                <label className="chat-generated-image-prompt-check">
+                                    <input
+                                        type="checkbox"
+                                        checked={photoUseReferenceDraft}
+                                        disabled={photoRegenerating}
+                                        onChange={e => setPhotoUseReferenceDraft(e.target.checked)}
+                                    />
+                                    <span>使用角色参考图（角色出镜）</span>
+                                </label>
+                            ) : (
+                                <div className="chat-generated-image-prompt-empty-hint">该角色未配置参考图</div>
+                            )}
                             {photoRetryError && <div className="feed-post-photo-retry-error">{photoRetryError}</div>}
                         </div>
                         <div className="modal-footer" data-ui="modal-footer">

--- a/lib/chat-storage.ts
+++ b/lib/chat-storage.ts
@@ -1821,23 +1821,37 @@ export function updateChatMessage(
     return updated;
 }
 
-function replacePhotoDirectiveDescription(text: string | undefined, oldDescription: string, nextDescription: string): string | undefined {
+function replacePhotoDirectiveDescription(
+    text: string | undefined,
+    oldDescription: string,
+    nextDescription: string,
+    nextUseReferenceImage?: boolean,
+): string | undefined {
     const oldDesc = oldDescription.trim();
     const nextDesc = nextDescription.trim();
-    if (!text || !oldDesc || !nextDesc || oldDesc === nextDesc) return text;
+    if (!text || (!oldDesc && !nextDesc)) return text;
 
     let changed = false;
     const withExplicitMode = text.replace(/\[照片[:：]\s*(使用参考图|不使用参考图)\s*[:：]\s*([^\]]+?)\]/g, (full, mode: string, desc: string) => {
-        if (desc.trim() !== oldDesc) return full;
+        if (oldDesc && desc.trim() !== oldDesc) return full;
+        const targetMode = nextUseReferenceImage !== undefined
+            ? (nextUseReferenceImage ? "使用参考图" : "不使用参考图")
+            : mode;
+        if (targetMode === mode && desc.trim() === nextDesc) return full;
         changed = true;
-        return `[照片:${mode}:${nextDesc}]`;
+        return `[照片:${targetMode}:${nextDesc}]`;
     });
     if (changed) return withExplicitMode;
 
     return text.replace(/\[照片[:：]\s*([^\]]+?)\]/g, (full, desc: string) => {
-        if (desc.trim() !== oldDesc) return full;
+        if (oldDesc && desc.trim() !== oldDesc) return full;
+        const targetMode = nextUseReferenceImage !== undefined
+            ? (nextUseReferenceImage ? "使用参考图" : "不使用参考图")
+            : undefined;
+        const replacement = targetMode ? `[照片:${targetMode}:${nextDesc}]` : `[照片:${nextDesc}]`;
+        if (replacement === full) return full;
         changed = true;
-        return `[照片:${nextDesc}]`;
+        return replacement;
     });
 }
 
@@ -1845,13 +1859,14 @@ export function syncChatGeneratedImagePromptText(
     messageId: string,
     oldDescription: string,
     nextDescription: string,
+    nextUseReferenceImage?: boolean,
 ): ChatMessage[] {
     const target = _messagesCache.find(m => m.id === messageId);
     if (!target) return [];
 
     const changed = new Map<string, ChatMessage>();
-    const targetNextRaw = replacePhotoDirectiveDescription(target.rawResponseText, oldDescription, nextDescription);
-    const targetNextEditable = replacePhotoDirectiveDescription(target.editableResponseText, oldDescription, nextDescription);
+    const targetNextRaw = replacePhotoDirectiveDescription(target.rawResponseText, oldDescription, nextDescription, nextUseReferenceImage);
+    const targetNextEditable = replacePhotoDirectiveDescription(target.editableResponseText, oldDescription, nextDescription, nextUseReferenceImage);
 
     if (target.rawResponseText && targetNextRaw && targetNextRaw !== target.rawResponseText && target.responseBatchId) {
         for (const msg of _messagesCache) {

--- a/lib/generated-image-retry.ts
+++ b/lib/generated-image-retry.ts
@@ -40,13 +40,21 @@ export function isPendingChatGeneratedImageMessage(message: Pick<ChatMessage, "m
 export async function generateAndApplyChatGeneratedImage(
     message: ChatMessage,
     characterId?: string,
-    options?: { signal?: AbortSignal; description?: string },
+    options?: { signal?: AbortSignal; description?: string; useReferenceImage?: boolean },
 ): Promise<ChatMessage> {
     const previousDescription = message.mediaData?.label?.trim() || "";
     const description = (options?.description ?? previousDescription).trim();
     if (!description) throw new Error("缺少图片描述，无法重新生成");
-    if (previousDescription && previousDescription !== description) {
-        syncChatGeneratedImagePromptText(message.id, previousDescription, description);
+
+    const effectiveUseReference = options?.useReferenceImage !== undefined
+        ? options.useReferenceImage
+        : (message.mediaData?.useReferenceImage === true);
+
+    if (
+        (previousDescription && previousDescription !== description) ||
+        (options?.useReferenceImage !== undefined && options.useReferenceImage !== (message.mediaData?.useReferenceImage === true))
+    ) {
+        syncChatGeneratedImagePromptText(message.id, previousDescription, description, options?.useReferenceImage);
     }
 
     // 重试路径：先落库为 pending 并广播，气泡立刻切到"生成中"态（首次生图本来就是 pending，无需重写）。
@@ -56,6 +64,7 @@ export async function generateAndApplyChatGeneratedImage(
             mediaData: {
                 ...message.mediaData,
                 label: description,
+                useReferenceImage: effectiveUseReference,
                 imageGenerationStatus: "pending",
                 imageGenerationError: undefined,
             },
@@ -67,7 +76,7 @@ export async function generateAndApplyChatGeneratedImage(
         const generated = await generateImageFromConfiguredApi({
             description,
             characterId,
-            useReferenceImage: message.mediaData?.useReferenceImage === true,
+            useReferenceImage: effectiveUseReference,
             signal: options?.signal,
         });
         if (!generated) throw new Error("生图配置未启用或不完整");
@@ -79,6 +88,7 @@ export async function generateAndApplyChatGeneratedImage(
             label: description,
             fileType: "image",
             fileName,
+            useReferenceImage: effectiveUseReference,
             imageGenerationMediaRef: generated.mediaRef,
             imageGenerationPrompt: generated.prompt,
             imageGenerationUsedReference: generated.usedReferenceImage,
@@ -99,6 +109,7 @@ export async function generateAndApplyChatGeneratedImage(
             mediaData: {
                 ...message.mediaData,
                 label: description,
+                useReferenceImage: effectiveUseReference,
                 imageGenerationStatus: "failed",
                 imageGenerationError: errorToMessage(error),
             },
@@ -112,17 +123,30 @@ export async function retryChatGeneratedImage(
     message: ChatMessage,
     characterId?: string,
     nextDescription?: string,
+    useReferenceImage?: boolean,
 ): Promise<ChatMessage> {
-    return generateAndApplyChatGeneratedImage(message, characterId, { description: nextDescription });
+    return generateAndApplyChatGeneratedImage(message, characterId, {
+        description: nextDescription,
+        useReferenceImage,
+    });
 }
 
-export async function retryMomentGeneratedPhoto(post: MomentPost, nextDescription?: string): Promise<MomentPost> {
+export async function retryMomentGeneratedPhoto(
+    post: MomentPost,
+    nextDescription?: string,
+    useReferenceImage?: boolean,
+): Promise<MomentPost> {
     const description = (nextDescription ?? post.photoDescription)?.trim();
     if (!description) throw new Error("缺少图片描述，无法重新生成");
+
+    const effectiveUseReference = useReferenceImage !== undefined
+        ? useReferenceImage
+        : (post.photoUseReferenceImage === true);
 
     // 同聊天：重试先置 pending 并广播，卡片立刻显示"图片生成中…"；成功/失败都会再写状态。
     updateMomentPost(post.id, {
         photoDescription: description,
+        photoUseReferenceImage: effectiveUseReference,
         photoGenerationStatus: "pending",
         photoGenerationError: undefined,
     });
@@ -132,7 +156,7 @@ export async function retryMomentGeneratedPhoto(post: MomentPost, nextDescriptio
         const generated = await generateImageFromConfiguredApi({
             description,
             characterId: post.authorType === "character" ? post.authorId : undefined,
-            useReferenceImage: post.photoUseReferenceImage === true,
+            useReferenceImage: effectiveUseReference,
         });
         if (!generated) throw new Error("生图配置未启用或不完整");
 
@@ -140,6 +164,7 @@ export async function retryMomentGeneratedPhoto(post: MomentPost, nextDescriptio
         const updated = updateMomentPost(post.id, {
             photoUrl: `asset://${assetId}`,
             photoDescription: description,
+            photoUseReferenceImage: effectiveUseReference,
             photoGenerationStatus: "generated",
             photoGenerationPrompt: generated.prompt,
             photoGenerationError: undefined,
@@ -150,6 +175,7 @@ export async function retryMomentGeneratedPhoto(post: MomentPost, nextDescriptio
     } catch (error) {
         updateMomentPost(post.id, {
             photoDescription: description,
+            photoUseReferenceImage: effectiveUseReference,
             photoGenerationStatus: "failed",
             photoGenerationError: errorToMessage(error),
         });

--- a/lib/image-generation-service.ts
+++ b/lib/image-generation-service.ts
@@ -815,3 +815,10 @@ export function generatedImageFilename(description: string, mimeType = "image/pn
     .slice(0, 28) || "generated-image";
   return `${safe}.${imageExtension(mimeType)}`;
 }
+
+export function hasCharacterReferenceImage(characterId?: string): boolean {
+  if (!characterId) return false;
+  const settings = loadImageGenerationSettings();
+  const ref = settings.characterReferences?.[characterId];
+  return Boolean(ref?.assetId);
+}

--- a/lib/moments-engine.ts
+++ b/lib/moments-engine.ts
@@ -1158,7 +1158,11 @@ export function parseMomentPostResponse(rawText: string): {
     const photoDescription = explicitPhotoMatch
         ? explicitPhotoMatch[2].trim()
         : legacyPhotoMatch ? legacyPhotoMatch[1].trim() : undefined;
-    const photoUseReferenceImage = explicitPhotoMatch ? explicitPhotoMatch[1] === "使用参考图" : false;
+    const photoUseReferenceImage = explicitPhotoMatch
+        ? explicitPhotoMatch[1] === "使用参考图"
+        : legacyPhotoMatch
+            ? /(?:自拍|对镜拍|selfie)/i.test(photoDescription || "")
+            : false;
 
     const content = text
         .replace(/\[照片[:：]\s*(?:使用参考图|不使用参考图)\s*[:：]\s*[\s\S]*?\]/g, "")

--- a/lib/rich-message-parser.ts
+++ b/lib/rich-message-parser.ts
@@ -175,11 +175,17 @@ const RICH_PATTERNS: {
     },
     {
         regex: new RegExp(`\\[照片${C}([^\\]]+)\\]`),
-        build: (m) => ({
-            content: "",
-            mediaType: "image",
-            mediaData: { label: m[1].trim(), useReferenceImage: false },
-        }),
+        build: (m) => {
+            const label = m[1].trim();
+            return {
+                content: "",
+                mediaType: "image",
+                mediaData: {
+                    label,
+                    useReferenceImage: /(?:自拍|对镜拍|selfie)/i.test(label),
+                },
+            };
+        },
     },
     {
         regex: new RegExp(`\\[位置${C}([^\\]]+)\\]`),

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -1723,6 +1723,7 @@
   width: 100%;
 }
 
+.chat-generated-image-prompt-check,
 .feed-post-edit-check {
   display: flex;
   align-items: center;
@@ -1731,12 +1732,24 @@
   color: var(--c-text);
   font-size: calc(12px*var(--app-text-scale,1));
   cursor: pointer;
+  user-select: none;
 }
 
+.chat-generated-image-prompt-check input,
 .feed-post-edit-check input {
   width: 16px;
   height: 16px;
   accent-color: var(--c-icon-active);
+}
+
+.chat-generated-image-prompt-empty-hint {
+  display: flex;
+  align-items: center;
+  min-height: 32px;
+  color: var(--c-icon);
+  font-size: calc(12px*var(--app-text-scale,1));
+  user-select: none;
+  text-align: left;
 }
 
 @keyframes chat-generated-image-spin {


### PR DESCRIPTION
贡献者：什锦杂货铺
感谢作者上一次的贡献采纳！本次贡献是基于PR #186 的优化版本。以下为搭档Gemini所述的pr简介：

### 背景与概述

感谢作者在 PR #186 中对短期记忆回写与 `Array.from` 类型修复的合并与详细反馈！针对作者在讨论中提到的宝贵思路，我们结合真实的手机端交互与多场景体验，对角色参考图的判定链路和图片重试机制进行了更深度的梳理与迭代，主要涵盖以下四个维度的完善：

1. **判定逻辑回归模型权威**：显式标签绝对尊重模型，仅对无模式旧标签做极简自拍兜底；
2. **重试弹窗交互增强**：允许用户在重试时手动决定是否使用参考图，并支持角色参考图配置的动态状态感知；
3. **中断容灾与状态解绑**：解决移动端在生图期间刷新/网络中断后可能导致重试入口不可用或虚假等待的边界情况；
4. **换图视觉平滑度优化**：消除图片替换瞬间的容器塌陷跳动（CLS），并引入新图预解码彻底杜绝“提示已撤但新图未出”导致的误判与重复点击。

---

### 具体改动说明

#### 1. 解析引擎：回归模型权威，克制兜底策略
- **显式前缀 100% 遵从**：当模型输出显式前缀 `[照片:使用参考图:...]` 或 `[照片:不使用参考图:...]` 时，无论描述内容为何，均完全尊重模型判定，不再使用关键词覆写，彻底避免了“无人的书桌”、“青年旅舍招牌”、“小鹿特写”等纯景物/静物被误加参考图的情况。
- **极简无前缀兜底**：仅在模型漏写模式前缀（输出旧式 `[照片:描述]`）时，使用最克制的 `/(?:自拍|对镜拍|selfie)/i` 正则进行安全兜底，且不绑定人名关键词，避免泛化误判。

#### 2. 聊天与朋友圈重试弹窗：赋予用户即时控制权
- **新增出镜参考图开关**：在聊天与朋友圈单图的重新生成弹窗中，**_新增「使用角色参考图（角色出镜）」选项_**。当模型偶尔遗漏参考图时，用户可直接在弹窗中勾选修正，无需重新生成整条文案。
- **参考图状态动态感知**：
  - 弹窗打开时实时调用 `hasCharacterReferenceImage` 校验角色参考图配置。若角色未配置参考图，以整洁的左对齐提示文案_**「该角色未配置参考图」替代勾选框**_，避免无效交互与排版混乱；
  - 若用户在生成后前往设置补充了角色参考图，再次点开弹窗时_**可无缝动态变为可用状态**_。
- **提示词与状态全链路同步**：聊天图片重试时，通过 `syncChatGeneratedImagePromptText` 同步更新消息文本内的模式前缀（如将旧模式切换为 `[照片:使用参考图:...]`），确保上下文与短期记忆回写始终一致。

#### 3. 容灾与生命周期状态解绑（解决移动端刷新/中断时的体验瑕疵）
在手机端实际体验测试中，如果在生图过程中遇到用户刷新页面、切出后台或网络中断，容易出现两种令人困惑的体验小瑕疵：
- **瑕疵场景一（重试入口锁死）**：刷新后后台任务已被系统切断，新图未载入，卡片上的“生成中”提示也没了，但点开图片发现“重新生成”按钮也一同消失了（只剩“保存图片”），导致用户即便想重试也无从下手，该图片的重试入口被永久锁死；
- **瑕疵场景二（悬挂假提示误导空等）**：刷新后虽然有“重新生成”按钮，但卡片下方却依然长久挂着“图片重新生成中…”的提示语，让用户误以为后台还在默默生成，白白干等半天。

**本次优化方案**：
- **解绑不可重试死锁**：只要帖子具备有效图片与描述，始终保留“重新生成”能力，即使遇到网络波动或意外刷新，也能随时再次点击重试，彻底杜绝死锁；
- **自动清理悬挂状态**：在组件挂载时，若发现已有正常配图但残留了因刷新中断遗留的 `pending` 标记，自动复位为正常状态，做到“没在生成就绝不误导，想要重试随时可点”。

#### 4. 换图过渡与视觉体验优化
- **消灭容器塌陷与页面抖动（CLS 优化）**：
  在原逻辑中，每次配图 URL 发生变化时会先行调用 `setResolvedPhotoUrl(null)`，导致在读取新图的几十毫秒内，配图 DOM 容器短暂卸载并塌陷为 0（正文下方内容瞬间上移），新图就绪后再猛烈下弹砸开。现调整为保持旧图稳定占位，待新图 URL 解析完成后直接原地平滑置换，彻底消灭空白塌陷与排版跳动。
- **图片就绪预解码（Image Pre-decode，防失败误判与重复点击）**：
  - **痛点分析**：在原有时序下，接口数据刚返回就立刻撤下了“生成中”提示，但此时几兆的高清大图往往还在手机内存与 GPU 中解码绘制，导致出现 数秒的空窗期——“提示语早没了，屏幕上却依然是老图”。用户极易误以为“是不是生图失败了或者卡死了”，进而困惑地反复点击重新生成，徒增开销与混淆；
  - **优化方案**：在生成完毕准备解除“生成中”状态前，通过 `img.decode()` 预先把新图解码载入内存。只有当新图完全准备好直接绘制在屏幕上的瞬间，才解除“生成中”状态。此时提示消失与新图亮相完全同步，丝滑无感，彻底杜绝误判与重复点击。

---

### 测试与验证

1. **类型检查**：运行 `npx tsc --noEmit` 全仓通过，0 错误、0 警告。
2. **逻辑测试**：
   - 覆盖显式使用、显式不使用、自拍兜底、带人名静物等全场景解析断言，解析结果均符合预期；
   - 验证角色未配置参考图时的优雅降级（自动降级为文本生图且不阻断流程）；
   - 真机（手机端局域网）多轮次验证：动态切换参考图配置、中途重载恢复、换图无抖动平滑过渡均正常运行。
3. **零污染审查**：代码仅包含上述功能所需生产文件，无多余格式化变更，不包含本地测试脚本与私有配置。